### PR TITLE
Remove usage of custom AirflowVariable class

### DIFF
--- a/oaebu_workflows/workflows/tests/test_google_books_telescope.py
+++ b/oaebu_workflows/workflows/tests/test_google_books_telescope.py
@@ -269,7 +269,7 @@ class TestGoogleBooksTelescope(ObservatoryTestCase):
                     env.run_task(telescope.cleanup.__name__, dag, execution_date)
                     self.assert_cleanup(download_folder, extract_folder, transform_folder)
 
-    @patch("observatory.platform.utils.workflow_utils.AirflowVariable.get")
+    @patch("observatory.platform.utils.workflow_utils.Variable.get")
     def test_transform(self, mock_variable_get):
         """Test sanity check in transform method when transaction date falls outside release month
 

--- a/oaebu_workflows/workflows/tests/test_oapen_irus_uk_telescope.py
+++ b/oaebu_workflows/workflows/tests/test_oapen_irus_uk_telescope.py
@@ -260,7 +260,7 @@ class TestOapenIrusUkTelescope(ObservatoryTestCase):
                 # Delete oapen bucket
                 env._delete_bucket(OapenIrusUkTelescope.OAPEN_BUCKET)
 
-    @patch("observatory.platform.utils.workflow_utils.AirflowVariable.get")
+    @patch("observatory.platform.utils.workflow_utils.Variable.get")
     @patch("oaebu_workflows.workflows.oapen_irus_uk_telescope.upload_source_code_to_bucket")
     @patch("oaebu_workflows.workflows.oapen_irus_uk_telescope.cloud_function_exists")
     @patch("oaebu_workflows.workflows.oapen_irus_uk_telescope.create_cloud_function")
@@ -350,7 +350,7 @@ class TestOapenIrusUkTelescope(ObservatoryTestCase):
             with self.assertRaises(AirflowException):
                 release.create_cloud_function(telescope.max_active_runs)
 
-    @patch("observatory.platform.utils.workflow_utils.AirflowVariable.get")
+    @patch("observatory.platform.utils.workflow_utils.Variable.get")
     @patch("oaebu_workflows.workflows.oapen_irus_uk_telescope.BaseHook.get_connection")
     @patch("oaebu_workflows.workflows.oapen_irus_uk_telescope.get_publisher_uuid")
     @patch("oaebu_workflows.workflows.oapen_irus_uk_telescope.call_cloud_function")
@@ -426,7 +426,7 @@ class TestOapenIrusUkTelescope(ObservatoryTestCase):
 
     @patch("oaebu_workflows.workflows.oapen_irus_uk_telescope.upload_file_to_cloud_storage")
     @patch("oaebu_workflows.workflows.oapen_irus_uk_telescope.create_cloud_storage_bucket")
-    @patch("observatory.platform.utils.workflow_utils.AirflowVariable.get")
+    @patch("observatory.platform.utils.workflow_utils.Variable.get")
     def test_upload_source_code_to_bucket(self, mock_variable_get, mock_create_bucket, mock_upload_to_bucket):
         """Test getting source code from oapen irus uk release and uploading to storage bucket.
         Test expected results both when md5 hashes match and when they don't.

--- a/oaebu_workflows/workflows/tests/test_oapen_metadata_telescope.py
+++ b/oaebu_workflows/workflows/tests/test_oapen_metadata_telescope.py
@@ -81,7 +81,7 @@ def side_effect(arg):
     return values[arg]
 
 
-@patch("observatory.platform.utils.workflow_utils.AirflowVariable.get")
+@patch("observatory.platform.utils.workflow_utils.Variable.get")
 class TestOapenMetadataTelescope(unittest.TestCase):
     """Tests for the functions used by the OapenMetadata telescope"""
 
@@ -110,7 +110,7 @@ class TestOapenMetadataTelescope(unittest.TestCase):
         self.transform_crc = "415144d7"
 
         # Create release instance that is used to test download/transform
-        with patch("observatory.platform.utils.workflow_utils.AirflowVariable.get") as mock_variable_get:
+        with patch("observatory.platform.utils.workflow_utils.Variable.get") as mock_variable_get:
             mock_variable_get.side_effect = side_effect
 
             self.release = OapenMetadataRelease(

--- a/oaebu_workflows/workflows/tests/test_ucl_discovery_telescope.py
+++ b/oaebu_workflows/workflows/tests/test_ucl_discovery_telescope.py
@@ -204,11 +204,11 @@ class TestUclDiscoveryTelescope(ObservatoryTestCase):
                 self.assert_cleanup(download_folder, extract_folder, transform_folder)
 
     @patch("oaebu_workflows.workflows.ucl_discovery_telescope.retry_session")
-    @patch("observatory.platform.utils.workflow_utils.AirflowVariable.get")
+    @patch("observatory.platform.utils.workflow_utils.Variable.get")
     def test_download(self, mock_variable_get, mock_retry_session):
         """Test download method of UCL Discovery release
 
-        :param mock_variable_get: Mock AirflowVariable get
+        :param mock_variable_get: Mock Variable get
         :param mock_retry_session: Mock retry_session
         :return: None.
         """


### PR DESCRIPTION
The custom AirflowVariable class has been removed in the observatory-platform, this PR updates usage of that custom class to Airflow's standard Variable class instead.