### PR TITLE
MEL-556 added usage flag to book product list

### DIFF
--- a/oaebu_workflows/database/mappings/oaebu-list-mappings.json.jinja2
+++ b/oaebu_workflows/database/mappings/oaebu-list-mappings.json.jinja2
@@ -38,6 +38,9 @@
           }
         }
       },
+      "usage_flag": {
+        "type": "boolean"
+      },
       "EditionNumber": {
         "type": "integer"
       },

--- a/oaebu_workflows/database/sql/export_book_list.sql.jinja2
+++ b/oaebu_workflows/database/sql/export_book_list.sql.jinja2
@@ -19,6 +19,7 @@ SELECT
     work_id,
     work_family_id,
     onix.ProductForm,
+    (ARRAY_LENGTH(months) > 0) as usage_flag,
     onix.EditionNumber,
     DATE(CAST(onix.published_year as INT64), 12, 31) AS time_field,
     CAST(onix.published_year as INT64) as published_year,


### PR DESCRIPTION
This change adds a new field to the book product list. It indicates whether there are any metrics (from any source) linked to this book. It should enable a greater flexibility of filtering out records in charts and dropdown lists.

The change should be self contained. Changes will be seen the next time the ingest occurs