### PR TITLE
MEL-535 Ensures unmatched isbns in ucl_discovery are exported

### DIFF
--- a/oaebu_workflows/database/mappings/oaebu-unmatched-metrics-mappings.json.jinja2
+++ b/oaebu_workflows/database/mappings/oaebu-unmatched-metrics-mappings.json.jinja2
@@ -46,6 +46,15 @@
           }
         }
       },
+      "ucl_discovery_title": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
       "release_date": {
         "type": "date",
         "format": "yyyy-MM-dd"
@@ -78,6 +87,15 @@
         }
       },
       "in_oapen": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "in_ucl_discovery": {
         "type": "text",
         "fields": {
           "keyword": {

--- a/oaebu_workflows/database/sql/export_unmatched_metrics.sql.jinja2
+++ b/oaebu_workflows/database/sql/export_unmatched_metrics.sql.jinja2
@@ -82,6 +82,23 @@ oapen as (
     {% endif %}
 ),
 
+ucl_discovery as (
+    {% if ucl_discovery %}
+    SELECT
+        {{ ucl_isbn }} as ISBN,
+        title,
+        release_date,
+        "ucl_discovery" as source
+    FROM `{{ project_id }}.{{ dataset_id }}.{{ ucl_table }}_unmatched_{{ ucl_isbn }}{{ release.strftime('%Y%m%d') }}`
+    {% else %}
+    SELECT
+        CAST(NULL as STRING) as ISBN,
+        CAST(NULL as STRING) as title,
+        CAST(NULL as DATE) as release_date,
+        "ucl_discovery" as source
+    {% endif %}
+),
+
 all_un_matched as (
 SELECT * FROM google_analytics
     UNION ALL
@@ -90,6 +107,8 @@ SELECT * FROM google_books
 SELECT * FROM jstor
     UNION ALL
 SELECT * FROM oapen
+    UNION ALL
+SELECT * FROM ucl_discovery
 )
 
 SELECT
@@ -99,10 +118,12 @@ SELECT
     ARRAY_AGG(DISTINCT IF(source = "google_books", title, NULL) IGNORE NULLS LIMIT 1)[SAFE_OFFSET(0)] as google_books_title,
     ARRAY_AGG(DISTINCT IF(source = "jstor", title, NULL) IGNORE NULLS LIMIT 1)[SAFE_OFFSET(0)] as jstor_title,
     ARRAY_AGG(DISTINCT IF(source = "oapen", title, NULL) IGNORE NULLS LIMIT 1)[SAFE_OFFSET(0)] as oapen_title,
+    ARRAY_AGG(DISTINCT IF(source = "ucl_discovery", title, NULL) IGNORE NULLS LIMIT 1)[SAFE_OFFSET(0)] as ucl_discovery_title,
     "google_analytics" in UNNEST(ARRAY_AGG(source)) as in_google_analytics,
     "google_books" in UNNEST(ARRAY_AGG(source)) as in_google_books,
     "jstor" in UNNEST(ARRAY_AGG(source)) as in_jstor,
     "oapen" in UNNEST(ARRAY_AGG(source)) as in_oapen,
+    "ucl_discovery" in UNNEST(ARRAY_AGG(source)) as in_ucl_discovery,
 FROM all_un_matched
 WHERE ISBN IS NOT NULL
 GROUP BY ISBN, release_date


### PR DESCRIPTION
Currently unmatched ISBNs are aggregated and exported to Kibana. This logic was written before UCl-Discovery was added as a metrics source, so unmatched ISBNs from there were not included in the output. This change ensures those ISBNs are also exported.

There is an associated update to the Elasticsearch mapping. This should not require any other changes to the DAG.