### PR TITLE
Remove 'expand=metadata' param to fix hanging request.

### DIFF
--- a/oaebu_workflows/workflows/oapen_irus_uk_telescope.py
+++ b/oaebu_workflows/workflows/oapen_irus_uk_telescope.py
@@ -222,7 +222,7 @@ class OapenIrusUkTelescope(OrganisationTelescope):
     # cloud function
     FUNCTION_MD5_HASH = "46b07fbc9e70756b3cc80cb9ab38934c"  # MD5 hash of the zipped source code
     FUNCTION_BLOB_NAME = "cloud_function_source_code.zip"  # blob name of zipped source code
-    OAPEN_API_URL = "https://library.oapen.org/rest/search?query=publisher.name:{publisher_name}&expand=metadata"
+    OAPEN_API_URL = "https://library.oapen.org/rest/search?query=publisher.name:{publisher_name}"
 
     def __init__(
         self,
@@ -379,8 +379,8 @@ def get_publisher_uuid(publisher_name: str) -> str:
     :return: The publisher UUID
     """
     url = OapenIrusUkTelescope.OAPEN_API_URL.format(publisher_name=publisher_name)
-    response = requests.get(url)
     logging.info(f"Getting publisher UUID for publisher: {publisher_name}, from: {url}")
+    response = requests.get(url)
     if response.status_code != 200:
         raise RuntimeError(
             f"Request to get publisher UUID unsuccessful, url: {url}, status code: {response.status_code}, "


### PR DESCRIPTION
When trying to get the publisher UUID based on a publishers name using the OAPEN rest api it would hang sometimes, probably for publishers with a lot of metadata.
The query would unnecessarily return metadata associated with the publisher, by removing the 'expand=metadata' param the request will not hang anymore while the UUID is still returned.