### PR TITLE
OAPEN Workflow and bug fixes to ONIX workflow

### DIFF
--- a/oaebu_workflows/dags/elastic_import_workflow.py
+++ b/oaebu_workflows/dags/elastic_import_workflow.py
@@ -137,6 +137,19 @@ configs = [
         kibana_time_fields=OAEBU_KIBANA_TIME_FIELDS,
         index_keep_info=index_keep_info,
     ),
+    ElasticImportConfig(
+        dag_id=make_dag_id(DAG_PREFIX, "oapen"),
+        project_id="oaebu-oapen",
+        dataset_id=DATASET_ID,
+        bucket_name="oaebu-oapen-transform",
+        data_location=DATA_LOCATION,
+        file_type=FILE_TYPE_JSONL,
+        sensor_dag_ids=[make_dag_id(DAG_ONIX_WORKFLOW_PREFIX, "oapen")],
+        elastic_mappings_path=ELASTIC_MAPPINGS_PATH,
+        elastic_mappings_func=load_elastic_mappings_oaebu,
+        kibana_spaces=["oaebu-oapen", "dev-oaebu-oapen"],
+        kibana_time_fields=OAEBU_KIBANA_TIME_FIELDS,
+    ),
 ]
 
 for config in configs:

--- a/oaebu_workflows/dags/oapen_workflow.py
+++ b/oaebu_workflows/dags/oapen_workflow.py
@@ -1,4 +1,4 @@
-{# Copyright 2020 Curtin University
+# Copyright 2021 Curtin University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,19 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Author: Richard Hosking #}
+# Author: Richard Hosking
 
-SELECT
-    ISBN13 as product_id,
-    work_id,
-    work_family_id,
-    onix.ProductForm,
-    onix.EditionNumber,
-    DATE(CAST(onix.published_year as INT64), 12, 31) AS time_field,
-    CAST(onix.published_year as INT64) as published_year,
-    onix.title,
-    onix.bic_subjects,
-    onix.bisac_subjects,
-    onix.thema_subjects,
-    onix.keywords
-FROM `{{ project_id }}.{{ dataset_id }}.book_product{{ release.strftime('%Y%m%d') }}`
+# The keywords airflow and DAG are required to load the DAGs from this file, see bullet 2 in the Apache Airflow FAQ:
+# https://airflow.apache.org/docs/stable/faq.html
+
+from oaebu_workflows.workflows.oapen_workflow import OapenWorkflow
+
+oapen_workflow = OapenWorkflow()
+globals()[oapen_workflow.dag_id] = oapen_workflow.make_dag()

--- a/oaebu_workflows/dags/onix_workflow.py
+++ b/oaebu_workflows/dags/onix_workflow.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Author: Tuan Chien
+# Author: Tuan Chien & Richard Hosking
 
 # The keywords airflow and DAG are required to load the DAGs from this file, see bullet 2 in the Apache Airflow FAQ:
 # https://airflow.apache.org/docs/stable/faq.html
@@ -36,6 +36,7 @@ def get_oaebu_partner_data(project_id, org_name):
             gcp_dataset_id="google",
             gcp_table_id="google_analytics",
             isbn_field_name="publication_id",
+            title_field_name="title",
             sharded=False,
         ),
         OaebuPartners(
@@ -45,6 +46,7 @@ def get_oaebu_partner_data(project_id, org_name):
             gcp_dataset_id="google",
             gcp_table_id="google_books_sales",
             isbn_field_name="Primary_ISBN",
+            title_field_name="Title",
             sharded=False,
         ),
         OaebuPartners(
@@ -54,6 +56,7 @@ def get_oaebu_partner_data(project_id, org_name):
             gcp_dataset_id="google",
             gcp_table_id="google_books_traffic",
             isbn_field_name="Primary_ISBN",
+            title_field_name="Title",
             sharded=False,
         ),
         OaebuPartners(
@@ -63,6 +66,7 @@ def get_oaebu_partner_data(project_id, org_name):
             gcp_dataset_id="jstor",
             gcp_table_id="jstor_country",
             isbn_field_name="eISBN",
+            title_field_name="Book_Title",
             sharded=False,
         ),
         OaebuPartners(
@@ -72,6 +76,7 @@ def get_oaebu_partner_data(project_id, org_name):
             gcp_dataset_id="jstor",
             gcp_table_id="jstor_institution",
             isbn_field_name="eISBN",
+            title_field_name="Book_Title",
             sharded=False,
         ),
         OaebuPartners(
@@ -81,6 +86,7 @@ def get_oaebu_partner_data(project_id, org_name):
             gcp_dataset_id="oapen",
             gcp_table_id="oapen_irus_uk",
             isbn_field_name="ISBN",
+            title_field_name="book_title",
             sharded=False,
         ),
         OaebuPartners(
@@ -90,6 +96,7 @@ def get_oaebu_partner_data(project_id, org_name):
             gcp_dataset_id="ucl",
             gcp_table_id="ucl_discovery",
             isbn_field_name="ISBN",
+            title_field_name="book_title",
             sharded=False,
         ),
     ]

--- a/oaebu_workflows/database/mappings/oaebu-list-mappings.json.jinja2
+++ b/oaebu_workflows/database/mappings/oaebu-list-mappings.json.jinja2
@@ -10,6 +10,24 @@
           }
         }
       },
+      "work_id": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "work_family_id": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
       "ProductForm": {
         "type": "text",
         "analyzer": "text_analyzer",

--- a/oaebu_workflows/database/mappings/oaebu-metrics-city-mappings.json.jinja2
+++ b/oaebu_workflows/database/mappings/oaebu-metrics-city-mappings.json.jinja2
@@ -10,6 +10,24 @@
           }
         }
       },
+      "work_id": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "work_family_id": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
       "title": {
         "type": "text",
         "fields": {

--- a/oaebu_workflows/database/mappings/oaebu-metrics-country-mappings.json.jinja2
+++ b/oaebu_workflows/database/mappings/oaebu-metrics-country-mappings.json.jinja2
@@ -10,6 +10,24 @@
           }
         }
       },
+      "work_id": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "work_family_id": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
       "title": {
         "type": "text",
         "fields": {

--- a/oaebu_workflows/database/mappings/oaebu-metrics-country-mappings.json.jinja2
+++ b/oaebu_workflows/database/mappings/oaebu-metrics-country-mappings.json.jinja2
@@ -100,6 +100,20 @@
             "type": "integer"
           }
         }
+      },
+      "google_books": {
+        "properties": {
+          "qty": {
+            "type": "integer"
+          }
+        }
+      },
+      "ucl_discovery": {
+        "properties": {
+          "download_count": {
+            "type": "integer"
+          }
+        }
       }
     }
   }

--- a/oaebu_workflows/database/mappings/oaebu-metrics-events-mappings.json.jinja2
+++ b/oaebu_workflows/database/mappings/oaebu-metrics-events-mappings.json.jinja2
@@ -10,6 +10,24 @@
           }
         }
       },
+      "work_id": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "work_family_id": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
       "title": {
         "type": "text",
         "fields": {

--- a/oaebu_workflows/database/mappings/oaebu-metrics-mappings.json.jinja2
+++ b/oaebu_workflows/database/mappings/oaebu-metrics-mappings.json.jinja2
@@ -10,6 +10,24 @@
           }
         }
       },
+      "work_id": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "work_family_id": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
       "title": {
         "type": "text",
         "fields": {

--- a/oaebu_workflows/database/mappings/oaebu-metrics-referrer-mappings.json.jinja2
+++ b/oaebu_workflows/database/mappings/oaebu-metrics-referrer-mappings.json.jinja2
@@ -10,6 +10,24 @@
           }
         }
       },
+      "work_id": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "work_family_id": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
       "title": {
         "type": "text",
         "fields": {

--- a/oaebu_workflows/database/mappings/oaebu-unmatched-metrics-mappings.json.jinja2
+++ b/oaebu_workflows/database/mappings/oaebu-unmatched-metrics-mappings.json.jinja2
@@ -10,6 +10,42 @@
           }
         }
       },
+      "google_analytics_title": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "google_books_title": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "jstor_title": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "oapen_title": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
       "release_date": {
         "type": "date",
         "format": "yyyy-MM-dd"

--- a/oaebu_workflows/database/sql/create_book_products.sql.jinja2
+++ b/oaebu_workflows/database/sql/create_book_products.sql.jinja2
@@ -270,7 +270,7 @@ onix_ebook_titles as (
 google_analytics_metrics as (
     SELECT
         publication_id as ISBN13, release_date, STRUCT(STRUCT(AVG(average_time) as average_time, group_items(ARRAY_CONCAT_AGG(unique_views.country)) as country, group_items(ARRAY_CONCAT_AGG(unique_views.referrer)) as referrer, group_items(ARRAY_CONCAT_AGG(unique_views.social_network)) as social_network) as unique_views) as metrics
-    FROM {% if google_analytics %} `{{ project_id }}.{{ dataset_id }}.{{ google_analytics_dataset }}_google_analytics_matched{{ release_date.strftime('%Y%m%d') }}` {% else %} empty_google_analytics {% endif %}
+    FROM `{{ google_analytics_table_id }}`
     WHERE publication_whole_or_part = '(citation)' and publication_type = "book"
     GROUP BY publication_id, release_date
 ),
@@ -279,28 +279,28 @@ google_analytics_metrics as (
 google_books_sales_metrics as (
     SELECT
         Primary_ISBN as ISBN13, release_date, STRUCT(SUM(qty) as qty, group_items_google_books_sales(ARRAY_AGG(STRUCT(Country_of_Sale, qty))) as countries) as metrics
-    FROM {% if google_books %} `{{ project_id }}.{{ dataset_id }}.{{ google_books_dataset }}_google_books_sales_matched{{ release_date.strftime('%Y%m%d') }}` {% else %} empty_google_books_sales {% endif %} as google_books
+    FROM `{{ google_books_sales_table_id }}`
     GROUP BY Primary_ISBN, release_date
 ),
 
 google_books_sales_metadata as (
     SELECT
         Primary_ISBN as ISBN13, MAX(Imprint_Name) as Imprint_Name, MAX(Title) as Title, MAX(Author) as Author
-    FROM {% if google_books %} `{{ project_id }}.{{ dataset_id }}.{{ google_books_dataset }}_google_books_sales_matched{{ release_date.strftime('%Y%m%d') }}` {% else %} empty_google_books_sales {% endif %} as google_books
+    FROM `{{ google_books_sales_table_id }}`
     GROUP BY Primary_ISBN
 ),
 
 google_books_traffic_metrics as (
     SELECT
         Primary_ISBN  as ISBN13, release_date, STRUCT(SUM(Book_Visits_BV_) as Book_Visits_BV_, SUM(BV_with_Pages_Viewed) as BV_with_Pages_Viewed, SUM(Non_Unique_Buy_Clicks) as Non_Unique_Buy_Clicks, SUM(BV_with_Buy_Clicks) as BV_with_Buy_Clicks, SUM(Buy_Link_CTR) as Buy_Link_CTR, SUM(Pages_Viewed) as Pages_Viewed) as metrics
-    FROM {% if google_books %} `{{ project_id }}.{{ dataset_id }}.{{ google_books_dataset }}_google_books_traffic_matched{{ release_date.strftime('%Y%m%d') }}` {% else %} empty_google_books_traffic {% endif %} as google_books
+    FROM `{{ google_books_traffic_table_id }}`
     GROUP BY Primary_ISBN, release_date
 ),
 
 google_books_traffic_metadata as (
     SELECT
         Primary_ISBN  as ISBN13, MAX(title) as Title
-    FROM {% if google_books %} `{{ project_id }}.{{ dataset_id }}.{{ google_books_dataset }}_google_books_traffic_matched{{ release_date.strftime('%Y%m%d') }}` {% else %} empty_google_books_traffic {% endif %} as google_books
+    FROM `{{ google_books_traffic_table_id }}`
     GROUP BY Primary_ISBN
 ),
 
@@ -308,28 +308,28 @@ google_books_traffic_metadata as (
 jstor_country_metrics as (
     SELECT
         eISBN as ISBN13, release_date, group_items_jstor_country(ARRAY_AGG(STRUCT(Country_name, Total_Item_Requests))) as metrics
-    FROM {% if jstor %} `{{ project_id }}.{{ dataset_id }}.{{ jstor_dataset }}_jstor_country_matched{{ release_date.strftime('%Y%m%d') }}` {% else %} empty_jstor_country {% endif %} as jstor_country
+    FROM `{{ jstor_country_table_id }}`
     GROUP BY eISBN, release_date
 ),
 
 jstor_country_metadata as (
     SELECT
         eISBN as ISBN13, MAX(Book_Title) as Book_Title, MAX(Book_ID) as Book_ID, MAX(Authors) as Authors, MAX(ISBN) as ISBN, eISBN, MAX(Copyright_Year) as Copyright_Year, MAX(Disciplines) as Disciplines, MAX(Usage_Type) as Usage_Type
-    FROM {% if jstor %} `{{ project_id }}.{{ dataset_id }}.{{ jstor_dataset }}_jstor_country_matched{{ release_date.strftime('%Y%m%d') }}` {% else %} empty_jstor_country {% endif %} as jstor_country
+    FROM `{{ jstor_country_table_id }}`
     GROUP BY eISBN
 ),
 
 jstor_institution_metrics as (
     SELECT
         eISBN as ISBN13, release_date, group_items_jstor_institution(ARRAY_AGG(STRUCT(Institution, Total_Item_Requests))) as metrics
-    FROM {% if jstor %} `{{ project_id }}.{{ dataset_id }}.{{ jstor_dataset }}_jstor_institution_matched{{ release_date.strftime('%Y%m%d') }}` {% else %} empty_jstor_institution {% endif %} as jstor_institution
+    FROM `{{ jstor_institution_table_id }}`
     GROUP BY eISBN, release_date
 ),
 
 jstor_institution_metadata as (
     SELECT
         eISBN as ISBN13, MAX(Book_Title) as Book_Title, MAX(Book_ID) as Book_ID, MAX(Authors) as Authors, MAX(ISBN) as ISBN, eISBN, MAX(Copyright_Year) as Copyright_Year, MAX(Disciplines) as Disciplines, MAX(Usage_Type) as Usage_Type
-    FROM {% if jstor %} `{{ project_id }}.{{ dataset_id }}.{{ jstor_dataset }}_jstor_institution_matched{{ release_date.strftime('%Y%m%d') }}` {% else %} empty_jstor_institution {% endif %} as jstor_institution
+    FROM `{{ jstor_institution_table_id }}`
     GROUP BY eISBN
 ),
 
@@ -337,14 +337,14 @@ jstor_institution_metadata as (
 oapen_irus_uk_metrics as (
     SELECT
         ISBN as ISBN13, release_date, STRUCT(MAX(version) as version, SUM(title_requests) as title_requests, SUM(total_item_investigations) as total_item_investigations, SUM(total_item_requests) as total_item_requests, SUM(unique_item_investigations) as unique_item_investigations, SUM(unique_item_requests) as unique_item_requests, group_items_irus_country(ARRAY_CONCAT_AGG(country)) as country, group_items_irus_location(ARRAY_CONCAT_AGG(locations)) as locations) as metrics
-    FROM {% if oapen %} `{{ project_id }}.{{ dataset_id }}.{{ oapen_dataset }}_oapen_irus_uk_matched{{ release_date.strftime('%Y%m%d') }}` {% else %} empty_oapen {% endif %} as oapen_irus_uk
+    FROM `{{ oapen_table_id }}`
     GROUP BY ISBN, release_date
 ),
 
 oapen_irus_uk_metadata as (
     SELECT
         ISBN as ISBN13, MAX(book_title) as book_title, MAX(publisher) as publisher
-    FROM {% if oapen %} `{{ project_id }}.{{ dataset_id }}.{{ oapen_dataset }}_oapen_irus_uk_matched{{ release_date.strftime('%Y%m%d') }}` {% else %} empty_oapen {% endif %} as oapen_irus_uk
+    FROM `{{ oapen_table_id }}`
     GROUP BY ISBN
 ),
 
@@ -352,7 +352,7 @@ oapen_irus_uk_metadata as (
 ucl_discovery_metrics as (
     SELECT
         isbn as ISBN13, release_date, STRUCT(SUM(total_downloads) as total_downloads, group_items_ucl_country(ARRAY_CONCAT_AGG(downloads_per_country)) as downloads_per_country ) as metrics
-    FROM {% if ucl %} `{{ project_id }}.{{ dataset_id }}.{{ ucl_dataset }}_ucl_discovery_matched{{ release_date.strftime('%Y%m%d') }}` {% else %} empty_ucl_discovery {% endif %} as ucl_discovery
+    FROM `{{ ucl_table_id }}`
     WHERE isbn IS NOT NULL
     GROUP BY isbn, release_date
 ),
@@ -362,7 +362,7 @@ crossref_events as (
         public_data.isbn as ISBN13,
         LAST_DAY(DATE(CAST(SPLIT(month_source.month, "-")[OFFSET(0)] as INT64), CAST(SPLIT(month_source.month, "-")[OFFSET(1)] as INT64), 1), MONTH) as release_date,
         ARRAY_AGG(STRUCT(month_source.source, month_source.count)) as metrics
-    FROM `academic-observatory.observatory.book20210529` as public_data, UNNEST(public_data.events.months) as month_source
+    FROM `academic-observatory.observatory.book{{ public_book_release_date.strftime('%Y%m%d') }}` as public_data, UNNEST(public_data.events.months) as month_source
     GROUP BY public_data.isbn, month_source.month
 ),
 
@@ -431,4 +431,3 @@ LEFT JOIN google_books_traffic_metadata on google_books_traffic_metadata.ISBN13 
 LEFT JOIN jstor_country_metadata on jstor_country_metadata.ISBN13 = onix_ebook_titles.ISBN13
 LEFT JOIN jstor_institution_metadata on jstor_institution_metadata.ISBN13 = onix_ebook_titles.ISBN13
 LEFT JOIN oapen_irus_uk_metadata on oapen_irus_uk_metadata.ISBN13 = onix_ebook_titles.ISBN13
-LEFT JOIN `academic-observatory.observatory.book{{ public_book_release_date.strftime('%Y%m%d') }}` as public_data on public_data.isbn = onix_ebook_titles.ISBN13

--- a/oaebu_workflows/database/sql/create_book_products.sql.jinja2
+++ b/oaebu_workflows/database/sql/create_book_products.sql.jinja2
@@ -169,8 +169,7 @@ empty_google_books_sales as (
         CAST(NULL as STRING) as Author,
         CAST(NULL as DATE) as release_date,
         CAST(NULL as INT64) as qty,
-        CAST(NULL as STRING) as Country_of_Sale,
-        CAST(NULL as INT64) as qty
+        CAST(NULL as STRING) as Country_of_Sale
 ),
 
 empty_google_analytics as (

--- a/oaebu_workflows/database/sql/create_book_products.sql.jinja2
+++ b/oaebu_workflows/database/sql/create_book_products.sql.jinja2
@@ -431,3 +431,4 @@ LEFT JOIN google_books_traffic_metadata on google_books_traffic_metadata.ISBN13 
 LEFT JOIN jstor_country_metadata on jstor_country_metadata.ISBN13 = onix_ebook_titles.ISBN13
 LEFT JOIN jstor_institution_metadata on jstor_institution_metadata.ISBN13 = onix_ebook_titles.ISBN13
 LEFT JOIN oapen_irus_uk_metadata on oapen_irus_uk_metadata.ISBN13 = onix_ebook_titles.ISBN13
+LEFT JOIN `academic-observatory.observatory.book{{ public_book_release_date.strftime('%Y%m%d') }}` as public_data on public_data.isbn = onix_ebook_titles.ISBN13

--- a/oaebu_workflows/database/sql/create_book_products.sql.jinja2
+++ b/oaebu_workflows/database/sql/create_book_products.sql.jinja2
@@ -24,6 +24,15 @@ CREATE TEMP FUNCTION group_items(items ARRAY<STRUCT<name STRING, value INT64>>) 
   )
 );
 
+CREATE TEMP FUNCTION group_items_google_books_sales(items ARRAY<STRUCT<Country_of_Sale STRING, qty INT64>>) as (
+  ARRAY(
+    (SELECT AS STRUCT
+      Country_of_Sale,
+      SUM(qty) as qty,
+    FROM UNNEST(items)
+    GROUP BY Country_of_Sale)
+  )
+
 CREATE TEMP FUNCTION group_items_jstor_country(items ARRAY<STRUCT<Country_name STRING, Total_Item_Requests INT64>>) as (
   ARRAY(
     (SELECT AS STRUCT
@@ -158,7 +167,8 @@ empty_google_books_sales as (
         CAST(NULL as STRING) as Title,
         CAST(NULL as STRING) as Author,
         CAST(NULL as DATE) as release_date,
-        CAST(NULL as INT64) as qty
+        CAST(NULL as INT64) as qty,
+        [STRUCT(CAST(NULL as STRING) as Country_of_Sale, CAST(null as INT64) as qty)] as country
 ),
 
 empty_google_analytics as (
@@ -267,7 +277,7 @@ google_analytics_metrics as (
 # Google Books
 google_books_sales_metrics as (
     SELECT
-        Primary_ISBN as ISBN13, release_date, STRUCT(SUM(qty) as qty) as metrics
+        Primary_ISBN as ISBN13, release_date, STRUCT(SUM(qty) as qty, group_items_google_books_sales(ARRAY_AGG(STRUCT(Country_of_Sale, qty))) as countries) as metrics
     FROM {% if google_books %} `{{ project_id }}.{{ dataset_id }}.{{ google_books_dataset }}_google_books_sales_matched{{ release_date.strftime('%Y%m%d') }}` {% else %} empty_google_books_sales {% endif %} as google_books
     GROUP BY Primary_ISBN, release_date
 ),

--- a/oaebu_workflows/database/sql/create_book_products.sql.jinja2
+++ b/oaebu_workflows/database/sql/create_book_products.sql.jinja2
@@ -362,7 +362,7 @@ crossref_events as (
         public_data.isbn as ISBN13,
         LAST_DAY(DATE(CAST(SPLIT(month_source.month, "-")[OFFSET(0)] as INT64), CAST(SPLIT(month_source.month, "-")[OFFSET(1)] as INT64), 1), MONTH) as release_date,
         ARRAY_AGG(STRUCT(month_source.source, month_source.count)) as metrics
-    FROM `academic-observatory.observatory.book{{ public_book_release_date.strftime('%Y%m%d') }}` as public_data, UNNEST(public_data.events.months) as month_source
+    FROM `{{ public_book_tabel_id }}` as public_data, UNNEST(public_data.events.months) as month_source
     GROUP BY public_data.isbn, month_source.month
 ),
 
@@ -431,4 +431,4 @@ LEFT JOIN google_books_traffic_metadata on google_books_traffic_metadata.ISBN13 
 LEFT JOIN jstor_country_metadata on jstor_country_metadata.ISBN13 = onix_ebook_titles.ISBN13
 LEFT JOIN jstor_institution_metadata on jstor_institution_metadata.ISBN13 = onix_ebook_titles.ISBN13
 LEFT JOIN oapen_irus_uk_metadata on oapen_irus_uk_metadata.ISBN13 = onix_ebook_titles.ISBN13
-LEFT JOIN `academic-observatory.observatory.book{{ public_book_release_date.strftime('%Y%m%d') }}` as public_data on public_data.isbn = onix_ebook_titles.ISBN13
+LEFT JOIN `{{ public_book_tabel_id }}` as public_data on public_data.isbn = onix_ebook_titles.ISBN13

--- a/oaebu_workflows/database/sql/create_book_products.sql.jinja2
+++ b/oaebu_workflows/database/sql/create_book_products.sql.jinja2
@@ -14,6 +14,80 @@
 
 # Author: Richard Hosking #}
 
+CREATE TEMP FUNCTION group_items(items ARRAY<STRUCT<name STRING, value INT64>>) as (
+  ARRAY(
+    (SELECT AS STRUCT
+      name,
+      SUM(value) as value,
+    FROM UNNEST(items)
+    GROUP BY name)
+  )
+);
+
+CREATE TEMP FUNCTION group_items_jstor_country(items ARRAY<STRUCT<Country_name STRING, Total_Item_Requests INT64>>) as (
+  ARRAY(
+    (SELECT AS STRUCT
+      Country_name,
+      SUM(Total_Item_Requests) as Total_Item_Requests,
+    FROM UNNEST(items)
+    GROUP BY Country_name)
+  )
+);
+
+CREATE TEMP FUNCTION group_items_jstor_institution(items ARRAY<STRUCT<Institution STRING, Total_Item_Requests INT64>>) as (
+  ARRAY(
+    (SELECT AS STRUCT
+      Institution,
+      SUM(Total_Item_Requests) as Total_Item_Requests,
+    FROM UNNEST(items)
+    GROUP BY Institution)
+  )
+);
+
+CREATE TEMP FUNCTION group_items_irus_country(items ARRAY<STRUCT<name STRING, code STRING, title_requests INT64, total_item_investigations INT64, total_item_requests INT64, unique_item_investigations INT64, unique_item_requests INT64>>) as (
+  ARRAY(
+    (SELECT AS STRUCT
+      name,
+      MAX(code) as code,
+      SUM(title_requests) as title_requests,
+      SUM(total_item_investigations) as total_item_investigations,
+      SUM(total_item_requests) as total_item_requests,
+      SUM(unique_item_investigations) as unique_item_investigations,
+      SUM(unique_item_requests) as unique_item_requests
+    FROM UNNEST(items)
+    GROUP BY name)
+  )
+);
+
+CREATE TEMP FUNCTION group_items_irus_location(items ARRAY<STRUCT<latitude FLOAT64, longitude FLOAT64, city STRING, country_name STRING, country_code STRING, title_requests INT64, total_item_investigations INT64, total_item_requests INT64, unique_item_investigations INT64, unique_item_requests INT64>>) as (
+  ARRAY(
+    (SELECT AS STRUCT
+      MAX(latitude) as latitude,
+      MAX(longitude) as longitude,
+      city,
+      MAX(country_name) as country_name,
+      MAX(country_code) as country_code,
+      SUM(title_requests) as title_requests,
+      SUM(total_item_investigations) as total_item_investigations,
+      SUM(total_item_requests) as total_item_requests,
+      SUM(unique_item_investigations) as unique_item_investigations,
+      SUM(unique_item_requests) as unique_item_requests
+    FROM UNNEST(items)
+    GROUP BY city)
+  )
+);
+
+CREATE TEMP FUNCTION group_items_ucl_country(items ARRAY<STRUCT<download_count INT64, country_name STRING, country_code STRING>>) as (
+  ARRAY(
+    (SELECT AS STRUCT
+      country_code,
+      MAX(country_name) as country_name,
+      SUM(download_count) as download_count,
+    FROM UNNEST(items)
+    GROUP BY country_code)
+  )
+);
+
 WITH empty_oapen as (
     SELECT
         CAST(null as STRING) as ISBN,
@@ -101,7 +175,28 @@ empty_google_analytics as (
         ) as unique_views
 ),
 
-onix_ebook_titles as (
+empty_ucl_discovery as (
+    SELECT
+        CAST(NULL as STRING) as isbn,
+        CAST(NULL as STRING) as book_title,
+        CAST(NULL as DATE) as release_date,
+        CAST(NULL as INT64) as total_downloads,
+        [STRUCT(CAST(null as INT64) as download_count, CAST(NULL as STRING) as country_name, CAST(NULL as STRING) as country_code)] as downloads_per_country
+),
+
+empty_work_ids as (
+    SELECT
+        CAST(NULL as STRING) as isbn13,
+        CAST(NULL as STRING) as work_id,
+),
+
+empty_work_family_ids as (
+    SELECT
+        CAST(NULL as STRING) as isbn13,
+        CAST(NULL as STRING) as work_family_id,
+),
+
+onix_ebook_titles_raw as (
     SELECT
         ISBN13,
         STRUCT(
@@ -149,10 +244,21 @@ onix_ebook_titles as (
     WHERE ProductForm = "Digital download and online" OR ProductForm = "Digital (delivered electronically)" OR ProductForm = "Digital download"
 ),
 
+onix_ebook_titles as (
+    SELECT
+        dedupe.*
+    FROM (
+        SELECT
+            ARRAY_AGG(raw LIMIT 1)[OFFSET(0)] dedupe
+        FROM onix_ebook_titles_raw as raw
+        GROUP BY ISBN13
+    )
+),
+
 # Google Analytics
 google_analytics_metrics as (
     SELECT
-        publication_id as ISBN13, release_date, STRUCT(STRUCT(AVG(average_time) as average_time, ARRAY_CONCAT_AGG(unique_views.country) as country, ARRAY_CONCAT_AGG(unique_views.referrer) as referrer, ARRAY_CONCAT_AGG(unique_views.social_network) as social_network) as unique_views) as metrics
+        publication_id as ISBN13, release_date, STRUCT(STRUCT(AVG(average_time) as average_time, group_items(ARRAY_CONCAT_AGG(unique_views.country)) as country, group_items(ARRAY_CONCAT_AGG(unique_views.referrer)) as referrer, group_items(ARRAY_CONCAT_AGG(unique_views.social_network)) as social_network) as unique_views) as metrics
     FROM {% if google_analytics %} `{{ project_id }}.{{ dataset_id }}.{{ google_analytics_dataset }}_google_analytics_matched{{ release_date.strftime('%Y%m%d') }}` {% else %} empty_google_analytics {% endif %}
     WHERE publication_whole_or_part = '(citation)' and publication_type = "book"
     GROUP BY publication_id, release_date
@@ -175,8 +281,9 @@ google_books_sales_metadata as (
 
 google_books_traffic_metrics as (
     SELECT
-        Primary_ISBN  as ISBN13, release_date, STRUCT(Book_Visits_BV_, BV_with_Pages_Viewed, Non_Unique_Buy_Clicks, BV_with_Buy_Clicks, Buy_Link_CTR, Pages_Viewed) as metrics
+        Primary_ISBN  as ISBN13, release_date, STRUCT(SUM(Book_Visits_BV_) as Book_Visits_BV_, SUM(BV_with_Pages_Viewed) as BV_with_Pages_Viewed, SUM(Non_Unique_Buy_Clicks) as Non_Unique_Buy_Clicks, SUM(BV_with_Buy_Clicks) as BV_with_Buy_Clicks, SUM(Buy_Link_CTR) as Buy_Link_CTR, SUM(Pages_Viewed) as Pages_Viewed) as metrics
     FROM {% if google_books %} `{{ project_id }}.{{ dataset_id }}.{{ google_books_dataset }}_google_books_traffic_matched{{ release_date.strftime('%Y%m%d') }}` {% else %} empty_google_books_traffic {% endif %} as google_books
+    GROUP BY Primary_ISBN, release_date
 ),
 
 google_books_traffic_metadata as (
@@ -189,7 +296,7 @@ google_books_traffic_metadata as (
 # JSTOR
 jstor_country_metrics as (
     SELECT
-        eISBN as ISBN13, release_date, ARRAY_AGG(STRUCT(Country_name, Total_Item_Requests)) as metrics
+        eISBN as ISBN13, release_date, group_items_jstor_country(ARRAY_AGG(STRUCT(Country_name, Total_Item_Requests))) as metrics
     FROM {% if jstor %} `{{ project_id }}.{{ dataset_id }}.{{ jstor_dataset }}_jstor_country_matched{{ release_date.strftime('%Y%m%d') }}` {% else %} empty_jstor_country {% endif %} as jstor_country
     GROUP BY eISBN, release_date
 ),
@@ -203,7 +310,7 @@ jstor_country_metadata as (
 
 jstor_institution_metrics as (
     SELECT
-        eISBN as ISBN13, release_date, ARRAY_AGG(STRUCT(Institution, Total_Item_Requests)) as metrics
+        eISBN as ISBN13, release_date, group_items_jstor_institution(ARRAY_AGG(STRUCT(Institution, Total_Item_Requests))) as metrics
     FROM {% if jstor %} `{{ project_id }}.{{ dataset_id }}.{{ jstor_dataset }}_jstor_institution_matched{{ release_date.strftime('%Y%m%d') }}` {% else %} empty_jstor_institution {% endif %} as jstor_institution
     GROUP BY eISBN, release_date
 ),
@@ -218,8 +325,9 @@ jstor_institution_metadata as (
 # OAPEN IRUS UK
 oapen_irus_uk_metrics as (
     SELECT
-        ISBN as ISBN13, release_date, STRUCT(version, title_requests, total_item_investigations, total_item_requests, unique_item_investigations, unique_item_requests, country, locations) as metrics
+        ISBN as ISBN13, release_date, STRUCT(MAX(version) as version, SUM(title_requests) as title_requests, SUM(total_item_investigations) as total_item_investigations, SUM(total_item_requests) as total_item_requests, SUM(unique_item_investigations) as unique_item_investigations, SUM(unique_item_requests) as unique_item_requests, group_items_irus_country(ARRAY_CONCAT_AGG(country)) as country, group_items_irus_location(ARRAY_CONCAT_AGG(locations)) as locations) as metrics
     FROM {% if oapen %} `{{ project_id }}.{{ dataset_id }}.{{ oapen_dataset }}_oapen_irus_uk_matched{{ release_date.strftime('%Y%m%d') }}` {% else %} empty_oapen {% endif %} as oapen_irus_uk
+    GROUP BY ISBN, release_date
 ),
 
 oapen_irus_uk_metadata as (
@@ -229,8 +337,14 @@ oapen_irus_uk_metadata as (
     GROUP BY ISBN
 ),
 
-# TODO UCL Discovery
-
+# UCL Discovery
+ucl_discovery_metrics as (
+    SELECT
+        isbn as ISBN13, release_date, STRUCT(SUM(total_downloads) as total_downloads, group_items_ucl_country(ARRAY_CONCAT_AGG(downloads_per_country)) as downloads_per_country ) as metrics
+    FROM {% if ucl %} `{{ project_id }}.{{ dataset_id }}.{{ ucl_dataset }}_ucl_discovery_matched{{ release_date.strftime('%Y%m%d') }}` {% else %} empty_ucl_discovery {% endif %} as ucl_discovery
+    WHERE isbn IS NOT NULL
+    GROUP BY isbn, release_date
+),
 
 crossref_events as (
     SELECT
@@ -279,7 +393,8 @@ metrics as (
             google_books_traffic.metrics as google_books_traffic,
             jstor_country.metrics as jstor_country,
             jstor_institution.metrics as jstor_institution,
-            oapen_irus_uk.metrics as oapen_irus_uk
+            oapen_irus_uk.metrics as oapen_irus_uk,
+            ucl_discovery.metrics as ucl_discovery
         ) ORDER BY ebook_months.release_date DESC) as months
     FROM ebook_months
     LEFT JOIN google_analytics_metrics as google_analytics ON ebook_months.ISBN13 = google_analytics.ISBN13 AND ebook_months.release_date = google_analytics.release_date
@@ -288,18 +403,21 @@ metrics as (
     LEFT JOIN jstor_country_metrics as jstor_country ON ebook_months.ISBN13 = jstor_country.ISBN13 AND ebook_months.release_date = jstor_country.release_date
     LEFT JOIN jstor_institution_metrics as jstor_institution ON ebook_months.ISBN13 = jstor_institution.ISBN13 AND ebook_months.release_date = jstor_institution.release_date
     LEFT JOIN oapen_irus_uk_metrics as oapen_irus_uk ON ebook_months.ISBN13 = oapen_irus_uk.ISBN13 AND ebook_months.release_date = oapen_irus_uk.release_date
-    LEFT JOIN crossref_events  as crossref_events ON ebook_months.ISBN13 = crossref_events.ISBN13 AND ebook_months.release_date = crossref_events.release_date
+    LEFT JOIN ucl_discovery_metrics as ucl_discovery ON ebook_months.ISBN13 = ucl_discovery.ISBN13 AND ebook_months.release_date = ucl_discovery.release_date
+    LEFT JOIN crossref_events as crossref_events ON ebook_months.ISBN13 = crossref_events.ISBN13 AND ebook_months.release_date = crossref_events.release_date
     WHERE crossref_events.metrics IS NOT NULL OR google_books_sales.metrics IS NOT NULL OR google_books_traffic.metrics IS NOT NULL OR jstor_country.metrics IS NOT NULL OR jstor_institution.metrics is not null OR oapen_irus_uk.metrics IS NOT NULL
     GROUP BY ebook_months.ISBN13
 )
 
 SELECT
-    onix_ebook_titles.*, STRUCT(crossref_objects, chapters, events.overall as events, google_books_sales_metadata as google_books_sales, google_books_traffic_metadata as google_books_traffic, jstor_country_metadata as jstor_metadata, jstor_institution_metadata as jstor_institution_metadata, oapen_irus_uk_metadata as oapen_irus_uk_metadata) as metadata, metrics.months
+    onix_ebook_titles.*, empty_work_ids.work_id, empty_work_family_ids.work_family_id, STRUCT(crossref_objects, chapters, events.overall as events, google_books_sales_metadata as google_books_sales, google_books_traffic_metadata as google_books_traffic, jstor_country_metadata as jstor_metadata, jstor_institution_metadata as jstor_institution_metadata, oapen_irus_uk_metadata as oapen_irus_uk_metadata) as metadata, metrics.months
 FROM onix_ebook_titles
+LEFT JOIN {% if onix_workflow %} `{{ project_id }}.{{ onix_workflow_dataset }}.onix_workid_isbn{{ release_date.strftime('%Y%m%d') }}` {% else %} empty_work_ids {% endif %} as empty_work_ids on empty_work_ids.isbn13 = onix_ebook_titles.isbn13
+LEFT JOIN {% if onix_workflow %} `{{ project_id }}.{{ onix_workflow_dataset }}.onix_workfamilyid_isbn{{ release_date.strftime('%Y%m%d') }}` {% else %} empty_work_family_ids {% endif %} as empty_work_family_ids on empty_work_family_ids.isbn13 = onix_ebook_titles.isbn13
 LEFT JOIN metrics as metrics on metrics.ISBN13 = onix_ebook_titles.ISBN13
 LEFT JOIN google_books_sales_metadata on google_books_sales_metadata.ISBN13  = onix_ebook_titles.ISBN13
 LEFT JOIN google_books_traffic_metadata on google_books_traffic_metadata.ISBN13  = onix_ebook_titles.ISBN13
 LEFT JOIN jstor_country_metadata on jstor_country_metadata.ISBN13 = onix_ebook_titles.ISBN13
 LEFT JOIN jstor_institution_metadata on jstor_institution_metadata.ISBN13 = onix_ebook_titles.ISBN13
 LEFT JOIN oapen_irus_uk_metadata on oapen_irus_uk_metadata.ISBN13 = onix_ebook_titles.ISBN13
-LEFT JOIN `academic-observatory.observatory.book20210529` as public_data on public_data.isbn = onix_ebook_titles.ISBN13
+LEFT JOIN `academic-observatory.observatory.book{{ public_book_release_date.strftime('%Y%m%d') }}` as public_data on public_data.isbn = onix_ebook_titles.ISBN13

--- a/oaebu_workflows/database/sql/create_book_products.sql.jinja2
+++ b/oaebu_workflows/database/sql/create_book_products.sql.jinja2
@@ -169,7 +169,8 @@ empty_google_books_sales as (
         CAST(NULL as STRING) as Author,
         CAST(NULL as DATE) as release_date,
         CAST(NULL as INT64) as qty,
-        [STRUCT(CAST(NULL as STRING) as Country_of_Sale, CAST(null as INT64) as qty)] as country
+        CAST(NULL as STRING) as Country_of_Sale,
+        CAST(NULL as INT64) as qty
 ),
 
 empty_google_analytics as (

--- a/oaebu_workflows/database/sql/create_book_products.sql.jinja2
+++ b/oaebu_workflows/database/sql/create_book_products.sql.jinja2
@@ -32,6 +32,7 @@ CREATE TEMP FUNCTION group_items_google_books_sales(items ARRAY<STRUCT<Country_o
     FROM UNNEST(items)
     GROUP BY Country_of_Sale)
   )
+);
 
 CREATE TEMP FUNCTION group_items_jstor_country(items ARRAY<STRUCT<Country_name STRING, Total_Item_Requests INT64>>) as (
   ARRAY(

--- a/oaebu_workflows/database/sql/create_mock_onix_data.sql.jinja2
+++ b/oaebu_workflows/database/sql/create_mock_onix_data.sql.jinja2
@@ -1,0 +1,64 @@
+{# Copyright 2020 Curtin University
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Author: Richard Hosking #}
+
+SELECT
+    oapen.identifier.isbn as ISBN13,
+    oapen.identifier.doi as Doi,
+    "Digital download and online" as ProductForm,
+    CAST(NULL as STRING) as EditionNumber,
+
+    [STRUCT(
+        [STRUCT(dc.title.value[SAFE_OFFSET(0)] as TitleText, dc.title.alternative as TitleWithoutPrefix)] as TitleElements,
+        CAST(NULL as STRING) as TitleType,
+        CAST(NULL as STRING) as TitleStatement
+    )] as TitleDetails,
+
+    ARRAY(
+        SELECT AS STRUCT
+            "Publication date" as PublishingDateRole,
+            CAST(FORMAT_DATETIME("%Y%m%d", published) as INT64) as `Date`
+        FROM UNNEST(dc.date.issued) as published
+    )  as PublishingDates,
+
+    ARRAY_CONCAT(
+        ARRAY(
+            SELECT AS STRUCT
+                "BIC_subject_category" as SubjectSchemeIdentifier,
+                code as SubjectCode,
+                ARRAY<STRING>[] as SubjectHeadingText
+            FROM UNNEST(dc.subject.classification_code) as code
+        ),
+        ARRAY(
+            SELECT AS STRUCT
+                "Keywords" as SubjectSchemeIdentifier,
+                CAST(NULL as STRING) as SubjectCode,
+                IF(
+                    ARRAY_TO_STRING(ARRAY_AGG(code), '; ') IS NOT NULL,
+                    [ARRAY_TO_STRING(ARRAY_AGG(code), '; ')],
+                    ARRAY<STRING>[]
+                ) as SubjectHeadingText
+            FROM UNNEST(dc.subject.other) as code
+        )
+    ) as Subjects,
+
+    ARRAY(
+        SELECT AS STRUCT
+            SPLIT(author, '::')[SAFE_OFFSET(0)] as PersonName,
+            SPLIT(author, '::')[SAFE_OFFSET(1)] as ORCID
+        FROM UNNEST(dc.contributor.author) as author
+    )  as Contributors,
+
+FROM `{{ project_id }}.{{ dataset_id }}.{{ table_id }}` as onix

--- a/oaebu_workflows/database/sql/export_book_metrics.sql.jinja2
+++ b/oaebu_workflows/database/sql/export_book_metrics.sql.jinja2
@@ -15,7 +15,9 @@
 # Author: Richard Hosking #}
 
 SELECT
-    ISBN13,
+    ISBN13 as product_id,
+    work_id,
+    work_family_id,
     onix.title as title,
     CAST(onix.published_year as INT64) as published_year,
     month.month,
@@ -32,5 +34,6 @@ SELECT
         month.oapen_irus_uk.unique_item_investigations,
         month.oapen_irus_uk.unique_item_requests
     ) as oapen_irus_uk,
+    STRUCT(month.ucl_discovery.total_downloads) as ucl_discovery
 FROM `{{ project_id }}.{{ dataset_id }}.book_product{{ release.strftime('%Y%m%d') }}`, UNNEST(months) as month
 WHERE month.oapen_irus_uk IS NOT NULL OR month.google_books_traffic IS NOT NULL OR month.google_books_sales IS NOT NULL

--- a/oaebu_workflows/database/sql/export_book_metrics_city.sql.jinja2
+++ b/oaebu_workflows/database/sql/export_book_metrics_city.sql.jinja2
@@ -16,6 +16,8 @@
 
 SELECT
     ISBN13 as product_id,
+    MAX(work_id) as work_id,
+    MAX(work_family_id) as work_family_id,
     MAX(onix.title) as title,
     CAST(MAX(onix.published_year) as INT64) as published_year,
     month.month,

--- a/oaebu_workflows/database/sql/export_book_metrics_country.sql.jinja2
+++ b/oaebu_workflows/database/sql/export_book_metrics_country.sql.jinja2
@@ -24,6 +24,7 @@ WITH months as (SELECT
     month.jstor_country as jstor,
     month.oapen_irus_uk.country as oapen_irus_uk,
     month.google_analytics.unique_views.country as google_analytics,
+    month.google_books_sales.countries as google_books_sales,
     month.ucl_discovery.downloads_per_country as ucl_discovery
 FROM `{{ project_id }}.{{ dataset_id }}.book_product{{ release.strftime('%Y%m%d') }}`, UNNEST(months) as month
 WHERE ISBN13 is not null AND month.month is not null AND (month.jstor_country IS NOT NULL OR month.oapen_irus_uk.locations IS NOT NULL OR month.ucl_discovery.downloads_per_country IS NOT NULL)),
@@ -47,6 +48,15 @@ month_country as (
         name as country_name
     FROM months
     CROSS JOIN countries
+),
+
+google_books_month_country as (
+    SELECT
+        ISBN13,
+        month,
+        Country_of_Sale as alpha2,
+        qty
+    FROM months, UNNEST(google_books_sales)
 ),
 
 jstor_month_country as (
@@ -109,10 +119,12 @@ SELECT
     STRUCT(jstor.Total_Item_Requests) as jstor,
     STRUCT(oapen.title_requests, oapen.total_item_investigations, oapen.total_item_requests, oapen.unique_item_investigations, oapen.unique_item_requests) as oapen_irus_uk,
     STRUCT(google.value as value) as google_analytics,
+    STRUCT(google_books.qty as qty) as google_books,
     STRUCT(ucl_discovery.download_count as download_count) as ucl_discovery
 FROM month_country
 LEFT JOIN jstor_month_country as jstor ON month_country.ISBN13 = jstor.ISBN13 AND month_country.month = jstor.month AND month_country.alpha2 = jstor.alpha2
 LEFT JOIN oapen_month_country as oapen ON month_country.ISBN13 = oapen.ISBN13 AND month_country.month = oapen.month AND month_country.alpha2 = oapen.alpha2
 LEFT JOIN google_analytics_month_country as google ON month_country.ISBN13 = google.ISBN13 AND month_country.month = google.month AND month_country.alpha2 = google.country_code
+LEFT JOIN google_books_month_country as google_books ON month_country.ISBN13 = google_books.ISBN13 AND month_country.month = google_books.month AND month_country.alpha2 = google_books.alpha2
 LEFT JOIN ucl_discovery_month_country as ucl_discovery ON month_country.ISBN13 = ucl_discovery.ISBN13 AND month_country.month = ucl_discovery.month AND month_country.alpha2 = ucl_discovery.alpha2
 WHERE jstor.total_item_requests IS NOT NULL OR oapen.title_requests IS NOT NULL OR 	oapen.total_item_requests IS NOT NULL or google.value IS NOT NULL

--- a/oaebu_workflows/database/sql/export_book_metrics_country.sql.jinja2
+++ b/oaebu_workflows/database/sql/export_book_metrics_country.sql.jinja2
@@ -16,14 +16,17 @@
 
 WITH months as (SELECT
     ISBN13,
+    work_id,
+    work_family_id,
     onix.title as title,
     CAST(onix.published_year as INT64) as published_year,
     month.month,
     month.jstor_country as jstor,
-    month.oapen_irus_uk.locations as oapen_irus_uk,
-    month.google_analytics.unique_views.country as google_analytics
+    month.oapen_irus_uk.country as oapen_irus_uk,
+    month.google_analytics.unique_views.country as google_analytics,
+    month.ucl_discovery.downloads_per_country as ucl_discovery
 FROM `{{ project_id }}.{{ dataset_id }}.book_product{{ release.strftime('%Y%m%d') }}`, UNNEST(months) as month
-WHERE ISBN13 is not null AND month.month is not null AND (month.jstor_country IS NOT NULL OR month.oapen_irus_uk.locations IS NOT NULL)),
+WHERE ISBN13 is not null AND month.month is not null AND (month.jstor_country IS NOT NULL OR month.oapen_irus_uk.locations IS NOT NULL OR month.ucl_discovery.downloads_per_country IS NOT NULL)),
 
 countries as (
     SELECT
@@ -35,6 +38,8 @@ countries as (
 month_country as (
     SELECT
         ISBN13,
+        work_id,
+        work_family_id,
         title,
         published_year,
         month,
@@ -57,7 +62,7 @@ oapen_month_country as (
     SELECT
         ISBN13,
         month,
-        country_code as alpha2,
+        code as alpha2,
         title_requests,
         total_item_investigations,
         total_item_requests,
@@ -70,13 +75,32 @@ google_analytics_month_country as (
     SELECT
         ISBN13,
         month,
+        google.country_name,
+        country_code.country_code,
+        value
+    FROM (SELECT
+        ISBN13,
+        month,
         name as country_name,
         value
-    FROM months, UNNEST(google_analytics)
+    FROM months, UNNEST(google_analytics)) as google
+    LEFT JOIN `academic-observatory.settings.country_to_alpha2` as country_code on country_code.country_name = google.country_name
+),
+
+ucl_discovery_month_country as (
+    SELECT
+        ISBN13,
+        month,
+        country_name,
+        country_code as alpha2,
+        download_count
+    FROM months, UNNEST(ucl_discovery)
 )
 
 SELECT
     month_country.ISBN13 as product_id,
+    month_country.work_id as work_id,
+    month_country.work_family_id as work_family_id,
     month_country.title,
     month_country.published_year,
     month_country.month,
@@ -84,9 +108,11 @@ SELECT
     month_country.country_name,
     STRUCT(jstor.Total_Item_Requests) as jstor,
     STRUCT(oapen.title_requests, oapen.total_item_investigations, oapen.total_item_requests, oapen.unique_item_investigations, oapen.unique_item_requests) as oapen_irus_uk,
-    STRUCT(google.value as value) as google_analytics
+    STRUCT(google.value as value) as google_analytics,
+    STRUCT(ucl_discovery.download_count as download_count) as ucl_discovery
 FROM month_country
 LEFT JOIN jstor_month_country as jstor ON month_country.ISBN13 = jstor.ISBN13 AND month_country.month = jstor.month AND month_country.alpha2 = jstor.alpha2
 LEFT JOIN oapen_month_country as oapen ON month_country.ISBN13 = oapen.ISBN13 AND month_country.month = oapen.month AND month_country.alpha2 = oapen.alpha2
-LEFT JOIN google_analytics_month_country as google ON month_country.ISBN13 = google.ISBN13 AND month_country.month = google.month AND UPPER(month_country.country_name) = UPPER(google.country_name)
+LEFT JOIN google_analytics_month_country as google ON month_country.ISBN13 = google.ISBN13 AND month_country.month = google.month AND month_country.alpha2 = google.country_code
+LEFT JOIN ucl_discovery_month_country as ucl_discovery ON month_country.ISBN13 = ucl_discovery.ISBN13 AND month_country.month = ucl_discovery.month AND month_country.alpha2 = ucl_discovery.alpha2
 WHERE jstor.total_item_requests IS NOT NULL OR oapen.title_requests IS NOT NULL OR 	oapen.total_item_requests IS NOT NULL or google.value IS NOT NULL

--- a/oaebu_workflows/database/sql/export_book_metrics_event.sql.jinja2
+++ b/oaebu_workflows/database/sql/export_book_metrics_event.sql.jinja2
@@ -16,6 +16,8 @@
 
 SELECT
     ISBN13 as product_id,
+    MAX(work_id) as work_id,
+    MAX(work_family_id) as work_family_id,
     MAX(onix.title) as title,
     CAST(MAX(onix.published_year) as INT64) as published_year,
     month.month,

--- a/oaebu_workflows/database/sql/export_book_metrics_referrer.sql.jinja2
+++ b/oaebu_workflows/database/sql/export_book_metrics_referrer.sql.jinja2
@@ -16,6 +16,8 @@
 
 SELECT
     ISBN13 as product_id,
+    MAX(work_id) as work_id,
+    MAX(work_family_id) as work_family_id,
     MAX(onix.title) as title,
     CAST(MAX(onix.published_year) as INT64) as published_year,
     month.month,

--- a/oaebu_workflows/database/sql/export_unmatched_metrics.sql.jinja2
+++ b/oaebu_workflows/database/sql/export_unmatched_metrics.sql.jinja2
@@ -18,12 +18,14 @@ WITH google_analytics as (
     {% if google_analytics %}
     SELECT
         {{ google_analytics_isbn }} as ISBN,
+        title,
         release_date,
         "google_analytics" as source
     FROM `{{ project_id }}.{{ dataset_id }}.{{ google_analytics_table }}_unmatched_{{ google_analytics_isbn }}{{ release.strftime('%Y%m%d') }}`
     {% else %}
     SELECT
         CAST(NULL as STRING) as ISBN,
+        CAST(NULL as STRING) as title,
         CAST(NULL as DATE) as release_date,
         "google_analytics" as source
     {% endif %}
@@ -33,12 +35,14 @@ google_books as (
     {% if google_books %}
     SELECT
         {{ google_books_isbn }} as ISBN,
+        title,
         release_date,
         "google_books" as source
     FROM `{{ project_id }}.{{ dataset_id }}.{{ google_books_table }}_unmatched_{{ google_books_isbn }}{{ release.strftime('%Y%m%d') }}`
     {% else %}
     SELECT
         CAST(NULL as STRING) as ISBN,
+        CAST(NULL as STRING) as title,
         CAST(NULL as DATE) as release_date,
         "google_books" as source
     {% endif %}
@@ -48,12 +52,14 @@ jstor as (
     {% if jstor %}
     SELECT
         {{ jstor_isbn }} as ISBN,
+        title,
         release_date,
         "jstor" as source
     FROM `{{ project_id }}.{{ dataset_id }}.{{ jstor_table }}_unmatched_{{ jstor_isbn }}{{ release.strftime('%Y%m%d') }}`
     {% else %}
     SELECT
         CAST(NULL as STRING) as ISBN,
+        CAST(NULL as STRING) as title,
         CAST(NULL as DATE) as release_date,
         "jstor" as source
     {% endif %}
@@ -63,12 +69,14 @@ oapen as (
     {% if oapen %}
     SELECT
         {{ oapen_isbn }} as ISBN,
+        title,
         release_date,
         "oapen" as source
     FROM `{{ project_id }}.{{ dataset_id }}.{{ oapen_table }}_unmatched_{{ oapen_isbn }}{{ release.strftime('%Y%m%d') }}`
     {% else %}
     SELECT
         CAST(NULL as STRING) as ISBN,
+        CAST(NULL as STRING) as title,
         CAST(NULL as DATE) as release_date,
         "oapen" as source
     {% endif %}
@@ -87,6 +95,10 @@ SELECT * FROM oapen
 SELECT
     ISBN,
     release_date,
+    ARRAY_AGG(DISTINCT IF(source = "google_analytics", title, NULL) IGNORE NULLS LIMIT 1)[SAFE_OFFSET(0)] as google_analytics_title,
+    ARRAY_AGG(DISTINCT IF(source = "google_books", title, NULL) IGNORE NULLS LIMIT 1)[SAFE_OFFSET(0)] as google_books_title,
+    ARRAY_AGG(DISTINCT IF(source = "jstor", title, NULL) IGNORE NULLS LIMIT 1)[SAFE_OFFSET(0)] as jstor_title,
+    ARRAY_AGG(DISTINCT IF(source = "oapen", title, NULL) IGNORE NULLS LIMIT 1)[SAFE_OFFSET(0)] as oapen_title,
     "google_analytics" in UNNEST(ARRAY_AGG(source)) as in_google_analytics,
     "google_books" in UNNEST(ARRAY_AGG(source)) as in_google_books,
     "jstor" in UNNEST(ARRAY_AGG(source)) as in_jstor,

--- a/oaebu_workflows/database/sql/oaebu_intermediate_metrics.sql.jinja2
+++ b/oaebu_workflows/database/sql/oaebu_intermediate_metrics.sql.jinja2
@@ -16,6 +16,7 @@
 
 SELECT
   {{ isbn }},
+  {{ title }} as title,
   release_date
 FROM
   `{{ project_id }}.{{ dataset_id }}.{{ table_id }}`

--- a/oaebu_workflows/workflows/oaebu_partners.py
+++ b/oaebu_workflows/workflows/oaebu_partners.py
@@ -41,6 +41,7 @@ class OaebuPartners:
     :param gcp_dataset_id: GCP Dataset ID.
     :param gcp_table_id: Table name without the date suffix.
     :param isbn_field_name: Name of the field containing the ISBN.
+    :param title_field_name: Name of the field containing the Title.
     :param sharded: whether the table is sharded or not.
     """
 
@@ -50,4 +51,5 @@ class OaebuPartners:
     gcp_dataset_id: str
     gcp_table_id: str
     isbn_field_name: str
+    title_field_name: str
     sharded: bool

--- a/oaebu_workflows/workflows/oapen_workflow.py
+++ b/oaebu_workflows/workflows/oapen_workflow.py
@@ -25,6 +25,7 @@ from airflow.models import Variable
 from airflow.sensors.external_task import ExternalTaskSensor
 from oaebu_workflows.config import sql_folder
 
+from oaebu_workflows.workflows.onix_workflow import make_table_id
 from observatory.platform.workflows.workflow import Workflow
 from observatory.platform.utils.gc_utils import (
     bigquery_sharded_table_id,
@@ -63,6 +64,7 @@ class OapenWorkflowRelease:
         :return: None.
         """
         pass
+
 
 class OapenWorkflow(Workflow):
     """
@@ -209,7 +211,6 @@ class OapenWorkflow(Workflow):
 
         release.cleanup()
 
-
     def create_onix_formatted_metadata_output_tasks(
         self,
         release: OapenWorkflowRelease,
@@ -276,12 +277,13 @@ class OapenWorkflow(Workflow):
         table_id = bigquery_sharded_table_id(output_table, release_date)
 
         # Identify latest Book release from the Academic Observatory
-        public_book_release_date = select_table_shard_dates(
+        public_book_table_id = make_table_id(
             project_id=self.ao_gcp_project_id,
             dataset_id=self.public_book_metadata_dataset_id,
             table_id=self.public_book_metadata_table_id,
             end_date=release.release_date,
-        )[0]
+            sharded=True,
+        )
 
         google_analytics_table_id = "empty_google_analytics"
         google_books_sales_table_id = "empty_google_books_sales"
@@ -307,7 +309,7 @@ class OapenWorkflow(Workflow):
             jstor_institution_table_id=jstor_institution_table_id,
             oapen_table_id=oapen_table_id,
             ucl_table_id=ucl_table_id,
-            public_book_release_date=public_book_release_date,
+            public_book_tabel_id=public_book_table_id,
         )
 
         create_bigquery_dataset(project_id=project_id, dataset_id=output_dataset, location=data_location)

--- a/oaebu_workflows/workflows/oapen_workflow.py
+++ b/oaebu_workflows/workflows/oapen_workflow.py
@@ -309,7 +309,7 @@ class OapenWorkflow(Workflow):
             jstor_institution_table_id=jstor_institution_table_id,
             oapen_table_id=oapen_table_id,
             ucl_table_id=ucl_table_id,
-            public_book_tabel_id=public_book_table_id,
+            public_book_tabel_id=f"{self.ao_gcp_project_id}.{self.public_book_metadata_dataset_id}.{public_book_table_id}",
         )
 
         create_bigquery_dataset(project_id=project_id, dataset_id=output_dataset, location=data_location)

--- a/oaebu_workflows/workflows/oapen_workflow.py
+++ b/oaebu_workflows/workflows/oapen_workflow.py
@@ -1,0 +1,568 @@
+# Copyright 2020 Curtin University
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+# Author: Richard Hosking
+
+import os
+import shutil
+from functools import partial, update_wrapper
+from pathlib import Path
+from typing import List, Optional
+
+import pendulum
+from airflow.exceptions import AirflowException
+from airflow.models import Variable
+from airflow.sensors.external_task import ExternalTaskSensor
+from google.cloud.bigquery import SourceFormat
+from observatory.dags.config import sql_folder
+
+from observatory.platform.workflows.workflow import AbstractRelease, Workflow
+from observatory.platform.utils.gc_utils import (
+    bigquery_sharded_table_id,
+    create_bigquery_dataset,
+    create_bigquery_table_from_query,
+    run_bigquery_query,
+    select_table_shard_dates,
+    copy_bigquery_table
+)
+from observatory.platform.utils.jinja2_utils import render_template
+from observatory.platform.utils.airflow_utils import AirflowVars
+from observatory.platform.utils.workflow_utils import (
+    bq_load_shard_v2,
+    table_ids_from_path,
+    make_dag_id,
+)
+
+
+class OapenWorkflowRelease(AbstractRelease):
+    """
+    Release information for OapenWorkflow.
+    """
+
+    def __init__(
+        self,
+        *,
+        dag_id: str,
+        release_date: pendulum.DateTime,
+        gcp_project_id: str,
+        ao_gcp_project_id: str = "academic-observatory",
+        oapen_metadata_dataset_id: str = "oapen",
+        oapen_metadata_table_id: str = "metadata",
+        public_book_metadata_dataset_id: str = "observatory",
+        public_book_metadata_table_id: str = "book",
+        irus_uk_dag_id_prefix: str = "oapen_irus_uk",
+        irus_uk_dataset_id: str = "oapen",
+        irus_uk_table_id: str = "oapen_irus_uk",
+        oaebu_dataset: str = "oaebu",
+        oaebu_onix_dataset: str = "oapen_onix",
+        oaebu_intermediate_dataset: str = "oaebu_intermediate",
+        oaebu_elastic_dataset: str = "data_export",
+        dataset_location: str = "us",
+        dataset_description: str = "Oapen workflow tables",
+    ):
+        """
+        :param dag_id: DAG ID.
+        :param release_date: The release date. It's the current execution date.
+        :param oapen_release_date: the OAPEN release date.
+        :param gcp_project_id: GCP Project ID.
+        :param ao_gcp_project_id: GCP project ID for the Academic Observatory.
+        :param oapen_metadata_dataset_id: GCP dataset ID for the oapen data.
+        :param oapen_metadata_table_id: GCP table ID for the oapen data.
+        :param public_book_dataset_id: GCP dataset ID for the public book data.
+        :param public_book_table_id: GCP table ID for the public book data.
+        :param irus_uk_dag_id_prefix: OAEBU IRUS_UK dag id prefix.
+        :param irus_uk_dataset_id: OAEBU IRUS_UK dataset id.
+        :param irus_uk_table_id: OAEBU IRUS_UK table id.
+        :param oaebu_dataset: OAEBU dataset.
+        :param oaebu_intermediate_dataset: OAEBU intermediate dataset.
+        :param oaebu_elastic_dataset: OAEBU elastic dataset.
+        """
+
+        self.dag_id = dag_id
+        self.release_date = release_date
+
+        # GCP parameters for oaebu_oapen project
+        self.gcp_project_id = gcp_project_id
+        self.dataset_location = dataset_location
+        self.dataset_description = dataset_description
+
+        self.oaebu_dataset = oaebu_dataset
+        self.oaebu_onix_dataset = oaebu_onix_dataset
+        self.oaebu_intermediate_dataset = oaebu_intermediate_dataset
+        self.oaebu_elastic_dataset = oaebu_elastic_dataset
+
+        # Academic Observatory Reference
+        self.ao_gcp_project_id = ao_gcp_project_id
+
+        # OAPEN Metadata
+        self.oapen_metadata_dataset_id = oapen_metadata_dataset_id
+        self.oapen_metadata_table_id = oapen_metadata_table_id
+
+        # Public Book Data
+        self.public_book_metadata_dataset_id = public_book_metadata_dataset_id
+        self.public_book_metadata_table_id = public_book_metadata_table_id
+
+        # IRUS-UK
+        self.irus_uk_dag_id_prefix = irus_uk_dag_id_prefix
+        self.irus_uk_dataset_id = irus_uk_dataset_id
+        self.irus_uk_table_id = irus_uk_table_id
+
+
+    @property
+    def transform_bucket(self) -> str:
+        """Not used.
+        :return: Empty string.
+        """
+        return str()
+
+    @property
+    def transform_folder(self) -> str:
+        """Not used.
+        :return: Empty string.
+        """
+        return str()
+
+    @property
+    def transform_files(self) -> List[str]:
+        """Not used.
+        :return: Empty list.
+        """
+        return list()
+
+    @property
+    def download_bucket(self) -> str:
+        """Not used.
+        :return: Empty string.
+        """
+        return str()
+
+    @property
+    def download_files(self) -> List[str]:
+        """Not used.
+        :return: Empty list.
+        """
+        return list()
+
+    @property
+    def extract_files(self) -> List[str]:
+        """Not used.
+        :return: Empty list.
+        """
+        return list()
+
+    @property
+    def download_folder(self) -> str:
+        """Not used.
+        :return: Empty string.
+        """
+        return str()
+
+    @property
+    def extract_folder(self) -> str:
+        """Not used.
+        :return: Empty string.
+        """
+        return str()
+
+    def cleanup(self):
+        """Delete all files and folders associated with this release.
+        :return: None.
+        """
+        pass
+
+
+def make_table_id(*, project_id: str, dataset_id: str, table_id: str, end_date: pendulum.datetime, sharded: bool):
+    """
+    Make a BQ table ID.
+    :param project_id: GCP Project ID.
+    :param dataset_id: GCP Dataset ID.
+    :param table_id: Table name to convert to the suitable BQ table ID.
+    :param end_date: Latest date considered.
+    :param sharded: whether the table is sharded or not.
+    """
+
+    new_table_id = table_id
+    if sharded:
+        table_date = select_table_shard_dates(
+            project_id=project_id,
+            dataset_id=dataset_id,
+            table_id=table_id,
+            end_date=end_date,
+        )[0]
+        new_table_id = f"{table_id}{table_date.strftime('%Y%m%d')}"
+
+    return new_table_id
+
+
+class OapenWorkflow(Workflow):
+    """
+    Workflow for processing the OAPEN metadata and IRUS-UK metrics data
+    """
+
+    DAG_ID_PREFIX = "oapen_workflow"
+    ORG_NAME = "OAPEN"
+
+    def __init__(
+        self,
+        *,
+        irus_uk_dag_id_prefix: str = "oapen_irus_uk",
+        dag_id: Optional[str] = None,
+        start_date: Optional[pendulum.datetime] = pendulum.datetime(2021, 3, 28),
+        schedule_interval: Optional[str] = "@weekly",
+        catchup: Optional[bool] = False,
+        airflow_vars: List = None,
+    ):
+        """Initialises the workflow object.
+        :param gcp_project_id: Project ID in GCP.
+        :param gcp_dataset_id: Dataset ID in GCP.
+        :param irus_uk_dag_id_prefix: OAEBU IRUS_UK dag id prefix.
+        :param dag_id: DAG ID.
+        :param start_date: Start date of the DAG.
+        :param schedule_interval: Scheduled interval for running the DAG.
+        :param catchup: Whether to catch up missed DAG runs.
+        :param airflow_vars: list of airflow variable keys, for each variable it is checked if it exists in airflow.
+        """
+
+        self.dag_id = dag_id
+        if dag_id is None:
+            self.dag_id = make_dag_id(self.DAG_ID_PREFIX, self.ORG_NAME)
+
+        if airflow_vars is None:
+            airflow_vars = [
+                AirflowVars.DATA_PATH,
+                AirflowVars.PROJECT_ID,
+                AirflowVars.DATA_LOCATION,
+                AirflowVars.DOWNLOAD_BUCKET,
+                AirflowVars.TRANSFORM_BUCKET,
+            ]
+
+        self.org_name = self.ORG_NAME
+        self.irus_uk_dag_id_prefix = irus_uk_dag_id_prefix
+
+        # Initialise Telesecope base class
+        super().__init__(
+            dag_id=self.dag_id, start_date=start_date, schedule_interval=schedule_interval, catchup=catchup, airflow_vars=airflow_vars
+        )
+
+        # Wait for irus_uk workflow to finish
+        ext_dag_id = make_dag_id(irus_uk_dag_id_prefix, self.ORG_NAME)
+        sensor = ExternalTaskSensor(task_id=f"{ext_dag_id}_sensor", external_dag_id=ext_dag_id, mode="reschedule")
+        self.add_sensor(sensor)
+
+        # Format OAPEN Metadata like ONIX to enable the next steps
+        self.add_task(
+            self.create_onix_formatted_metadata_output_tasks,
+            task_id="create_onix_formatted_metadata_output_tasks"
+        )
+
+        # Copy IRUS-UK data and add release date
+        self.add_task(
+            self.copy_irus_uk_release,
+            task_id="copy_irus_uk_release"
+        )
+
+        # Create OAEBU book product table
+        self.add_task(
+            self.create_oaebu_book_product_table,
+            task_id="create_oaebu_book_product_table"
+        )
+
+        # Create OAEBU Elastic Export tables
+        self.create_oaebu_export_tasks()
+
+        # Cleanup tasks
+        self.add_task(self.cleanup)
+
+
+    def make_release(self, **kwargs) -> OapenWorkflowRelease:
+        """Creates a release object.
+        :param kwargs: From Airflow. Contains the execution_date.
+        :return: an OapenWorkflowRelease object.
+        """
+
+        # Make release date
+        release_date = kwargs["next_execution_date"].subtract(microseconds=1).date()
+        project_id = Variable.get(AirflowVars.PROJECT_ID)
+
+        return OapenWorkflowRelease(
+            dag_id=self.dag_id,
+            release_date=release_date,
+            gcp_project_id=project_id,
+        )
+
+
+    def cleanup(self, release: OapenWorkflowRelease, **kwargs):
+        """Cleanup temporary files.
+
+        :param release: Workflow release objects.
+        :param kwargs: Unused.
+        """
+
+        release.cleanup()
+
+
+    def copy_irus_uk_release(
+            self,
+            release: OapenWorkflowRelease,
+            **kwargs,
+    ):
+        """Copy state of the oapen-irus-uk dataset and create a labled release
+        :param release: Oapen workflow release information.
+        """
+
+        source_table_id = f"{release.gcp_project_id}.{release.irus_uk_dataset_id}.{release.irus_uk_table_id}"
+        destination_table_id = f"{release.gcp_project_id}.{release.oaebu_intermediate_dataset}.{release.irus_uk_dataset_id}_{bigquery_sharded_table_id('oapen_irus_uk_matched', release.release_date)}"
+
+        create_bigquery_dataset(project_id=release.gcp_project_id, dataset_id=release.oaebu_intermediate_dataset, location=release.dataset_location)
+
+        status = copy_bigquery_table(source_table_id, destination_table_id, release.dataset_location)
+
+        if not status:
+            raise AirflowException(
+                f"Issue copying table: {source_table_id} to {destination_table_id}"
+            )
+
+    def create_onix_formatted_metadata_output_tasks(
+            self,
+            release: OapenWorkflowRelease,
+            **kwargs,
+    ):
+        """Create the Book Product Table
+        :param release: Oapen workflow release information.
+        """
+
+        output_dataset = release.oaebu_onix_dataset
+        data_location = release.dataset_location
+        project_id = release.gcp_project_id
+
+        output_table = "onix"
+        release_date = release.release_date
+        table_id = bigquery_sharded_table_id(output_table, release_date)
+
+        # SQL reference
+        table_joining_template_file = "create_mock_onix_data.sql.jinja2"
+        template_path = os.path.join(sql_folder(), table_joining_template_file)
+
+        sql = render_template(
+            template_path,
+            project_id=release.ao_gcp_project_id,
+            dataset_id=release.oapen_metadata_dataset_id,
+            table_id=release.oapen_metadata_table_id,
+        )
+
+        create_bigquery_dataset(project_id=project_id, dataset_id=output_dataset, location=data_location)
+
+        status = create_bigquery_table_from_query(
+            sql=sql,
+            project_id=project_id,
+            dataset_id=output_dataset,
+            table_id=table_id,
+            location=data_location,
+        )
+
+        if not status:
+            raise AirflowException(
+                f"create_bigquery_table_from_query failed on {project_id}.{output_dataset}.{table_id}"
+            )
+
+
+    def create_oaebu_book_product_table(
+        self,
+        release: OapenWorkflowRelease,
+        **kwargs,
+    ):
+        """Create the Book Product Table
+        :param release: Oapen workflow release information.
+        :param oapen_dataset: dataset_id if it is  a relevant data source for this publisher
+        """
+
+        output_table = "book_product"
+        output_dataset = release.oaebu_dataset
+        project_id = release.gcp_project_id
+
+        data_location = release.dataset_location
+        release_date = release.release_date
+
+        table_joining_template_file = "create_book_products.sql.jinja2"
+        template_path = os.path.join(sql_folder(), table_joining_template_file)
+
+        table_id = bigquery_sharded_table_id(output_table, release_date)
+
+        # Identify latest Book release from the Academic Observatory
+        public_book_release_date = select_table_shard_dates(
+            project_id=release.ao_gcp_project_id,
+            dataset_id=release.public_book_metadata_dataset_id,
+            table_id=release.public_book_metadata_table_id,
+            end_date=release.release_date,
+        )[0]
+
+        sql = render_template(
+            template_path,
+            project_id=project_id,
+            onix_dataset_id=release.oaebu_onix_dataset,
+            dataset_id=release.oaebu_intermediate_dataset,
+            release_date=release_date,
+            onix_release_date=release_date,
+            google_analytics=False,
+            google_books=False,
+            jstor=False,
+            oapen=True,
+            ucl=False,
+            onix_workflow=False,
+            onix_workflow_dataset='',
+            google_analytics_dataset='',
+            google_books_dataset='',
+            jstor_dataset='',
+            oapen_dataset=release.irus_uk_dataset_id,
+            ucl_dataset='',
+            public_book_release_date=public_book_release_date,
+        )
+
+        create_bigquery_dataset(project_id=project_id, dataset_id=output_dataset, location=data_location)
+
+        status = create_bigquery_table_from_query(
+            sql=sql,
+            project_id=project_id,
+            dataset_id=output_dataset,
+            table_id=table_id,
+            location=data_location,
+        )
+
+        if not status:
+            raise AirflowException(
+                f"create_bigquery_table_from_query failed on {project_id}.{output_dataset}.{table_id}"
+            )
+
+
+    def export_oaebu_table(
+        self,
+        release: OapenWorkflowRelease,
+        *,
+        output_table: str,
+        query_template: str,
+        **kwargs,
+    ):
+        """Create an exported oaebu table.
+        :param release: Oapen workflow release information.
+        """
+
+        project_id = release.gcp_project_id
+        output_dataset = release.oaebu_elastic_dataset
+        data_location = release.dataset_location
+        release_date = release.release_date
+
+        create_bigquery_dataset(project_id=project_id, dataset_id=output_dataset, location=data_location)
+
+        table_id = bigquery_sharded_table_id(f"{project_id.replace('-', '_')}_{output_table}", release_date)
+        template_path = os.path.join(sql_folder(), query_template)
+
+        sql = render_template(
+            template_path,
+            project_id=project_id,
+            dataset_id=release.oaebu_dataset,
+            release=release_date,
+        )
+
+        status = create_bigquery_table_from_query(
+            sql=sql,
+            project_id=project_id,
+            dataset_id=output_dataset,
+            table_id=table_id,
+            location=data_location,
+        )
+
+        if not status:
+            raise AirflowException(
+                f"create_bigquery_table_from_query failed on {project_id}.{output_dataset}.{table_id}"
+            )
+
+
+    def create_oaebu_export_tasks(self):
+        """Create tasks for exporting final metrics from our OAEBU data.  It will create output tables in the oaebu_elastic dataset.
+        :param data_partners: Oapen workflow release information.
+        """
+
+        export_tables = [
+            {"output_table": "book_product_list", "query_template": "export_book_list.sql.jinja2", "file_type": "json"},
+            {
+                "output_table": "book_product_metrics",
+                "query_template": "export_book_metrics.sql.jinja2",
+                "file_type": "json",
+            },
+            {
+                "output_table": "book_product_metrics_country",
+                "query_template": "export_book_metrics_country.sql.jinja2",
+                "file_type": "json",
+            },
+            {
+                "output_table": "book_product_metrics_institution",
+                "query_template": "export_book_metrics_institution.sql.jinja2",
+                "file_type": "json",
+            },
+            {
+                "output_table": "book_product_metrics_city",
+                "query_template": "export_book_metrics_city.sql.jinja2",
+                "file_type": "json",
+            },
+            {
+                "output_table": "book_product_metrics_referrer",
+                "query_template": "export_book_metrics_referrer.sql.jinja2",
+                "file_type": "json",
+            },
+            {
+                "output_table": "book_product_metrics_events",
+                "query_template": "export_book_metrics_event.sql.jinja2",
+                "file_type": "json",
+            },
+            {
+                "output_table": "book_product_publisher_metrics",
+                "query_template": "export_book_publisher_metrics.sql.jinja2",
+                "file_type": "json",
+            },
+            {
+                "output_table": "book_product_subject_metrics",
+                "query_template": "export_book_subject_metrics.sql.jinja2",
+                "file_type": "json",
+            },
+            {
+                "output_table": "book_product_year_metrics",
+                "query_template": "export_book_year_metrics.sql.jinja2",
+                "file_type": "json",
+            },
+            {
+                "output_table": "book_product_subject_year_metrics",
+                "query_template": "export_book_subject_year_metrics.sql.jinja2",
+                "file_type": "json",
+            },
+            {
+                "output_table": "book_product_author_metrics",
+                "query_template": "export_book_author_metrics.sql.jinja2",
+                "file_type": "json",
+            },
+        ]
+
+        # Create each export table in BiqQuery
+        for export_table in export_tables:
+            fn = partial(
+                self.export_oaebu_table,
+                output_table=export_table["output_table"],
+                query_template=export_table["query_template"],
+            )
+
+            # Populate the __name__ attribute of the partial object (it lacks one by default).
+            update_wrapper(fn, self.export_oaebu_table)
+            fn.__name__ += f".{export_table['output_table']}"
+
+            self.add_task(fn)

--- a/oaebu_workflows/workflows/oapen_workflow.py
+++ b/oaebu_workflows/workflows/oapen_workflow.py
@@ -58,6 +58,11 @@ class OapenWorkflowRelease:
         self.release_date = release_date
         self.gcp_project_id = gcp_project_id
 
+    def cleanup(self):
+        """Delete all files and folders associated with this release.
+        :return: None.
+        """
+        pass
 
 class OapenWorkflow(Workflow):
     """
@@ -157,6 +162,11 @@ class OapenWorkflow(Workflow):
 
         # Wait for irus_uk workflow to finish
         ext_dag_id = make_dag_id(irus_uk_dag_id_prefix, self.ORG_NAME)
+        sensor = ExternalTaskSensor(task_id=f"{ext_dag_id}_sensor", external_dag_id=ext_dag_id, mode="reschedule")
+        self.add_sensor(sensor)
+
+        # Wait for OAPEN Metadata workflow to finish
+        ext_dag_id = "oapen_metadata"
         sensor = ExternalTaskSensor(task_id=f"{ext_dag_id}_sensor", external_dag_id=ext_dag_id, mode="reschedule")
         self.add_sensor(sensor)
 

--- a/oaebu_workflows/workflows/oapen_workflow.py
+++ b/oaebu_workflows/workflows/oapen_workflow.py
@@ -174,15 +174,13 @@ class OapenWorkflow(Workflow):
         self.add_setup_task(self.check_dependencies)
 
         # Format OAPEN Metadata like ONIX to enable the next steps
-        self.add_task(
-            self.create_onix_formatted_metadata_output_tasks, task_id="create_onix_formatted_metadata_output_tasks"
-        )
+        self.add_task(self.create_onix_formatted_metadata_output_tasks)
 
         # Copy IRUS-UK data and add release date
-        self.add_task(self.copy_irus_uk_release, task_id="copy_irus_uk_release")
+        self.add_task(self.copy_irus_uk_release)
 
         # Create OAEBU book product table
-        self.add_task(self.create_oaebu_book_product_table, task_id="create_oaebu_book_product_table")
+        self.add_task(self.create_oaebu_book_product_table)
 
         # Create OAEBU Elastic Export tables
         self.create_oaebu_export_tasks()

--- a/oaebu_workflows/workflows/oapen_workflow.py
+++ b/oaebu_workflows/workflows/oapen_workflow.py
@@ -45,70 +45,17 @@ class OapenWorkflowRelease(AbstractRelease):
     def __init__(
         self,
         *,
-        dag_id: str,
         release_date: pendulum.DateTime,
         gcp_project_id: str,
-        ao_gcp_project_id: str = "academic-observatory",
-        oapen_metadata_dataset_id: str = "oapen",
-        oapen_metadata_table_id: str = "metadata",
-        public_book_metadata_dataset_id: str = "observatory",
-        public_book_metadata_table_id: str = "book",
-        irus_uk_dag_id_prefix: str = "oapen_irus_uk",
-        irus_uk_dataset_id: str = "oapen",
-        irus_uk_table_id: str = "oapen_irus_uk",
-        oaebu_dataset: str = "oaebu",
-        oaebu_onix_dataset: str = "oapen_onix",
-        oaebu_intermediate_dataset: str = "oaebu_intermediate",
-        oaebu_elastic_dataset: str = "data_export",
-        dataset_location: str = "us",
-        dataset_description: str = "Oapen workflow tables",
     ):
         """
-        :param dag_id: DAG ID.
         :param release_date: The release date. It's the current execution date.
         :param oapen_release_date: the OAPEN release date.
         :param gcp_project_id: GCP Project ID.
-        :param ao_gcp_project_id: GCP project ID for the Academic Observatory.
-        :param oapen_metadata_dataset_id: GCP dataset ID for the oapen data.
-        :param oapen_metadata_table_id: GCP table ID for the oapen data.
-        :param public_book_dataset_id: GCP dataset ID for the public book data.
-        :param public_book_table_id: GCP table ID for the public book data.
-        :param irus_uk_dag_id_prefix: OAEBU IRUS_UK dag id prefix.
-        :param irus_uk_dataset_id: OAEBU IRUS_UK dataset id.
-        :param irus_uk_table_id: OAEBU IRUS_UK table id.
-        :param oaebu_dataset: OAEBU dataset.
-        :param oaebu_intermediate_dataset: OAEBU intermediate dataset.
-        :param oaebu_elastic_dataset: OAEBU elastic dataset.
         """
 
-        self.dag_id = dag_id
         self.release_date = release_date
-
-        # GCP parameters for oaebu_oapen project
         self.gcp_project_id = gcp_project_id
-        self.dataset_location = dataset_location
-        self.dataset_description = dataset_description
-
-        self.oaebu_dataset = oaebu_dataset
-        self.oaebu_onix_dataset = oaebu_onix_dataset
-        self.oaebu_intermediate_dataset = oaebu_intermediate_dataset
-        self.oaebu_elastic_dataset = oaebu_elastic_dataset
-
-        # Academic Observatory Reference
-        self.ao_gcp_project_id = ao_gcp_project_id
-
-        # OAPEN Metadata
-        self.oapen_metadata_dataset_id = oapen_metadata_dataset_id
-        self.oapen_metadata_table_id = oapen_metadata_table_id
-
-        # Public Book Data
-        self.public_book_metadata_dataset_id = public_book_metadata_dataset_id
-        self.public_book_metadata_table_id = public_book_metadata_table_id
-
-        # IRUS-UK
-        self.irus_uk_dag_id_prefix = irus_uk_dag_id_prefix
-        self.irus_uk_dataset_id = irus_uk_dataset_id
-        self.irus_uk_table_id = irus_uk_table_id
 
 
     @property
@@ -184,7 +131,20 @@ class OapenWorkflow(Workflow):
     def __init__(
         self,
         *,
+        ao_gcp_project_id: str = "academic-observatory",
+        oapen_metadata_dataset_id: str = "oapen",
+        oapen_metadata_table_id: str = "metadata",
+        public_book_metadata_dataset_id: str = "observatory",
+        public_book_metadata_table_id: str = "book",
         irus_uk_dag_id_prefix: str = "oapen_irus_uk",
+        irus_uk_dataset_id: str = "oapen",
+        irus_uk_table_id: str = "oapen_irus_uk",
+        oaebu_dataset: str = "oaebu",
+        oaebu_onix_dataset: str = "oapen_onix",
+        oaebu_intermediate_dataset: str = "oaebu_intermediate",
+        oaebu_elastic_dataset: str = "data_export",
+        dataset_location: str = "us",
+        dataset_description: str = "Oapen workflow tables",
         dag_id: Optional[str] = None,
         start_date: Optional[pendulum.datetime] = pendulum.datetime(2021, 3, 28),
         schedule_interval: Optional[str] = "@weekly",
@@ -192,9 +152,17 @@ class OapenWorkflow(Workflow):
         airflow_vars: List = None,
     ):
         """Initialises the workflow object.
-        :param gcp_project_id: Project ID in GCP.
-        :param gcp_dataset_id: Dataset ID in GCP.
+        :param ao_gcp_project_id: GCP project ID for the Academic Observatory.
+        :param oapen_metadata_dataset_id: GCP dataset ID for the oapen data.
+        :param oapen_metadata_table_id: GCP table ID for the oapen data.
+        :param public_book_dataset_id: GCP dataset ID for the public book data.
+        :param public_book_table_id: GCP table ID for the public book data.
         :param irus_uk_dag_id_prefix: OAEBU IRUS_UK dag id prefix.
+        :param irus_uk_dataset_id: OAEBU IRUS_UK dataset id.
+        :param irus_uk_table_id: OAEBU IRUS_UK table id.
+        :param oaebu_dataset: OAEBU dataset.
+        :param oaebu_intermediate_dataset: OAEBU intermediate dataset.
+        :param oaebu_elastic_dataset: OAEBU elastic dataset.
         :param dag_id: DAG ID.
         :param start_date: Start date of the DAG.
         :param schedule_interval: Scheduled interval for running the DAG.
@@ -213,7 +181,31 @@ class OapenWorkflow(Workflow):
             ]
 
         self.org_name = self.ORG_NAME
+
+        # GCP parameters for oaebu_oapen project
+        self.dataset_location = dataset_location
+        self.dataset_description = dataset_description
+
+        self.oaebu_dataset = oaebu_dataset
+        self.oaebu_onix_dataset = oaebu_onix_dataset
+        self.oaebu_intermediate_dataset = oaebu_intermediate_dataset
+        self.oaebu_elastic_dataset = oaebu_elastic_dataset
+
+        # Academic Observatory Reference
+        self.ao_gcp_project_id = ao_gcp_project_id
+
+        # OAPEN Metadata
+        self.oapen_metadata_dataset_id = oapen_metadata_dataset_id
+        self.oapen_metadata_table_id = oapen_metadata_table_id
+
+        # Public Book Data
+        self.public_book_metadata_dataset_id = public_book_metadata_dataset_id
+        self.public_book_metadata_table_id = public_book_metadata_table_id
+
+        # IRUS-UK
         self.irus_uk_dag_id_prefix = irus_uk_dag_id_prefix
+        self.irus_uk_dataset_id = irus_uk_dataset_id
+        self.irus_uk_table_id = irus_uk_table_id
 
         # Initialise Telesecope base class
         super().__init__(
@@ -264,7 +256,6 @@ class OapenWorkflow(Workflow):
         project_id = Variable.get(AirflowVars.PROJECT_ID)
 
         return OapenWorkflowRelease(
-            dag_id=self.dag_id,
             release_date=release_date,
             gcp_project_id=project_id,
         )
@@ -289,12 +280,12 @@ class OapenWorkflow(Workflow):
         :param release: Oapen workflow release information.
         """
 
-        source_table_id = f"{release.gcp_project_id}.{release.irus_uk_dataset_id}.{release.irus_uk_table_id}"
-        destination_table_id = f"{release.gcp_project_id}.{release.oaebu_intermediate_dataset}.{release.irus_uk_dataset_id}_{bigquery_sharded_table_id('oapen_irus_uk_matched', release.release_date)}"
+        source_table_id = f"{release.gcp_project_id}.{self.irus_uk_dataset_id}.{self.irus_uk_table_id}"
+        destination_table_id = f"{release.gcp_project_id}.{self.oaebu_intermediate_dataset}.{self.irus_uk_dataset_id}_{bigquery_sharded_table_id('oapen_irus_uk_matched', release.release_date)}"
 
-        create_bigquery_dataset(project_id=release.gcp_project_id, dataset_id=release.oaebu_intermediate_dataset, location=release.dataset_location)
+        create_bigquery_dataset(project_id=release.gcp_project_id, dataset_id=self.oaebu_intermediate_dataset, location=self.dataset_location)
 
-        status = copy_bigquery_table(source_table_id, destination_table_id, release.dataset_location)
+        status = copy_bigquery_table(source_table_id, destination_table_id, self.dataset_location)
 
         if not status:
             raise AirflowException(
@@ -310,8 +301,8 @@ class OapenWorkflow(Workflow):
         :param release: Oapen workflow release information.
         """
 
-        output_dataset = release.oaebu_onix_dataset
-        data_location = release.dataset_location
+        output_dataset = self.oaebu_onix_dataset
+        data_location = self.dataset_location
         project_id = release.gcp_project_id
 
         output_table = "onix"
@@ -324,9 +315,9 @@ class OapenWorkflow(Workflow):
 
         sql = render_template(
             template_path,
-            project_id=release.ao_gcp_project_id,
-            dataset_id=release.oapen_metadata_dataset_id,
-            table_id=release.oapen_metadata_table_id,
+            project_id=self.ao_gcp_project_id,
+            dataset_id=self.oapen_metadata_dataset_id,
+            table_id=self.oapen_metadata_table_id,
         )
 
         create_bigquery_dataset(project_id=project_id, dataset_id=output_dataset, location=data_location)
@@ -356,10 +347,10 @@ class OapenWorkflow(Workflow):
         """
 
         output_table = "book_product"
-        output_dataset = release.oaebu_dataset
+        output_dataset = self.oaebu_dataset
         project_id = release.gcp_project_id
 
-        data_location = release.dataset_location
+        data_location = self.dataset_location
         release_date = release.release_date
 
         table_joining_template_file = "create_book_products.sql.jinja2"
@@ -369,17 +360,17 @@ class OapenWorkflow(Workflow):
 
         # Identify latest Book release from the Academic Observatory
         public_book_release_date = select_table_shard_dates(
-            project_id=release.ao_gcp_project_id,
-            dataset_id=release.public_book_metadata_dataset_id,
-            table_id=release.public_book_metadata_table_id,
+            project_id=self.ao_gcp_project_id,
+            dataset_id=self.public_book_metadata_dataset_id,
+            table_id=self.public_book_metadata_table_id,
             end_date=release.release_date,
         )[0]
 
         sql = render_template(
             template_path,
             project_id=project_id,
-            onix_dataset_id=release.oaebu_onix_dataset,
-            dataset_id=release.oaebu_intermediate_dataset,
+            onix_dataset_id=self.oaebu_onix_dataset,
+            dataset_id=self.oaebu_intermediate_dataset,
             release_date=release_date,
             onix_release_date=release_date,
             google_analytics=False,
@@ -392,7 +383,7 @@ class OapenWorkflow(Workflow):
             google_analytics_dataset='',
             google_books_dataset='',
             jstor_dataset='',
-            oapen_dataset=release.irus_uk_dataset_id,
+            oapen_dataset=self.irus_uk_dataset_id,
             ucl_dataset='',
             public_book_release_date=public_book_release_date,
         )
@@ -426,8 +417,8 @@ class OapenWorkflow(Workflow):
         """
 
         project_id = release.gcp_project_id
-        output_dataset = release.oaebu_elastic_dataset
-        data_location = release.dataset_location
+        output_dataset = self.oaebu_elastic_dataset
+        data_location = self.dataset_location
         release_date = release.release_date
 
         create_bigquery_dataset(project_id=project_id, dataset_id=output_dataset, location=data_location)
@@ -438,7 +429,7 @@ class OapenWorkflow(Workflow):
         sql = render_template(
             template_path,
             project_id=project_id,
-            dataset_id=release.oaebu_dataset,
+            dataset_id=self.oaebu_dataset,
             release=release_date,
         )
 

--- a/oaebu_workflows/workflows/oapen_workflow.py
+++ b/oaebu_workflows/workflows/oapen_workflow.py
@@ -16,35 +16,26 @@
 # Author: Richard Hosking
 
 import os
-import shutil
 from functools import partial, update_wrapper
-from pathlib import Path
 from typing import List, Optional
 
 import pendulum
 from airflow.exceptions import AirflowException
 from airflow.models import Variable
 from airflow.sensors.external_task import ExternalTaskSensor
-from google.cloud.bigquery import SourceFormat
-from observatory.dags.config import sql_folder
+from oaebu_workflows.config import sql_folder
 
 from observatory.platform.workflows.workflow import AbstractRelease, Workflow
 from observatory.platform.utils.gc_utils import (
     bigquery_sharded_table_id,
     create_bigquery_dataset,
     create_bigquery_table_from_query,
-    run_bigquery_query,
     select_table_shard_dates,
     copy_bigquery_table
 )
 from observatory.platform.utils.jinja2_utils import render_template
 from observatory.platform.utils.airflow_utils import AirflowVars
-from observatory.platform.utils.workflow_utils import (
-    bq_load_shard_v2,
-    table_ids_from_path,
-    make_dag_id,
-)
-
+from observatory.platform.utils.workflow_utils import make_dag_id
 
 class OapenWorkflowRelease(AbstractRelease):
     """

--- a/oaebu_workflows/workflows/onix_workflow.py
+++ b/oaebu_workflows/workflows/onix_workflow.py
@@ -241,6 +241,9 @@ class OnixWorkflow(Workflow):
         org_name: str,
         gcp_project_id: str,
         gcp_bucket_name: str,
+        ao_gcp_project_id: str = "academic-observatory",
+        public_book_metadata_dataset_id: str = "observatory",
+        public_book_metadata_table_id: str = "book",
         onix_dataset_id: str = "onix",
         onix_table_id: str = "onix",
         schema_folder: str = default_schema_folder(),
@@ -277,6 +280,11 @@ class OnixWorkflow(Workflow):
         self.onix_dataset_id = onix_dataset_id
         self.onix_table_id = onix_table_id
         self.schema_folder = schema_folder
+
+        # Public Book Data
+        self.ao_gcp_project_id = ao_gcp_project_id
+        self.public_book_metadata_dataset_id = public_book_metadata_dataset_id
+        self.public_book_metadata_table_id = public_book_metadata_table_id
 
         # Initialise Telesecope base class
         super().__init__(

--- a/oaebu_workflows/workflows/onix_workflow.py
+++ b/oaebu_workflows/workflows/onix_workflow.py
@@ -609,6 +609,9 @@ class OnixWorkflow(Workflow):
         :param ucl_dataset: dataset_id if it is  a relevant data source for this publisher
         """
 
+        project_id = release.project_id
+        oaebu_intermediate_dataset = release.oaebu_intermediate_dataset
+
         output_table = "book_product"
         output_dataset = release.oaebu_dataset
 
@@ -628,6 +631,35 @@ class OnixWorkflow(Workflow):
             end_date=release.release_date,
         )[0]
 
+        if include_google_analytics:
+            google_analytics_table_id = f"{project_id}.{oaebu_intermediate_dataset}.{google_analytics_dataset}_google_analytics_matched{release_date}"
+        else:
+            google_analytics_table_id = "empty_google_analytics"
+
+        if include_google_books:
+            google_books_sales_table_id = f"{project_id}.{oaebu_intermediate_dataset}.{google_books_dataset}_google_books_sales_matched{release_date}"
+            google_books_traffic_table_id = f"{project_id}.{oaebu_intermediate_dataset}.{google_books_dataset}_google_books_traffic_matched{release_date}"
+        else:
+            google_books_sales_table_id = "empty_google_books_sales"
+            google_books_traffic_table_id = "empty_google_books_traffic"
+
+        if include_jstor:
+            jstor_country_table_id = f"{project_id}.{oaebu_intermediate_dataset}.{jstor_dataset}_jstor_country_matched{release_date}"
+            jstor_institution_table_id = f"{project_id}.{oaebu_intermediate_dataset}.{jstor_dataset}_jstor_institution_matched{release_date}"
+        else:
+            jstor_country_table_id = "empty_jstor_country"
+            jstor_institution_table_id = "empty_jstor_institution"
+
+        if include_oapen:
+            oapen_table_id = f"{project_id}.{oaebu_intermediate_dataset}.{oapen_dataset}_oapen_irus_uk_matched{release_date}"
+        else:
+            oapen_table_id = "empty_oapen"
+
+        if include_ucl:
+            ucl_table_id = f"{project_id}.{oaebu_intermediate_dataset}.{ucl_dataset}_ucl_discovery_matched{release_date}"
+        else:
+            ucl_table_id = "empty_ucl_discovery"
+
         sql = render_template(
             template_path,
             project_id=release.project_id,
@@ -635,18 +667,15 @@ class OnixWorkflow(Workflow):
             dataset_id=release.oaebu_intermediate_dataset,
             onix_release_date=release.onix_release_date,
             release_date=release_date,
-            google_analytics=include_google_analytics,
-            google_books=include_google_books,
-            jstor=include_jstor,
-            oapen=include_oapen,
-            ucl=include_ucl,
             onix_workflow=True,
             onix_workflow_dataset=release.workflow_dataset,
-            google_analytics_dataset=google_analytics_dataset,
-            google_books_dataset=google_books_dataset,
-            jstor_dataset=jstor_dataset,
-            oapen_dataset=oapen_dataset,
-            ucl_dataset=ucl_dataset,
+            google_analytics_table_id=google_analytics_table_id,
+            google_books_sales_table_id=google_books_sales_table_id,
+            google_books_traffic_table_id=google_books_traffic_table_id,
+            jstor_country_table_id=jstor_country_table_id,
+            jstor_institution_table_id=jstor_institution_table_id,
+            oapen_table_id=oapen_table_id,
+            ucl_table_id=ucl_table_id,
             public_book_release_date=public_book_release_date,
         )
 

--- a/oaebu_workflows/workflows/onix_workflow.py
+++ b/oaebu_workflows/workflows/onix_workflow.py
@@ -207,7 +207,10 @@ def make_table_id(*, project_id: str, dataset_id: str, table_id: str, end_date: 
     new_table_id = table_id
     if sharded:
         table_date = select_table_shard_dates(
-            project_id=project_id, dataset_id=dataset_id, table_id=table_id, end_date=end_date,
+            project_id=project_id,
+            dataset_id=dataset_id,
+            table_id=table_id,
+            end_date=end_date,
         )[0]
         new_table_id = f"{table_id}{table_date.strftime('%Y%m%d')}"
 
@@ -619,9 +622,9 @@ class OnixWorkflow(Workflow):
 
         # Identify latest Book release from the Academic Observatory
         public_book_release_date = select_table_shard_dates(
-            project_id='academic-observatory',
-            dataset_id='observatory',
-            table_id='book',
+            project_id="academic-observatory",
+            dataset_id="observatory",
+            table_id="book",
             end_date=release.release_date,
         )[0]
 
@@ -691,7 +694,12 @@ class OnixWorkflow(Workflow):
         self.add_task(fn)
 
     def export_oaebu_table(
-        self, release: OnixWorkflowRelease, *, output_table: str, query_template: str, **kwargs,
+        self,
+        release: OnixWorkflowRelease,
+        *,
+        output_table: str,
+        query_template: str,
+        **kwargs,
     ):
         """Create an intermediate oaebu table.  They are of the form datasource_matched<date>
         :param release: Onix workflow release information.
@@ -707,7 +715,10 @@ class OnixWorkflow(Workflow):
         template_path = os.path.join(sql_folder(), query_template)
 
         sql = render_template(
-            template_path, project_id=release.project_id, dataset_id=release.oaebu_dataset, release=release_date,
+            template_path,
+            project_id=release.project_id,
+            dataset_id=release.oaebu_dataset,
+            release=release_date,
         )
 
         status = create_bigquery_table_from_query(
@@ -976,7 +987,9 @@ class OnixWorkflow(Workflow):
         )
 
         create_bigquery_dataset(
-            project_id=release.project_id, dataset_id=release.oaebu_data_qa_dataset, location=release.dataset_location,
+            project_id=release.project_id,
+            dataset_id=release.oaebu_data_qa_dataset,
+            location=release.dataset_location,
         )
 
         # Fix
@@ -1048,13 +1061,19 @@ class OnixWorkflow(Workflow):
         template_path = os.path.join(sql_folder(), isbn_validate_template_file)
 
         sql = render_template(
-            template_path, project_id=project_id, dataset_id=orig_dataset_id, table_id=orig_table_id, isbn=isbn,
+            template_path,
+            project_id=project_id,
+            dataset_id=orig_dataset_id,
+            table_id=orig_table_id,
+            isbn=isbn,
         )
 
         sql = isbn_utils_sql + sql
 
         create_bigquery_dataset(
-            project_id=project_id, dataset_id=output_dataset_id, location=dataset_location,
+            project_id=project_id,
+            dataset_id=output_dataset_id,
+            location=dataset_location,
         )
 
         status = create_bigquery_table_from_query(
@@ -1464,7 +1483,9 @@ class OnixWorkflow(Workflow):
         )
 
         create_bigquery_dataset(
-            project_id=release.project_id, dataset_id=release.oaebu_data_qa_dataset, location=release.dataset_location,
+            project_id=release.project_id,
+            dataset_id=release.oaebu_data_qa_dataset,
+            location=release.dataset_location,
         )
 
         status = create_bigquery_table_from_query(

--- a/oaebu_workflows/workflows/onix_workflow.py
+++ b/oaebu_workflows/workflows/onix_workflow.py
@@ -624,12 +624,13 @@ class OnixWorkflow(Workflow):
         table_id = bigquery_sharded_table_id(output_table, release_date)
 
         # Identify latest Book release from the Academic Observatory
-        public_book_release_date = select_table_shard_dates(
-            project_id="academic-observatory",
-            dataset_id="observatory",
-            table_id="book",
+        public_book_table_id = make_table_id(
+            project_id=self.ao_gcp_project_id,
+            dataset_id=self.public_book_metadata_dataset_id,
+            table_id=self.public_book_metadata_table_id,
             end_date=release.release_date,
-        )[0]
+            sharded=True,
+        )
 
         if include_google_analytics:
             google_analytics_table_id = f"{project_id}.{oaebu_intermediate_dataset}.{google_analytics_dataset}_google_analytics_matched{release_date.strftime('%Y%m%d')}"
@@ -676,7 +677,7 @@ class OnixWorkflow(Workflow):
             jstor_institution_table_id=jstor_institution_table_id,
             oapen_table_id=oapen_table_id,
             ucl_table_id=ucl_table_id,
-            public_book_release_date=public_book_release_date,
+            public_book_tabel_id=public_book_table_id,
         )
 
         create_bigquery_dataset(project_id=release.project_id, dataset_id=output_dataset, location=data_location)

--- a/oaebu_workflows/workflows/onix_workflow.py
+++ b/oaebu_workflows/workflows/onix_workflow.py
@@ -632,31 +632,31 @@ class OnixWorkflow(Workflow):
         )[0]
 
         if include_google_analytics:
-            google_analytics_table_id = f"{project_id}.{oaebu_intermediate_dataset}.{google_analytics_dataset}_google_analytics_matched{release_date}"
+            google_analytics_table_id = f"{project_id}.{oaebu_intermediate_dataset}.{google_analytics_dataset}_google_analytics_matched{release_date.strftime('%Y%m%d')}"
         else:
             google_analytics_table_id = "empty_google_analytics"
 
         if include_google_books:
-            google_books_sales_table_id = f"{project_id}.{oaebu_intermediate_dataset}.{google_books_dataset}_google_books_sales_matched{release_date}"
-            google_books_traffic_table_id = f"{project_id}.{oaebu_intermediate_dataset}.{google_books_dataset}_google_books_traffic_matched{release_date}"
+            google_books_sales_table_id = f"{project_id}.{oaebu_intermediate_dataset}.{google_books_dataset}_google_books_sales_matched{release_date.strftime('%Y%m%d')}"
+            google_books_traffic_table_id = f"{project_id}.{oaebu_intermediate_dataset}.{google_books_dataset}_google_books_traffic_matched{release_date.strftime('%Y%m%d')}"
         else:
             google_books_sales_table_id = "empty_google_books_sales"
             google_books_traffic_table_id = "empty_google_books_traffic"
 
         if include_jstor:
-            jstor_country_table_id = f"{project_id}.{oaebu_intermediate_dataset}.{jstor_dataset}_jstor_country_matched{release_date}"
-            jstor_institution_table_id = f"{project_id}.{oaebu_intermediate_dataset}.{jstor_dataset}_jstor_institution_matched{release_date}"
+            jstor_country_table_id = f"{project_id}.{oaebu_intermediate_dataset}.{jstor_dataset}_jstor_country_matched{release_date.strftime('%Y%m%d')}"
+            jstor_institution_table_id = f"{project_id}.{oaebu_intermediate_dataset}.{jstor_dataset}_jstor_institution_matched{release_date.strftime('%Y%m%d')}"
         else:
             jstor_country_table_id = "empty_jstor_country"
             jstor_institution_table_id = "empty_jstor_institution"
 
         if include_oapen:
-            oapen_table_id = f"{project_id}.{oaebu_intermediate_dataset}.{oapen_dataset}_oapen_irus_uk_matched{release_date}"
+            oapen_table_id = f"{project_id}.{oaebu_intermediate_dataset}.{oapen_dataset}_oapen_irus_uk_matched{release_date.strftime('%Y%m%d')}"
         else:
             oapen_table_id = "empty_oapen"
 
         if include_ucl:
-            ucl_table_id = f"{project_id}.{oaebu_intermediate_dataset}.{ucl_dataset}_ucl_discovery_matched{release_date}"
+            ucl_table_id = f"{project_id}.{oaebu_intermediate_dataset}.{ucl_dataset}_ucl_discovery_matched{release_date.strftime('%Y%m%d')}"
         else:
             ucl_table_id = "empty_ucl_discovery"
 

--- a/oaebu_workflows/workflows/onix_workflow.py
+++ b/oaebu_workflows/workflows/onix_workflow.py
@@ -685,7 +685,7 @@ class OnixWorkflow(Workflow):
             jstor_institution_table_id=jstor_institution_table_id,
             oapen_table_id=oapen_table_id,
             ucl_table_id=ucl_table_id,
-            public_book_tabel_id=public_book_table_id,
+            public_book_tabel_id=f"{self.ao_gcp_project_id}.{self.public_book_metadata_dataset_id}.{public_book_table_id}",
         )
 
         create_bigquery_dataset(project_id=release.project_id, dataset_id=output_dataset, location=data_location)

--- a/oaebu_workflows/workflows/tests/test_oapen_workflow.py
+++ b/oaebu_workflows/workflows/tests/test_oapen_workflow.py
@@ -199,6 +199,10 @@ class TestOapenWorkflowFunctional(ObservatoryTestCase):
                 )
                 self.assertEqual(expected_state, ti.state)
 
+                # Check dependencies
+                ti = env.run_task("check_dependencies", workflow_dag, execution_date=execution_date)
+                self.assertEqual(expected_state, ti.state)
+
                 # Mock make_release
                 workflow.make_release = MagicMock(
                     return_value=OapenWorkflowRelease(

--- a/oaebu_workflows/workflows/tests/test_oapen_workflow.py
+++ b/oaebu_workflows/workflows/tests/test_oapen_workflow.py
@@ -52,8 +52,8 @@ class TestOapenWorkflow(ObservatoryTestCase):
         self.oapen_metadata_table_id = "metadata"
 
 
-    @patch("observatory.dags.workflows.oapen_workflow.OapenWorkflow.make_release")
-    @patch("observatory.dags.workflows.oapen_workflow.select_table_shard_dates")
+    @patch("oaebu_workflows.workflows.oapen_workflow.OapenWorkflow.make_release")
+    @patch("oaebu_workflows.workflows.oapen_workflow.select_table_shard_dates")
     def test_cleanup(self, mock_sel_table_suffixes, mock_mr):
         mock_sel_table_suffixes.return_value = [pendulum.datetime(2021, 1, 1)]
         with CliRunner().isolated_filesystem():

--- a/oaebu_workflows/workflows/tests/test_oapen_workflow.py
+++ b/oaebu_workflows/workflows/tests/test_oapen_workflow.py
@@ -77,7 +77,8 @@ class TestOapenWorkflow(ObservatoryTestCase):
             dag = wf.make_dag()
             self.assert_dag_structure(
                 {
-                    "oapen_irus_uk_oapen_sensor": ["create_onix_formatted_metadata_output_tasks"],
+                    "oapen_irus_uk_oapen_sensor": ["check_dependencies"],
+                    "check_dependencies": ["create_onix_formatted_metadata_output_tasks"],
                     "create_onix_formatted_metadata_output_tasks": ["copy_irus_uk_release"],
                     "copy_irus_uk_release": ["create_oaebu_book_product_table"],
                     "create_oaebu_book_product_table": ["export_oaebu_table.book_product_list"],
@@ -132,7 +133,7 @@ class TestOapenWorkflowFunctional(ObservatoryTestCase):
         self.public_book_metadata_dataset_id = "observatory"
         self.public_book_metadata_table_id = "book"
 
-        self.org_name = "OAPEN"
+        self.org_name = OapenWorkflow.ORG_NAME
         self.gcp_project_id = os.getenv("TEST_GCP_PROJECT_ID")
 
         self.gcp_dataset_id = "oaebu"

--- a/oaebu_workflows/workflows/tests/test_oapen_workflow.py
+++ b/oaebu_workflows/workflows/tests/test_oapen_workflow.py
@@ -164,6 +164,7 @@ class TestOapenWorkflowFunctional(ObservatoryTestCase):
                         oaebu_dataset=oaebu_output_dataset_id,
                         oaebu_intermediate_dataset=oaebu_intermediate_dataset_id,
                         oaebu_elastic_dataset=oaebu_elastic_dataset_id,
+                        irus_uk_dataset_id=self.irus_uk_dataset_id,
                         start_date=start_date)
 
             # Make DAG

--- a/oaebu_workflows/workflows/tests/test_oapen_workflow.py
+++ b/oaebu_workflows/workflows/tests/test_oapen_workflow.py
@@ -201,7 +201,6 @@ class TestOapenWorkflowFunctional(ObservatoryTestCase):
                 ti = env.run_task("dummy_task", dag, execution_date=execution_date)
                 self.assertEqual(expected_state, ti.state)
 
-
             # Run end to end tests for the DAG
             with env.create_dag_run(workflow_dag, execution_date):
                 # Test that sensors go into 'success' state as the DAGs that they are waiting for have finished

--- a/oaebu_workflows/workflows/tests/test_oapen_workflow.py
+++ b/oaebu_workflows/workflows/tests/test_oapen_workflow.py
@@ -74,8 +74,7 @@ class TestOapenWorkflow(ObservatoryTestCase):
                     "oapen_irus_uk_oapen_press_sensor": ["check_dependencies"],
                     "oapen_metadata_sensor": ["check_dependencies"],
                     "check_dependencies": ["create_onix_formatted_metadata_output_tasks"],
-                    "create_onix_formatted_metadata_output_tasks": ["copy_irus_uk_release"],
-                    "copy_irus_uk_release": ["create_oaebu_book_product_table"],
+                    "create_onix_formatted_metadata_output_tasks": ["create_oaebu_book_product_table"],
                     "create_oaebu_book_product_table": ["export_oaebu_table.book_product_list"],
                     "export_oaebu_table.book_product_list": ["export_oaebu_table.book_product_metrics"],
                     "export_oaebu_table.book_product_metrics": ["export_oaebu_table.book_product_metrics_country"],
@@ -235,14 +234,6 @@ class TestOapenWorkflowFunctional(ObservatoryTestCase):
                 # Format OAPEN Metadata like ONIX to enable the next steps
                 ti = env.run_task(
                     workflow.create_onix_formatted_metadata_output_tasks.__name__,
-                    workflow_dag,
-                    execution_date,
-                )
-                self.assertEqual(expected_state, ti.state)
-
-                # Copy IRUS-UK data and add release date
-                ti = env.run_task(
-                    workflow.copy_irus_uk_release.__name__,
                     workflow_dag,
                     execution_date,
                 )

--- a/oaebu_workflows/workflows/tests/test_oapen_workflow.py
+++ b/oaebu_workflows/workflows/tests/test_oapen_workflow.py
@@ -21,7 +21,7 @@ from unittest.mock import MagicMock, patch
 import pendulum
 from click.testing import CliRunner
 
-from observatory.dags.workflows.oapen_workflow import OapenWorkflow, OapenWorkflowRelease
+from oaebu_workflows.workflows.oapen_workflow import OapenWorkflow, OapenWorkflowRelease
 
 from observatory.platform.utils.gc_utils import (
     run_bigquery_query,

--- a/oaebu_workflows/workflows/tests/test_oapen_workflow.py
+++ b/oaebu_workflows/workflows/tests/test_oapen_workflow.py
@@ -71,7 +71,7 @@ class TestOapenWorkflow(ObservatoryTestCase):
             dag = wf.make_dag()
             self.assert_dag_structure(
                 {
-                    "oapen_irus_uk_oapen_sensor": ["check_dependencies"],
+                    "oapen_irus_uk_oapen_press_sensor": ["check_dependencies"],
                     "oapen_metadata_sensor": ["check_dependencies"],
                     "check_dependencies": ["create_onix_formatted_metadata_output_tasks"],
                     "create_onix_formatted_metadata_output_tasks": ["copy_irus_uk_release"],

--- a/oaebu_workflows/workflows/tests/test_oapen_workflow.py
+++ b/oaebu_workflows/workflows/tests/test_oapen_workflow.py
@@ -48,8 +48,7 @@ class TestOapenWorkflow(ObservatoryTestCase):
 
         # Release Object Defaults for reference
         self.ao_gcp_project_id = "academic-observatory"
-        self.oapen_metadata_dataset_id = "oapen"
-        self.oapen_metadata_table_id = "metadata"
+
 
 
     @patch("oaebu_workflows.workflows.oapen_workflow.OapenWorkflow.make_release")
@@ -60,11 +59,8 @@ class TestOapenWorkflow(ObservatoryTestCase):
             wf = OapenWorkflow()
 
             mock_mr.return_value = OapenWorkflowRelease(
-                dag_id="oapen_workflow_test",
                 release_date=pendulum.datetime(2021, 1, 1),
                 gcp_project_id=self.gcp_project_id,
-                oapen_metadata_dataset_id=self.oapen_metadata_dataset_id,
-                oapen_metadata_table_id=self.oapen_metadata_table_id,
             )
 
             release = wf.make_release(execution_date=pendulum.datetime(2021, 1, 1))
@@ -151,7 +147,6 @@ class TestOapenWorkflowFunctional(ObservatoryTestCase):
         org_name = self.org_name
 
         # Create datasets
-        partner_release_date = pendulum.datetime(2021, 1, 1)
         oaebu_intermediate_dataset_id = env.add_dataset(prefix="oaebu_intermediate")
         oaebu_output_dataset_id = env.add_dataset(prefix="oaebu")
         oaebu_onix_dataset_id = env.add_dataset(prefix="oaebu_onix_dataset")
@@ -162,12 +157,14 @@ class TestOapenWorkflowFunctional(ObservatoryTestCase):
         with env.create(task_logging=True):
             self.gcp_bucket_name = env.transform_bucket
 
-            # Pull info from Observatory API
-            gcp_project_id = (self.gcp_project_id,)
-
             # Setup workflow
             start_date = pendulum.datetime(year=2021, month=5, day=9)
-            workflow = OapenWorkflow(start_date=start_date)
+            workflow = OapenWorkflow(
+                        oaebu_onix_dataset=oaebu_onix_dataset_id,
+                        oaebu_dataset=oaebu_output_dataset_id,
+                        oaebu_intermediate_dataset=oaebu_intermediate_dataset_id,
+                        oaebu_elastic_dataset=oaebu_elastic_dataset_id,
+                        start_date=start_date)
 
             # Make DAG
             workflow_dag = workflow.make_dag()
@@ -206,14 +203,8 @@ class TestOapenWorkflowFunctional(ObservatoryTestCase):
                 # Mock make_release
                 workflow.make_release = MagicMock(
                     return_value=OapenWorkflowRelease(
-                        dag_id=make_dag_id(self.irus_uk_dag_id_prefix, org_name),
                         release_date=release_date,
                         gcp_project_id=self.gcp_project_id,
-                        oaebu_onix_dataset=oaebu_onix_dataset_id,
-                        oaebu_dataset=oaebu_output_dataset_id,
-                        oaebu_intermediate_dataset=oaebu_intermediate_dataset_id,
-                        oaebu_elastic_dataset=oaebu_elastic_dataset_id,
-                        irus_uk_dataset_id=self.irus_uk_dataset_id,
                     )
                 )
 

--- a/oaebu_workflows/workflows/tests/test_oapen_workflow.py
+++ b/oaebu_workflows/workflows/tests/test_oapen_workflow.py
@@ -1,0 +1,290 @@
+# Copyright 2020 Curtin University
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Author: Richard Hosking
+
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pendulum
+from click.testing import CliRunner
+
+from observatory.dags.workflows.oapen_workflow import OapenWorkflow, OapenWorkflowRelease
+
+from observatory.platform.utils.gc_utils import (
+    run_bigquery_query,
+)
+from observatory.platform.utils.workflow_utils import make_dag_id
+from observatory.platform.utils.test_utils import (
+    ObservatoryEnvironment,
+    ObservatoryTestCase,
+    make_dummy_dag,
+)
+
+
+class TestOapenWorkflow(ObservatoryTestCase):
+    """
+    Test the OapenWorkflow class.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.org_name = "OAPEN"
+        self.gcp_project_id = "project_id"
+        self.data_location = os.getenv("TESTS_DATA_LOCATION")
+
+        # Release Object Defaults for reference
+        self.ao_gcp_project_id = "academic-observatory"
+        self.oapen_metadata_dataset_id = "oapen"
+        self.oapen_metadata_table_id = "metadata"
+
+
+    @patch("observatory.dags.workflows.oapen_workflow.OapenWorkflow.make_release")
+    @patch("observatory.dags.workflows.oapen_workflow.select_table_shard_dates")
+    def test_cleanup(self, mock_sel_table_suffixes, mock_mr):
+        mock_sel_table_suffixes.return_value = [pendulum.datetime(2021, 1, 1)]
+        with CliRunner().isolated_filesystem():
+            wf = OapenWorkflow()
+
+            mock_mr.return_value = OapenWorkflowRelease(
+                dag_id="oapen_workflow_test",
+                release_date=pendulum.datetime(2021, 1, 1),
+                gcp_project_id=self.gcp_project_id,
+                oapen_metadata_dataset_id=self.oapen_metadata_dataset_id,
+                oapen_metadata_table_id=self.oapen_metadata_table_id,
+            )
+
+            release = wf.make_release(execution_date=pendulum.datetime(2021, 1, 1))
+            wf.cleanup(release)
+
+    def test_dag_structure(self):
+
+        with CliRunner().isolated_filesystem():
+            wf = OapenWorkflow()
+            dag = wf.make_dag()
+            self.assert_dag_structure(
+                {
+                    "oapen_irus_uk_oapen_sensor": ["create_onix_formatted_metadata_output_tasks"],
+                    "create_onix_formatted_metadata_output_tasks": ["copy_irus_uk_release"],
+                    "copy_irus_uk_release": ["create_oaebu_book_product_table"],
+                    "create_oaebu_book_product_table": ["export_oaebu_table.book_product_list"],
+                    "export_oaebu_table.book_product_list": ["export_oaebu_table.book_product_metrics"],
+                    "export_oaebu_table.book_product_metrics": ["export_oaebu_table.book_product_metrics_country"],
+                    "export_oaebu_table.book_product_metrics_country": [
+                        "export_oaebu_table.book_product_metrics_institution"
+                    ],
+                    "export_oaebu_table.book_product_metrics_institution": [
+                        "export_oaebu_table.book_product_metrics_city"
+                    ],
+                    "export_oaebu_table.book_product_metrics_city": [
+                        "export_oaebu_table.book_product_metrics_referrer"
+                    ],
+                    "export_oaebu_table.book_product_metrics_referrer": [
+                        "export_oaebu_table.book_product_metrics_events"
+                    ],
+                    "export_oaebu_table.book_product_metrics_events": [
+                        "export_oaebu_table.book_product_publisher_metrics"
+                    ],
+                    "export_oaebu_table.book_product_publisher_metrics": [
+                        "export_oaebu_table.book_product_subject_metrics"
+                    ],
+                    "export_oaebu_table.book_product_subject_metrics": ["export_oaebu_table.book_product_year_metrics"],
+                    "export_oaebu_table.book_product_year_metrics": [
+                        "export_oaebu_table.book_product_subject_year_metrics"
+                    ],
+                    "export_oaebu_table.book_product_subject_year_metrics": [
+                        "export_oaebu_table.book_product_author_metrics"
+                    ],
+                    "export_oaebu_table.book_product_author_metrics": ["cleanup"],
+                    "cleanup": [],
+                },
+                dag,
+            )
+
+
+class TestOapenWorkflowFunctional(ObservatoryTestCase):
+    """Functionally test the workflow. """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.timestamp = pendulum.now()
+        self.oapen_table_id = "oapen"
+
+        self.data_location = os.getenv("TEST_GCP_DATA_LOCATION")
+
+        self.ao_gcp_project_id = "academic-observatory"
+        self.oapen_metadata_dataset_id = "oapen"
+        self.oapen_metadata_table_id = "metadata"
+        self.public_book_metadata_dataset_id = "observatory"
+        self.public_book_metadata_table_id = "book"
+
+        self.org_name = "OAPEN"
+        self.gcp_project_id = os.getenv("TEST_GCP_PROJECT_ID")
+
+        self.gcp_dataset_id = "oaebu"
+        self.irus_uk_dag_id_prefix = "oapen_irus_uk"
+        self.irus_uk_table_id = "oapen_irus_uk"
+
+        self.irus_uk_dataset_id = "fixtures"
+
+
+    def test_run_workflow_tests(self):
+        """Functional test of the OAPEN workflow"""
+
+        # Setup Observatory environment
+        env = ObservatoryEnvironment(self.gcp_project_id, self.data_location, enable_api=False)
+        org_name = self.org_name
+
+        # Create datasets
+        partner_release_date = pendulum.datetime(2021, 1, 1)
+        oaebu_intermediate_dataset_id = env.add_dataset(prefix="oaebu_intermediate")
+        oaebu_output_dataset_id = env.add_dataset(prefix="oaebu")
+        oaebu_onix_dataset_id = env.add_dataset(prefix="oaebu_onix_dataset")
+        oaebu_elastic_dataset_id = env.add_dataset(prefix="data_export")
+
+
+        # Create the Observatory environment and run tests
+        with env.create(task_logging=True):
+            self.gcp_bucket_name = env.transform_bucket
+
+            # Pull info from Observatory API
+            gcp_project_id = (self.gcp_project_id,)
+
+            # Setup workflow
+            start_date = pendulum.datetime(year=2021, month=5, day=9)
+            workflow = OapenWorkflow(start_date=start_date)
+
+            # Make DAG
+            workflow_dag = workflow.make_dag()
+
+            # Test that sensors go into the 'up_for_reschedule' state as the DAGs that they wait for haven't run
+            expected_state = "up_for_reschedule"
+            with env.create_dag_run(workflow_dag, start_date):
+                ti = env.run_task(
+                    f"{make_dag_id(self.irus_uk_dag_id_prefix, org_name)}_sensor", workflow_dag, execution_date=start_date
+                )
+                self.assertEqual(expected_state, ti.state)
+
+            # Run Dummy Dags
+            expected_state = "success"
+            execution_date = pendulum.datetime(year=2021, month=5, day=16)
+            release_date = pendulum.datetime(year=2021, month=5, day=22)
+
+            dag = make_dummy_dag(make_dag_id(self.irus_uk_dag_id_prefix, org_name), execution_date)
+            with env.create_dag_run(dag, execution_date):
+                # Running all of a DAGs tasks sets the DAG to finished
+                ti = env.run_task("dummy_task", dag, execution_date=execution_date)
+                self.assertEqual(expected_state, ti.state)
+
+            # Run end to end tests for the DAG
+            with env.create_dag_run(workflow_dag, execution_date):
+                # Test that sensors go into 'success' state as the DAGs that they are waiting for have finished
+                ti = env.run_task(
+                    f"{make_dag_id(self.irus_uk_dag_id_prefix, org_name)}_sensor", workflow_dag, execution_date=execution_date
+                )
+                self.assertEqual(expected_state, ti.state)
+
+                # Mock make_release
+                workflow.make_release = MagicMock(
+                    return_value=OapenWorkflowRelease(
+                        dag_id=make_dag_id(self.irus_uk_dag_id_prefix, org_name),
+                        release_date=release_date,
+                        gcp_project_id=self.gcp_project_id,
+                        oaebu_onix_dataset=oaebu_onix_dataset_id,
+                        oaebu_dataset=oaebu_output_dataset_id,
+                        oaebu_intermediate_dataset=oaebu_intermediate_dataset_id,
+                        oaebu_elastic_dataset=oaebu_elastic_dataset_id,
+                        irus_uk_dataset_id=self.irus_uk_dataset_id,
+                    )
+                )
+
+                # Format OAPEN Metadata like ONIX to enable the next steps
+                ti = env.run_task(
+                    workflow.create_onix_formatted_metadata_output_tasks.__name__,
+                    workflow_dag,
+                    execution_date,
+                )
+                self.assertEqual(expected_state, ti.state)
+
+                # Copy IRUS-UK data and add release date
+                ti = env.run_task(
+                    workflow.copy_irus_uk_release.__name__,
+                    workflow_dag,
+                    execution_date,
+                )
+                self.assertEqual(expected_state, ti.state)
+
+                # Create oaebu output tables
+                ti = env.run_task(
+                    workflow.create_oaebu_book_product_table.__name__,
+                    workflow_dag,
+                    execution_date,
+                )
+                self.assertEqual(expected_state, ti.state)
+
+                # Export oaebu elastic tables
+                export_tables = [
+                    "book_product_list",
+                    "book_product_metrics",
+                    "book_product_metrics_country",
+                    "book_product_metrics_institution",
+                    "book_product_metrics_city",
+                    "book_product_metrics_referrer",
+                    "book_product_metrics_events",
+                    "book_product_publisher_metrics",
+                    "book_product_subject_metrics",
+                    "book_product_year_metrics",
+                    "book_product_subject_year_metrics",
+                    "book_product_author_metrics",
+                ]
+
+                for table in export_tables:
+                    ti = env.run_task(
+                        f"{workflow.export_oaebu_table.__name__}.{table}",
+                        workflow_dag,
+                        execution_date,
+                    )
+                    self.assertEqual(expected_state, ti.state)
+
+
+                # Test conditions
+                release_suffix = release_date.strftime("%Y%m%d")
+
+                # Check records in book_product and book_product_list match
+                sql = f"SELECT COUNT(*) from {self.gcp_project_id}.{oaebu_output_dataset_id}.book_product{release_suffix}"
+                records = run_bigquery_query(sql)
+                count_book_product = len(records)
+
+                sql = f"SELECT COUNT(*) from {self.gcp_project_id}.{oaebu_elastic_dataset_id}.{self.gcp_project_id.replace('-', '_')}_book_product_list{release_suffix}"
+                records = run_bigquery_query(sql)
+                count_book_product_list = len(records)
+
+                self.assertEqual(count_book_product, count_book_product_list)
+
+                # Ensure there are no duplicates
+                sql = f"""  SELECT
+                                count
+                            FROM(SELECT 
+                                COUNT(*) as count
+                                FROM {self.gcp_project_id}.{oaebu_elastic_dataset_id}.{self.gcp_project_id.replace('-', '_')}_book_product_metrics{release_suffix} 
+                                GROUP BY product_id, month)
+                            WHERE count > 1"""
+                records = run_bigquery_query(sql)
+                self.assertEqual(len(records), 0)
+
+                # Cleanup
+                env.run_task(workflow.cleanup.__name__, workflow_dag, execution_date)

--- a/oaebu_workflows/workflows/tests/test_onix_workflow.py
+++ b/oaebu_workflows/workflows/tests/test_onix_workflow.py
@@ -394,6 +394,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
                 gcp_dataset_id="dataset",
                 gcp_table_id="jstor_country",
                 isbn_field_name="isbn",
+                title_field_name="Book_Title",
                 sharded=False,
             ),
             OaebuPartners(
@@ -403,6 +404,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
                 gcp_dataset_id="dataset",
                 gcp_table_id="oapen_irus_uk",
                 isbn_field_name="ISBN",
+                title_field_name="book_title",
                 sharded=False,
             ),
             OaebuPartners(
@@ -412,6 +414,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
                 gcp_dataset_id="dataset",
                 gcp_table_id="google_books_sales",
                 isbn_field_name="Primary_ISBN",
+                title_field_name="Title",
                 sharded=False,
             ),
             OaebuPartners(
@@ -421,6 +424,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
                 gcp_dataset_id="dataset",
                 gcp_table_id="google_books_traffic",
                 isbn_field_name="Primary_ISBN",
+                title_field_name="Title",
                 sharded=False,
             ),
         ]
@@ -524,6 +528,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
                 gcp_dataset_id="dataset",
                 gcp_table_id="jstor_country",
                 isbn_field_name="isbn",
+                title_field_name="Book_Title",
                 sharded=False,
             ),
             OaebuPartners(
@@ -533,6 +538,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
                 gcp_dataset_id="dataset",
                 gcp_table_id="oapen_irus_uk",
                 isbn_field_name="ISBN",
+                title_field_name="book_title",
                 sharded=False,
             ),
             OaebuPartners(
@@ -542,6 +548,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
                 gcp_dataset_id="dataset",
                 gcp_table_id="google_books_sales",
                 isbn_field_name="Primary_ISBN",
+                title_field_name="Title",
                 sharded=False,
             ),
             OaebuPartners(
@@ -551,6 +558,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
                 gcp_dataset_id="dataset",
                 gcp_table_id="google_books_traffic",
                 isbn_field_name="Primary_ISBN",
+                title_field_name="Title",
                 sharded=False,
             ),
             OaebuPartners(
@@ -560,6 +568,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
                 gcp_dataset_id="dataset",
                 gcp_table_id="google_analytics",
                 isbn_field_name="publication_id",
+                title_field_name="title",
                 sharded=False,
             ),
         ]
@@ -884,6 +893,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
                 gcp_dataset_id="test_dataset",
                 gcp_table_id="test_table",
                 isbn_field_name="isbn",
+                title_field_name="title",
                 sharded=True,
             ),
             OaebuPartners(
@@ -893,6 +903,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
                 gcp_dataset_id="test_dataset",
                 gcp_table_id="test_table2",
                 isbn_field_name="isbn",
+                title_field_name="title",
                 sharded=True,
             ),
         ]
@@ -1078,6 +1089,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
                 gcp_dataset_id="jstor",
                 gcp_table_id="country",
                 isbn_field_name="ISBN",
+                title_field_name="Book_Title",
                 sharded=False,
             )
         ]
@@ -1151,6 +1163,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
                 gcp_dataset_id="google_books",
                 gcp_table_id="sales",
                 isbn_field_name="Primary_ISBN",
+                title_field_name="Title",
                 sharded=False,
             )
         ]
@@ -1224,6 +1237,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
                 gcp_dataset_id="google_books",
                 gcp_table_id="traffic",
                 isbn_field_name="Primary_ISBN",
+                title_field_name="Title",
                 sharded=False,
             )
         ]
@@ -1295,6 +1309,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
                 gcp_dataset_id="irus_uk",
                 gcp_table_id="oapen_irus_uk",
                 isbn_field_name="ISBN",
+                title_field_name="book_title",
                 sharded=False,
             )
         ]
@@ -1366,6 +1381,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
                 gcp_dataset_id="google",
                 gcp_table_id="google_analytics",
                 isbn_field_name="publication_id",
+                title_field_name="book_title",
                 sharded=False,
             )
         ]
@@ -1439,6 +1455,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
                 gcp_dataset_id="jstor",
                 gcp_table_id="country",
                 isbn_field_name="ISBN",
+                title_field_name="Book_Title",
                 sharded=False,
             )
         ]
@@ -1464,6 +1481,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
                 orig_dataset_id="jstor",
                 orig_table="country",
                 orig_isbn="isbn",
+                orig_title="Book_Title",
             )
 
             _, call_args = mock_bq_ds.call_args
@@ -1476,7 +1494,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
 
             sql_hash = hashlib.md5(call_args["sql"].encode("utf-8"))
             sql_hash = sql_hash.hexdigest()
-            expected_hash = "bca797c0edc0fe8cc30e263a3fb37ee6"
+            expected_hash = "71bc329dd609017504e91bc8fd8931fe"
             self.assertEqual(sql_hash, expected_hash)
 
             mock_bq_table_query.return_value = False
@@ -1496,6 +1514,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
                 orig_dataset_id="jstor",
                 orig_table="country",
                 orig_isbn="isbn",
+                orig_title="Book_Title",
             )
 
 
@@ -1621,14 +1640,14 @@ class TestOnixWorkflowFunctional(ObservatoryTestCase):
 
         # Make partners
         partners = []
-        for (name, isbn_field_name, dag_id_prefix), table_id in zip(
+        for (name, isbn_field_name, title_field_name, dag_id_prefix), table_id in zip(
             [
-                (OaebuPartnerName.jstor_country, "ISBN", "jstor"),
-                (OaebuPartnerName.jstor_institution, "ISBN", "jstor"),
-                (OaebuPartnerName.google_books_sales, "Primary_ISBN", "google_books"),
-                (OaebuPartnerName.google_books_traffic, "Primary_ISBN", "google_books"),
-                (OaebuPartnerName.oapen_irus_uk, "ISBN", "oapen_irus_uk"),
-                (OaebuPartnerName.google_analytics, "publication_id", "google_analytics"),
+                (OaebuPartnerName.jstor_country, "ISBN", "Book_Title", "jstor"),
+                (OaebuPartnerName.jstor_institution, "ISBN", "Book_Title", "jstor"),
+                (OaebuPartnerName.google_books_sales, "Primary_ISBN", "Title", "google_books"),
+                (OaebuPartnerName.google_books_traffic, "Primary_ISBN", "Title", "google_books"),
+                (OaebuPartnerName.oapen_irus_uk, "ISBN", "book_title", "oapen_irus_uk"),
+                (OaebuPartnerName.google_analytics, "publication_id", "title", "google_analytics"),
             ],
             table_ids,
         ):
@@ -1640,6 +1659,7 @@ class TestOnixWorkflowFunctional(ObservatoryTestCase):
                     gcp_dataset_id=self.fake_partner_dataset,
                     gcp_table_id=table_id,
                     isbn_field_name=isbn_field_name,
+                    title_field_name=title_field_name,
                     sharded=False,
                 )
             )

--- a/oaebu_workflows/workflows/tests/test_onix_workflow.py
+++ b/oaebu_workflows/workflows/tests/test_onix_workflow.py
@@ -110,21 +110,29 @@ class TestOnixWorkflow(ObservatoryTestCase):
             "RelatedWorks": [
                 {
                     "WorkRelationCode": "Manifestation of",
-                    "WorkIdentifiers": [{"WorkIDType": "ISBN-13", "IDValue": "112"},],
+                    "WorkIdentifiers": [
+                        {"WorkIDType": "ISBN-13", "IDValue": "112"},
+                    ],
                 },
                 {
                     "WorkRelationCode": "Manifestation of",
-                    "WorkIdentifiers": [{"WorkIDType": "ISBN-13", "IDValue": "113"},],
+                    "WorkIdentifiers": [
+                        {"WorkIDType": "ISBN-13", "IDValue": "113"},
+                    ],
                 },
             ],
-            "RelatedProducts": [{"ProductRelationCodes": ["Replaces", "something random"], "ISBN13": "211"},],
+            "RelatedProducts": [
+                {"ProductRelationCodes": ["Replaces", "something random"], "ISBN13": "211"},
+            ],
         },
         {
             "ISBN13": "112",
             "RelatedWorks": [
                 {
                     "WorkRelationCode": "Manifestation of",
-                    "WorkIdentifiers": [{"WorkIDType": "ISBN-13", "IDValue": "112"},],
+                    "WorkIdentifiers": [
+                        {"WorkIDType": "ISBN-13", "IDValue": "112"},
+                    ],
                 },
             ],
             "RelatedProducts": [],
@@ -134,7 +142,9 @@ class TestOnixWorkflow(ObservatoryTestCase):
             "RelatedWorks": [
                 {
                     "WorkRelationCode": "Manifestation of",
-                    "WorkIdentifiers": [{"WorkIDType": "ISBN-13", "IDValue": "211"},],
+                    "WorkIdentifiers": [
+                        {"WorkIDType": "ISBN-13", "IDValue": "211"},
+                    ],
                 },
             ],
             "RelatedProducts": [],
@@ -143,7 +153,10 @@ class TestOnixWorkflow(ObservatoryTestCase):
 
     class MockTelescopeResponse:
         def __init__(self):
-            self.organisation = Organisation(name="test", gcp_project_id="project_id",)
+            self.organisation = Organisation(
+                name="test",
+                gcp_project_id="project_id",
+            )
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -1796,15 +1809,27 @@ class TestOnixWorkflowFunctional(ObservatoryTestCase):
                     self.assertEqual(expected_state, ti.state)
 
                 # Create oaebu output tables
-                ti = env.run_task(telescope.create_oaebu_book_product_table.__name__, workflow_dag, execution_date,)
+                ti = env.run_task(
+                    telescope.create_oaebu_book_product_table.__name__,
+                    workflow_dag,
+                    execution_date,
+                )
                 self.assertEqual(expected_state, ti.state)
 
                 # ONIX isbn check
-                ti = env.run_task(telescope.create_oaebu_data_qa_onix_isbn.__name__, workflow_dag, execution_date,)
+                ti = env.run_task(
+                    telescope.create_oaebu_data_qa_onix_isbn.__name__,
+                    workflow_dag,
+                    execution_date,
+                )
                 self.assertEqual(expected_state, ti.state)
 
                 # ONIX aggregate metrics
-                ti = env.run_task(telescope.create_oaebu_data_qa_onix_aggregate.__name__, workflow_dag, execution_date,)
+                ti = env.run_task(
+                    telescope.create_oaebu_data_qa_onix_aggregate.__name__,
+                    workflow_dag,
+                    execution_date,
+                )
                 self.assertEqual(expected_state, ti.state)
 
                 # JSTOR country isbn check
@@ -1841,7 +1866,9 @@ class TestOnixWorkflowFunctional(ObservatoryTestCase):
 
                 # Google Books Sales isbn check
                 ti = env.run_task(
-                    telescope.create_oaebu_data_qa_google_books_sales_isbn.__name__, workflow_dag, execution_date,
+                    telescope.create_oaebu_data_qa_google_books_sales_isbn.__name__,
+                    workflow_dag,
+                    execution_date,
                 )
                 self.assertEqual(expected_state, ti.state)
 
@@ -1855,7 +1882,9 @@ class TestOnixWorkflowFunctional(ObservatoryTestCase):
 
                 # Google Books Traffic isbn check
                 ti = env.run_task(
-                    telescope.create_oaebu_data_qa_google_books_traffic_isbn.__name__, workflow_dag, execution_date,
+                    telescope.create_oaebu_data_qa_google_books_traffic_isbn.__name__,
+                    workflow_dag,
+                    execution_date,
                 )
                 self.assertEqual(expected_state, ti.state)
 
@@ -1869,7 +1898,9 @@ class TestOnixWorkflowFunctional(ObservatoryTestCase):
 
                 # OAPEN IRUS UK isbn check
                 ti = env.run_task(
-                    telescope.create_oaebu_data_qa_oapen_irus_uk_isbn.__name__, workflow_dag, execution_date,
+                    telescope.create_oaebu_data_qa_oapen_irus_uk_isbn.__name__,
+                    workflow_dag,
+                    execution_date,
                 )
                 self.assertEqual(expected_state, ti.state)
 
@@ -1884,7 +1915,9 @@ class TestOnixWorkflowFunctional(ObservatoryTestCase):
                 if include_google_analytics:
                     # Google Analytics isbn check
                     env.run_task(
-                        telescope.create_oaebu_data_qa_google_analytics_isbn.__name__, workflow_dag, execution_date,
+                        telescope.create_oaebu_data_qa_google_analytics_isbn.__name__,
+                        workflow_dag,
+                        execution_date,
                     )
 
                     # Google Books Analytics unmatched isbns
@@ -1914,11 +1947,19 @@ class TestOnixWorkflowFunctional(ObservatoryTestCase):
                 ]
 
                 for table in export_tables:
-                    ti = env.run_task(f"{telescope.export_oaebu_table.__name__}.{table}", workflow_dag, execution_date,)
+                    ti = env.run_task(
+                        f"{telescope.export_oaebu_table.__name__}.{table}",
+                        workflow_dag,
+                        execution_date,
+                    )
                     self.assertEqual(expected_state, ti.state)
 
                 # Export oaebu elastic qa table
-                ti = env.run_task(telescope.export_oaebu_qa_metrics.__name__, workflow_dag, execution_date,)
+                ti = env.run_task(
+                    telescope.export_oaebu_qa_metrics.__name__,
+                    workflow_dag,
+                    execution_date,
+                )
                 self.assertEqual(expected_state, ti.state)
 
                 # Test conditions


### PR DESCRIPTION
Ported pull request from observatory-platform

Adds the new OAPEN workflow, which will combine the IRUS-UK, and public metrics with the OAPEN metadata. (MEL-217 + MEL-159)

It also adds a range of fixes across the OAEBU workflows:

- corrects matching for countries in google analytics (MEL-371)
- changes irus-uk to use the correct country field not city locations to stop over counting (MEL-391)
- adds UCL metrics for UCL press (MEL-212)
- deduplication of metrics from Google Analytics, IRUS-UK, Google Books, UCL Press and JSTOR (MEL-387, MEL-386, MEL-379)
- ensures that duplicate ONIX product records don't throw off the metrics (MEL-380, MEL-379)
- Adds work and work_family IDs to the exported tables (where it makes sense) (MEL-385)
- Adds titles to the unmatched ISBNs (MEL-384)