### PR TITLE
MEL-534 updating mapping to cover missing UCL Discovery field

### DIFF
--- a/oaebu_workflows/database/mappings/oaebu-metrics-mappings.json.jinja2
+++ b/oaebu_workflows/database/mappings/oaebu-metrics-mappings.json.jinja2
@@ -118,6 +118,13 @@
             "type": "integer"
           }
         }
+      },
+      "ucl_discovery": {
+        "properties": {
+          "total_downloads": {
+            "type": "integer"
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
There is a field that is currently being exported to Elasticsearch (ucl_discovery.total_downloads), however because it is missing from the mapping file elasticsearch is reverting to its default behaviour and assigning it's type to be 'text'. This pull request just forces the type to be integer to ensure it works correctly across various charts.

No other changes required from the workflow, changes should occur after the next ingest following deployment