### PR TITLE
Fix DOAB telescope

### DIFF
--- a/oaebu_workflows/database/schema/doab_2021-01-01.json
+++ b/oaebu_workflows/database/schema/doab_2021-01-01.json
@@ -220,6 +220,18 @@
             "mode": "NULLABLE",
             "name": "urlwebshop",
             "type": "STRING"
+          },
+          {
+            "description": "",
+            "mode": "NULLABLE",
+            "name": "citation",
+            "type": "STRING"
+          },
+          {
+            "description": "",
+            "mode": "NULLABLE",
+            "name": "isbn",
+            "type": "STRING"
           }
         ]
       },
@@ -239,6 +251,12 @@
         "description": "",
         "mode": "REPEATED",
         "name": "number",
+        "type": "STRING"
+      },
+      {
+        "description": "",
+        "mode": "NULLABLE",
+        "name": "publisher",
         "type": "STRING"
       },
       {

--- a/oaebu_workflows/workflows/doab_telescope.py
+++ b/oaebu_workflows/workflows/doab_telescope.py
@@ -66,9 +66,15 @@ class DoabRelease(StreamRelease):
             with open(self.csv_path, "w") as f:
                 f.write(response.content.decode("utf-8"))
             logging.info(f"Downloaded csv successful to {self.csv_path}")
-            return True
         else:
             raise AirflowException(f"Download csv unsuccessful, {response.text}")
+
+        with open(self.csv_path, "r") as f:
+            csv_dict = [row for row in csv.DictReader(f)]
+            if len(csv_dict) == 0:
+                raise AirflowException(f"CSV file is empty")
+
+        return True
 
     def transform(self):
         """Transform the doab csv file by storing in a jsonl format and restructuring lists/dicts.

--- a/oaebu_workflows/workflows/tests/test_doab_telescope.py
+++ b/oaebu_workflows/workflows/tests/test_doab_telescope.py
@@ -241,7 +241,7 @@ class TestDoabTelescope(ObservatoryTestCase):
         """Cover case when airflow_vars is given."""
 
         telescope = DoabTelescope(airflow_vars=[AirflowVars.DOWNLOAD_BUCKET])
-        self.assertEqual(telescope.airflow_vars, [AirflowVars.DOWNLOAD_BUCKET, AirflowVars.TRANSFORM_BUCKET])
+        self.assertEqual(set(telescope.airflow_vars), {AirflowVars.DOWNLOAD_BUCKET, AirflowVars.TRANSFORM_BUCKET})
 
     @patch("observatory.platform.utils.workflow_utils.Variable.get")
     def test_download(self, mock_variable_get):


### PR DESCRIPTION
The DAG run initially failed, because the CSV file that was downloaded was empty.
I'm not sure how this happened, when I downloaded it today the CSV was populated.

To prevent this or at least keep an eye on it I've added a check to verify that the CSV is not empty in the download step.
If it is empty hopefully it will be fixed automatically when the task is retried.

When I reran the tasks from 'download' onwards, the csv was now downloaded correctly, but the DAG run still fails because it seems that the schema also changed, so I've updated the schema in this PR as well.