### PR TITLE
INF-166/airflow-2.2

### DIFF
--- a/oaebu_workflows/workflows/tests/test_google_analytics_telescope.py
+++ b/oaebu_workflows/workflows/tests/test_google_analytics_telescope.py
@@ -154,7 +154,7 @@ class TestGoogleAnalyticsTelescope(ObservatoryTestCase):
                 env.add_connection(conn)
 
                 # Test that all dependencies are specified: no error should be thrown
-                env.run_task(telescope.check_dependencies.__name__, dag, execution_date)
+                env.run_task(telescope.check_dependencies.__name__)
 
                 # Use release to check tasks
                 cron_schedule = dag.normalized_schedule_interval
@@ -163,7 +163,7 @@ class TestGoogleAnalyticsTelescope(ObservatoryTestCase):
                 release = GoogleAnalyticsRelease(telescope.dag_id, execution_date, end_date, organisation)
 
                 # Test download_transform task
-                env.run_task(telescope.download_transform.__name__, dag, execution_date)
+                env.run_task(telescope.download_transform.__name__)
                 self.assertEqual(1, len(release.transform_files))
                 for file in release.transform_files:
                     self.assertTrue(os.path.isfile(file))
@@ -231,12 +231,12 @@ class TestGoogleAnalyticsTelescope(ObservatoryTestCase):
                     self.assertEqual(frozenset(expected_list[2]), frozenset(actual_list[2]))
 
                 # Test that transformed file uploaded
-                env.run_task(telescope.upload_transformed.__name__, dag, execution_date)
+                env.run_task(telescope.upload_transformed.__name__)
                 for file in release.transform_files:
                     self.assert_blob_integrity(env.transform_bucket, blob_name(file), file)
 
                 # Test that data loaded into BigQuery
-                env.run_task(telescope.bq_load_partition.__name__, dag, execution_date)
+                env.run_task(telescope.bq_load_partition.__name__)
                 for file in release.transform_files:
                     table_id, _ = table_ids_from_path(file)
                     table_id = f'{self.project_id}.{dataset_id}.{table_id}${release.release_date.strftime("%Y%m")}'
@@ -249,7 +249,7 @@ class TestGoogleAnalyticsTelescope(ObservatoryTestCase):
                     release.extract_folder,
                     release.transform_folder,
                 )
-                env.run_task(telescope.cleanup.__name__, dag, execution_date)
+                env.run_task(telescope.cleanup.__name__)
                 self.assert_cleanup(download_folder, extract_folder, transform_folder)
 
     @patch("oaebu_workflows.workflows.google_analytics_telescope.build")
@@ -301,7 +301,7 @@ class TestGoogleAnalyticsTelescope(ObservatoryTestCase):
                 env.add_connection(conn)
 
                 # Test that all dependencies are specified: no error should be thrown
-                env.run_task(telescope.check_dependencies.__name__, dag, execution_date)
+                env.run_task(telescope.check_dependencies.__name__)
 
                 # Use release to check tasks
                 cron_schedule = dag.normalized_schedule_interval
@@ -310,7 +310,7 @@ class TestGoogleAnalyticsTelescope(ObservatoryTestCase):
                 release = GoogleAnalyticsRelease(telescope.dag_id, execution_date, end_date, organisation)
 
                 # Test download_transform task
-                env.run_task(telescope.download_transform.__name__, dag, execution_date)
+                env.run_task(telescope.download_transform.__name__)
                 self.assertEqual(1, len(release.transform_files))
                 for file in release.transform_files:
                     self.assertTrue(os.path.isfile(file))
@@ -396,12 +396,12 @@ class TestGoogleAnalyticsTelescope(ObservatoryTestCase):
                     self.assertEqual(frozenset(expected_list[2]), frozenset(actual_list[2]))
 
                 # Test that transformed file uploaded
-                env.run_task(telescope.upload_transformed.__name__, dag, execution_date)
+                env.run_task(telescope.upload_transformed.__name__)
                 for file in release.transform_files:
                     self.assert_blob_integrity(env.transform_bucket, blob_name(file), file)
 
                 # Test that data loaded into BigQuery
-                env.run_task(telescope.bq_load_partition.__name__, dag, execution_date)
+                env.run_task(telescope.bq_load_partition.__name__)
                 for file in release.transform_files:
                     table_id, _ = table_ids_from_path(file)
                     table_id = f'{self.project_id}.{dataset_id}.{table_id}${release.release_date.strftime("%Y%m")}'
@@ -414,7 +414,7 @@ class TestGoogleAnalyticsTelescope(ObservatoryTestCase):
                     release.extract_folder,
                     release.transform_folder,
                 )
-                env.run_task(telescope.cleanup.__name__, dag, execution_date)
+                env.run_task(telescope.cleanup.__name__)
                 self.assert_cleanup(download_folder, extract_folder, transform_folder)
 
 

--- a/oaebu_workflows/workflows/tests/test_google_books_telescope.py
+++ b/oaebu_workflows/workflows/tests/test_google_books_telescope.py
@@ -202,7 +202,7 @@ class TestGoogleBooksTelescope(ObservatoryTestCase):
                         env.add_connection(conn)
                         with env.create_dag_run(dag, execution_date):
                             # Test that all dependencies are specified: no error should be thrown
-                            env.run_task(telescope.check_dependencies.__name__, dag, execution_date)
+                            env.run_task(telescope.check_dependencies.__name__)
 
                             # Add file to SFTP server
                             local_sftp_folders = SftpFolders(telescope.dag_id, self.organisation_name, sftp_root)
@@ -212,7 +212,7 @@ class TestGoogleBooksTelescope(ObservatoryTestCase):
                                 shutil.copy(file_path, upload_file)
 
                             # Check that the correct release info is returned via Xcom
-                            ti = env.run_task(telescope.list_release_info.__name__, dag, execution_date)
+                            ti = env.run_task(telescope.list_release_info.__name__)
                             release_info = ti.xcom_pull(
                                 key=GoogleBooksTelescope.RELEASE_INFO,
                                 task_ids=telescope.list_release_info.__name__,
@@ -246,7 +246,7 @@ class TestGoogleBooksTelescope(ObservatoryTestCase):
                                 )
 
                             # Test move file to in progress
-                            env.run_task(telescope.move_files_to_in_progress.__name__, dag, execution_date)
+                            env.run_task(telescope.move_files_to_in_progress.__name__)
                             for release in releases:
                                 for file in release.sftp_files:
                                     file_name = os.path.basename(file)
@@ -257,7 +257,7 @@ class TestGoogleBooksTelescope(ObservatoryTestCase):
                                     self.assertTrue(os.path.isfile(in_progress_file))
 
                             # Test download
-                            env.run_task(telescope.download.__name__, dag, execution_date)
+                            env.run_task(telescope.download.__name__)
                             for release in releases:
                                 self.assertEqual(setup["no_download_files"], len(release.download_files))
                                 files = release.download_files
@@ -274,13 +274,13 @@ class TestGoogleBooksTelescope(ObservatoryTestCase):
                                     self.assert_file_integrity(file, expected_file_hash, "md5")
 
                             # Test upload downloaded
-                            env.run_task(telescope.upload_downloaded.__name__, dag, execution_date)
+                            env.run_task(telescope.upload_downloaded.__name__)
                             for release in releases:
                                 for file in release.download_files:
                                     self.assert_blob_integrity(env.download_bucket, blob_name(file), file)
 
                             # Test that file transformed
-                            env.run_task(telescope.transform.__name__, dag, execution_date)
+                            env.run_task(telescope.transform.__name__)
                             for release in releases:
                                 self.assertEqual(2, len(release.transform_files))
                                 for file in release.transform_files:
@@ -291,13 +291,13 @@ class TestGoogleBooksTelescope(ObservatoryTestCase):
                                     self.assert_file_integrity(file, expected_file_hash, "gzip_crc")
 
                             # Test that transformed file uploaded
-                            env.run_task(telescope.upload_transformed.__name__, dag, execution_date)
+                            env.run_task(telescope.upload_transformed.__name__)
                             for release in releases:
                                 for file in release.transform_files:
                                     self.assert_blob_integrity(env.transform_bucket, blob_name(file), file)
 
                             # Test that data loaded into BigQuery
-                            env.run_task(telescope.bq_load_partition.__name__, dag, execution_date)
+                            env.run_task(telescope.bq_load_partition.__name__)
                             for release in releases:
                                 for file in release.transform_files:
                                     table_id, _ = table_ids_from_path(file)
@@ -306,7 +306,7 @@ class TestGoogleBooksTelescope(ObservatoryTestCase):
                                     self.assert_table_integrity(table_id, expected_rows)
 
                             # Test move files to finished
-                            env.run_task(telescope.move_files_to_finished.__name__, dag, execution_date)
+                            env.run_task(telescope.move_files_to_finished.__name__)
                             for release in releases:
                                 for file in release.sftp_files:
                                     file_name = os.path.basename(file)
@@ -322,7 +322,7 @@ class TestGoogleBooksTelescope(ObservatoryTestCase):
                                 release.extract_folder,
                                 release.transform_folder,
                             )
-                            env.run_task(telescope.cleanup.__name__, dag, execution_date)
+                            env.run_task(telescope.cleanup.__name__)
                             self.assert_cleanup(download_folder, extract_folder, transform_folder)
 
     @patch("observatory.platform.utils.workflow_utils.Variable.get")

--- a/oaebu_workflows/workflows/tests/test_oapen_metadata_telescope.py
+++ b/oaebu_workflows/workflows/tests/test_oapen_metadata_telescope.py
@@ -286,30 +286,30 @@ class TestOapenMetadataTelescopeDag(ObservatoryTestCase):
             with env.create_dag_run(dag, execution_date):
                 with CliRunner().isolated_filesystem():
                     # Test that all dependencies are specified: no error should be thrown
-                    env.run_task(telescope.check_dependencies.__name__, dag, execution_date)
+                    env.run_task(telescope.check_dependencies.__name__)
 
                     # Test download
                     with vcr.use_cassette(self.download_path):
-                        env.run_task(telescope.download.__name__, dag, execution_date)
+                        env.run_task(telescope.download.__name__)
                     self.assertEqual(len(release.download_files), 1)
 
                     # Test upload_downloaded
-                    env.run_task(telescope.upload_downloaded.__name__, dag, execution_date)
+                    env.run_task(telescope.upload_downloaded.__name__)
                     for file in release.download_files:
                         self.assert_blob_integrity(env.download_bucket, blob_name(file), file)
 
                     # Test download
-                    env.run_task(telescope.transform.__name__, dag, execution_date)
+                    env.run_task(telescope.transform.__name__)
                     self.assertEqual(len(release.transform_files), 1)
 
                     # Test upload_transformed
-                    env.run_task(telescope.upload_transformed.__name__, dag, execution_date)
+                    env.run_task(telescope.upload_transformed.__name__)
 
                     for file in release.transform_files:
                         self.assert_blob_integrity(env.transform_bucket, blob_name(file), file)
 
                     # Test bq_load partition
-                    ti = env.run_task(telescope.bq_load_partition.__name__, dag, execution_date)
+                    ti = env.run_task(telescope.bq_load_partition.__name__)
                     self.assertEqual(ti.state, "skipped")
 
                     # Test delete old task is skipped for the first release
@@ -317,7 +317,7 @@ class TestOapenMetadataTelescopeDag(ObservatoryTestCase):
                     self.assertEqual(ti.state, "skipped")
 
                     # Test bq_append_new
-                    env.run_task(telescope.bq_append_new.__name__, dag, execution_date)
+                    env.run_task(telescope.bq_append_new.__name__)
                     table_id = f"{self.project_id}.{telescope.dataset_id}.metadata"
                     expected_rows = 15310
                     self.assert_table_integrity(table_id, expected_rows)
@@ -329,5 +329,5 @@ class TestOapenMetadataTelescopeDag(ObservatoryTestCase):
                         release.transform_folder,
                     )
 
-                    env.run_task(telescope.cleanup.__name__, dag, execution_date)
+                    env.run_task(telescope.cleanup.__name__)
                     self.assert_cleanup(download_folder, extract_folder, transform_folder)

--- a/oaebu_workflows/workflows/tests/test_oapen_workflow.py
+++ b/oaebu_workflows/workflows/tests/test_oapen_workflow.py
@@ -173,16 +173,12 @@ class TestOapenWorkflowFunctional(ObservatoryTestCase):
             expected_state = "success"
             with env.create_dag_run(workflow_dag, start_date):
                 ti = env.run_task(
-                    f"{make_dag_id(self.irus_uk_dag_id_prefix, org_name)}_sensor",
-                    workflow_dag,
-                    execution_date=start_date,
+                    f"{make_dag_id(self.irus_uk_dag_id_prefix, org_name)}_sensor"
                 )
                 self.assertEqual(expected_state, ti.state)
 
                 ti = env.run_task(
-                    f"oapen_metadata_sensor",
-                    workflow_dag,
-                    execution_date=start_date,
+                    f"oapen_metadata_sensor"
                 )
                 self.assertEqual(expected_state, ti.state)
 
@@ -194,34 +190,30 @@ class TestOapenWorkflowFunctional(ObservatoryTestCase):
             dag = make_dummy_dag(make_dag_id(self.irus_uk_dag_id_prefix, org_name), execution_date)
             with env.create_dag_run(dag, execution_date):
                 # Running all of a DAGs tasks sets the DAG to finished
-                ti = env.run_task("dummy_task", dag, execution_date=execution_date)
+                ti = env.run_task("dummy_task")
                 self.assertEqual(expected_state, ti.state)
 
             dag = make_dummy_dag("oapen_metadata", execution_date)
             with env.create_dag_run(dag, execution_date):
                 # Running all of a DAGs tasks sets the DAG to finished
-                ti = env.run_task("dummy_task", dag, execution_date=execution_date)
+                ti = env.run_task("dummy_task")
                 self.assertEqual(expected_state, ti.state)
 
             # Run end to end tests for the DAG
             with env.create_dag_run(workflow_dag, execution_date):
                 # Test that sensors go into 'success' state as the DAGs that they are waiting for have finished
                 ti = env.run_task(
-                    f"{make_dag_id(self.irus_uk_dag_id_prefix, org_name)}_sensor",
-                    workflow_dag,
-                    execution_date=execution_date,
+                    f"{make_dag_id(self.irus_uk_dag_id_prefix, org_name)}_sensor"
                 )
                 self.assertEqual(expected_state, ti.state)
 
                 ti = env.run_task(
-                    f"oapen_metadata_sensor",
-                    workflow_dag,
-                    execution_date=execution_date,
+                    f"oapen_metadata_sensor"
                 )
                 self.assertEqual(expected_state, ti.state)
 
                 # Check dependencies
-                ti = env.run_task("check_dependencies", workflow_dag, execution_date=execution_date)
+                ti = env.run_task("check_dependencies")
                 self.assertEqual(expected_state, ti.state)
 
                 # Mock make_release
@@ -234,17 +226,13 @@ class TestOapenWorkflowFunctional(ObservatoryTestCase):
 
                 # Format OAPEN Metadata like ONIX to enable the next steps
                 ti = env.run_task(
-                    workflow.create_onix_formatted_metadata_output_tasks.__name__,
-                    workflow_dag,
-                    execution_date,
+                    workflow.create_onix_formatted_metadata_output_tasks.__name__
                 )
                 self.assertEqual(expected_state, ti.state)
 
                 # Create oaebu output tables
                 ti = env.run_task(
-                    workflow.create_oaebu_book_product_table.__name__,
-                    workflow_dag,
-                    execution_date,
+                    workflow.create_oaebu_book_product_table.__name__
                 )
                 self.assertEqual(expected_state, ti.state)
 
@@ -266,9 +254,7 @@ class TestOapenWorkflowFunctional(ObservatoryTestCase):
 
                 for table in export_tables:
                     ti = env.run_task(
-                        f"{workflow.export_oaebu_table.__name__}.{table}",
-                        workflow_dag,
-                        execution_date,
+                        f"{workflow.export_oaebu_table.__name__}.{table}"
                     )
                     self.assertEqual(expected_state, ti.state)
 
@@ -300,4 +286,4 @@ class TestOapenWorkflowFunctional(ObservatoryTestCase):
                 self.assertEqual(len(records), 0)
 
                 # Cleanup
-                env.run_task(workflow.cleanup.__name__, workflow_dag, execution_date)
+                env.run_task(workflow.cleanup.__name__)

--- a/oaebu_workflows/workflows/tests/test_onix_workflow.py
+++ b/oaebu_workflows/workflows/tests/test_onix_workflow.py
@@ -1741,7 +1741,7 @@ class TestOnixWorkflowFunctional(ObservatoryTestCase):
             with env.create_dag_run(workflow_dag, start_date):
                 for task_id in sensor_dag_ids:
                     ti = env.run_task(
-                        f"{make_dag_id(task_id, org_name)}_sensor", workflow_dag, execution_date=start_date
+                        f"{make_dag_id(task_id, org_name)}_sensor"
                     )
                     self.assertEqual(expected_state, ti.state)
 
@@ -1753,7 +1753,7 @@ class TestOnixWorkflowFunctional(ObservatoryTestCase):
                 dag = make_dummy_dag(make_dag_id(dag_id, org_name), execution_date)
                 with env.create_dag_run(dag, execution_date):
                     # Running all of a DAGs tasks sets the DAG to finished
-                    ti = env.run_task("dummy_task", dag, execution_date=execution_date)
+                    ti = env.run_task("dummy_task")
                     self.assertEqual(expected_state, ti.state)
 
             # Run end to end tests for DOI DAG
@@ -1761,7 +1761,7 @@ class TestOnixWorkflowFunctional(ObservatoryTestCase):
                 # Test that sensors go into 'success' state as the DAGs that they are waiting for have finished
                 for task_id in sensor_dag_ids:
                     ti = env.run_task(
-                        f"{make_dag_id(task_id, org_name)}_sensor", workflow_dag, execution_date=execution_date
+                        f"{make_dag_id(task_id, org_name)}_sensor"
                     )
                     self.assertEqual(expected_state, ti.state)
 
@@ -1784,23 +1784,23 @@ class TestOnixWorkflowFunctional(ObservatoryTestCase):
                 )
 
                 # Aggregate works
-                ti = env.run_task(telescope.aggregate_works.__name__, workflow_dag, execution_date)
+                ti = env.run_task(telescope.aggregate_works.__name__)
                 self.assertEqual(expected_state, ti.state)
 
                 # Upload aggregation tables
-                ti = env.run_task(telescope.upload_aggregation_tables.__name__, workflow_dag, execution_date)
+                ti = env.run_task(telescope.upload_aggregation_tables.__name__)
                 self.assertEqual(expected_state, ti.state)
 
                 # Load work id table into bigquery
-                ti = env.run_task(telescope.bq_load_workid_lookup.__name__, workflow_dag, execution_date)
+                ti = env.run_task(telescope.bq_load_workid_lookup.__name__)
                 self.assertEqual(expected_state, ti.state)
 
                 # Load work id errors table into bigquery
-                ti = env.run_task(telescope.bq_load_workid_lookup_errors.__name__, workflow_dag, execution_date)
+                ti = env.run_task(telescope.bq_load_workid_lookup_errors.__name__)
                 self.assertEqual(expected_state, ti.state)
 
                 # Load work family id table into bigquery
-                ti = env.run_task(telescope.bq_load_workfamilyid_lookup.__name__, workflow_dag, execution_date)
+                ti = env.run_task(telescope.bq_load_workfamilyid_lookup.__name__)
                 self.assertEqual(expected_state, ti.state)
 
                 # Create oaebu intermediate tables
@@ -1809,122 +1809,92 @@ class TestOnixWorkflowFunctional(ObservatoryTestCase):
                     oaebu_table = data_partner.gcp_table_id
 
                     ti = env.run_task(
-                        f"{telescope.create_oaebu_intermediate_table.__name__}.{oaebu_dataset}.{oaebu_table}",
-                        workflow_dag,
-                        execution_date,
+                        f"{telescope.create_oaebu_intermediate_table.__name__}.{oaebu_dataset}.{oaebu_table}"
                     )
                     self.assertEqual(expected_state, ti.state)
 
                 # Create oaebu output tables
                 ti = env.run_task(
-                    telescope.create_oaebu_book_product_table.__name__,
-                    workflow_dag,
-                    execution_date,
+                    telescope.create_oaebu_book_product_table.__name__
                 )
                 self.assertEqual(expected_state, ti.state)
 
                 # ONIX isbn check
                 ti = env.run_task(
-                    telescope.create_oaebu_data_qa_onix_isbn.__name__,
-                    workflow_dag,
-                    execution_date,
+                    telescope.create_oaebu_data_qa_onix_isbn.__name__
                 )
                 self.assertEqual(expected_state, ti.state)
 
                 # ONIX aggregate metrics
                 ti = env.run_task(
-                    telescope.create_oaebu_data_qa_onix_aggregate.__name__,
-                    workflow_dag,
-                    execution_date,
+                    telescope.create_oaebu_data_qa_onix_aggregate.__name__
                 )
                 self.assertEqual(expected_state, ti.state)
 
                 # JSTOR country isbn check
                 ti = env.run_task(
-                    f"{telescope.create_oaebu_data_qa_jstor_isbn.__name__}.{data_partners[0].gcp_dataset_id}.{data_partners[0].gcp_table_id}",
-                    workflow_dag,
-                    execution_date,
+                    f"{telescope.create_oaebu_data_qa_jstor_isbn.__name__}.{data_partners[0].gcp_dataset_id}.{data_partners[0].gcp_table_id}"
                 )
                 self.assertEqual(expected_state, ti.state)
 
                 # JSTOR country intermediate unmatched isbns
                 ti = env.run_task(
-                    f"{telescope.create_oaebu_data_qa_intermediate_unmatched_workid.__name__}.{data_partners[0].gcp_dataset_id}.{data_partners[0].gcp_table_id}",
-                    workflow_dag,
-                    execution_date,
+                    f"{telescope.create_oaebu_data_qa_intermediate_unmatched_workid.__name__}.{data_partners[0].gcp_dataset_id}.{data_partners[0].gcp_table_id}"
                 )
                 self.assertEqual(expected_state, ti.state)
 
                 # JSTOR institution isbn check
                 ti = env.run_task(
-                    f"{telescope.create_oaebu_data_qa_jstor_isbn.__name__}.{data_partners[1].gcp_dataset_id}.{data_partners[1].gcp_table_id}",
-                    workflow_dag,
-                    execution_date,
+                    f"{telescope.create_oaebu_data_qa_jstor_isbn.__name__}.{data_partners[1].gcp_dataset_id}.{data_partners[1].gcp_table_id}"
                 )
                 self.assertEqual(expected_state, ti.state)
 
                 # JSTOR institution intermediate unmatched isbns
                 ti = env.run_task(
-                    f"{telescope.create_oaebu_data_qa_intermediate_unmatched_workid.__name__}.{data_partners[1].gcp_dataset_id}.{data_partners[1].gcp_table_id}",
-                    workflow_dag,
-                    execution_date,
+                    f"{telescope.create_oaebu_data_qa_intermediate_unmatched_workid.__name__}.{data_partners[1].gcp_dataset_id}.{data_partners[1].gcp_table_id}"
                 )
                 self.assertEqual(expected_state, ti.state)
 
                 # Google Books Sales isbn check
                 ti = env.run_task(
-                    telescope.create_oaebu_data_qa_google_books_sales_isbn.__name__,
-                    workflow_dag,
-                    execution_date,
+                    telescope.create_oaebu_data_qa_google_books_sales_isbn.__name__
                 )
                 self.assertEqual(expected_state, ti.state)
 
                 # Google Books Sales intermediate unmatched isbns
                 ti = env.run_task(
-                    f"{telescope.create_oaebu_data_qa_intermediate_unmatched_workid.__name__}.{data_partners[2].gcp_dataset_id}.{data_partners[2].gcp_table_id}",
-                    workflow_dag,
-                    execution_date,
+                    f"{telescope.create_oaebu_data_qa_intermediate_unmatched_workid.__name__}.{data_partners[2].gcp_dataset_id}.{data_partners[2].gcp_table_id}"
                 )
                 self.assertEqual(expected_state, ti.state)
 
                 # Google Books Traffic isbn check
                 ti = env.run_task(
-                    telescope.create_oaebu_data_qa_google_books_traffic_isbn.__name__,
-                    workflow_dag,
-                    execution_date,
+                    telescope.create_oaebu_data_qa_google_books_traffic_isbn.__name__
                 )
                 self.assertEqual(expected_state, ti.state)
 
                 # Google Books Traffic intermediate unmatched isbns
                 ti = env.run_task(
-                    f"{telescope.create_oaebu_data_qa_intermediate_unmatched_workid.__name__}.{data_partners[3].gcp_dataset_id}.{data_partners[3].gcp_table_id}",
-                    workflow_dag,
-                    execution_date,
+                    f"{telescope.create_oaebu_data_qa_intermediate_unmatched_workid.__name__}.{data_partners[3].gcp_dataset_id}.{data_partners[3].gcp_table_id}"
                 )
                 self.assertEqual(expected_state, ti.state)
 
                 # OAPEN IRUS UK isbn check
                 ti = env.run_task(
-                    telescope.create_oaebu_data_qa_oapen_irus_uk_isbn.__name__,
-                    workflow_dag,
-                    execution_date,
+                    telescope.create_oaebu_data_qa_oapen_irus_uk_isbn.__name__
                 )
                 self.assertEqual(expected_state, ti.state)
 
                 # OAPEN IRUS UK intermediate unmatched isbns
                 ti = env.run_task(
-                    f"{telescope.create_oaebu_data_qa_intermediate_unmatched_workid.__name__}.{data_partners[4].gcp_dataset_id}.{data_partners[4].gcp_table_id}",
-                    workflow_dag,
-                    execution_date,
+                    f"{telescope.create_oaebu_data_qa_intermediate_unmatched_workid.__name__}.{data_partners[4].gcp_dataset_id}.{data_partners[4].gcp_table_id}"
                 )
                 self.assertEqual(expected_state, ti.state)
 
                 if include_google_analytics:
                     # Google Analytics isbn check
                     env.run_task(
-                        telescope.create_oaebu_data_qa_google_analytics_isbn.__name__,
-                        workflow_dag,
-                        execution_date,
+                        telescope.create_oaebu_data_qa_google_analytics_isbn.__name__
                     )
 
                     # Google Books Analytics unmatched isbns
@@ -1932,9 +1902,7 @@ class TestOnixWorkflowFunctional(ObservatoryTestCase):
                     print(f"{data_partners[5].gcp_dataset_id}.{data_partners[5].gcp_table_id}")
                     print("---------------------------------------")
                     env.run_task(
-                        f"{telescope.create_oaebu_data_qa_intermediate_unmatched_workid.__name__}.{data_partners[5].gcp_dataset_id}.{data_partners[5].gcp_table_id}",
-                        workflow_dag,
-                        execution_date,
+                        f"{telescope.create_oaebu_data_qa_intermediate_unmatched_workid.__name__}.{data_partners[5].gcp_dataset_id}.{data_partners[5].gcp_table_id}"
                     )
 
                 # Export oaebu elastic tables
@@ -1955,17 +1923,13 @@ class TestOnixWorkflowFunctional(ObservatoryTestCase):
 
                 for table in export_tables:
                     ti = env.run_task(
-                        f"{telescope.export_oaebu_table.__name__}.{table}",
-                        workflow_dag,
-                        execution_date,
+                        f"{telescope.export_oaebu_table.__name__}.{table}"
                     )
                     self.assertEqual(expected_state, ti.state)
 
                 # Export oaebu elastic qa table
                 ti = env.run_task(
-                    telescope.export_oaebu_qa_metrics.__name__,
-                    workflow_dag,
-                    execution_date,
+                    telescope.export_oaebu_qa_metrics.__name__
                 )
                 self.assertEqual(expected_state, ti.state)
 
@@ -2176,7 +2140,7 @@ class TestOnixWorkflowFunctional(ObservatoryTestCase):
                 self.assertTrue("112" in isbns)
 
                 # Cleanup
-                env.run_task(telescope.cleanup.__name__, workflow_dag, execution_date)
+                env.run_task(telescope.cleanup.__name__)
 
     def test_telescope(self):
         """Test that ONIX Workflow runs when Google Analytics is not included"""

--- a/oaebu_workflows/workflows/tests/test_ucl_discovery_telescope.py
+++ b/oaebu_workflows/workflows/tests/test_ucl_discovery_telescope.py
@@ -155,7 +155,7 @@ class TestUclDiscoveryTelescope(ObservatoryTestCase):
                 env.add_connection(conn)
 
                 # Test that all dependencies are specified: no error should be thrown
-                env.run_task(telescope.check_dependencies.__name__, dag, execution_date)
+                env.run_task(telescope.check_dependencies.__name__)
 
                 # Use release to check tasks
                 cron_schedule = dag.normalized_schedule_interval
@@ -165,29 +165,29 @@ class TestUclDiscoveryTelescope(ObservatoryTestCase):
 
                 # Test download
                 with vcr.use_cassette(self.metadata_cassette):
-                    env.run_task(telescope.download.__name__, dag, execution_date)
+                    env.run_task(telescope.download.__name__)
                 self.assertEqual(1, len(release.download_files))
                 for file in release.download_files:
                     self.assert_file_integrity(file, self.download_hash, "md5")
 
                 # Test upload downloaded
-                env.run_task(telescope.upload_downloaded.__name__, dag, execution_date)
+                env.run_task(telescope.upload_downloaded.__name__)
                 for file in release.download_files:
                     self.assert_blob_integrity(env.download_bucket, blob_name(file), file)
 
                 # Test that file transformed
-                env.run_task(telescope.transform.__name__, dag, execution_date)
+                env.run_task(telescope.transform.__name__)
                 self.assertEqual(1, len(release.transform_files))
                 for file in release.transform_files:
                     self.assert_file_integrity(file, self.transform_hash, "gzip_crc")
 
                 # Test that transformed file uploaded
-                env.run_task(telescope.upload_transformed.__name__, dag, execution_date)
+                env.run_task(telescope.upload_transformed.__name__)
                 for file in release.transform_files:
                     self.assert_blob_integrity(env.transform_bucket, blob_name(file), file)
 
                 # Test that data loaded into BigQuery
-                env.run_task(telescope.bq_load_partition.__name__, dag, execution_date)
+                env.run_task(telescope.bq_load_partition.__name__)
                 for file in release.transform_files:
                     table_id, _ = table_ids_from_path(file)
                     table_id = f'{self.project_id}.{dataset_id}.{table_id}${release.release_date.strftime("%Y%m")}'
@@ -200,7 +200,7 @@ class TestUclDiscoveryTelescope(ObservatoryTestCase):
                     release.extract_folder,
                     release.transform_folder,
                 )
-                env.run_task(telescope.cleanup.__name__, dag, execution_date)
+                env.run_task(telescope.cleanup.__name__)
                 self.assert_cleanup(download_folder, extract_folder, transform_folder)
 
     @patch("oaebu_workflows.workflows.ucl_discovery_telescope.retry_session")


### PR DESCRIPTION
Update unit tests to work with INF-166/airflow-2.2 branch on observatory-platform.

Remove passing "dag" and "execution_date" to `run_task`, passes on current observatory-platform develop.