### PR TITLE
Mel 553 autocomplete lists

### DIFF
--- a/oaebu_workflows/database/mappings/oaebu-institution-list-mappings.json.jinja2
+++ b/oaebu_workflows/database/mappings/oaebu-institution-list-mappings.json.jinja2
@@ -1,0 +1,15 @@
+{
+  "mappings": {
+    "properties": {
+      "institution": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      }
+    }
+  }
+}

--- a/oaebu_workflows/database/sql/export_institution_list.sql.jinja2
+++ b/oaebu_workflows/database/sql/export_institution_list.sql.jinja2
@@ -1,0 +1,21 @@
+{# Copyright 2020 Curtin University
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Author: Richard Hosking #}
+
+SELECT
+    institution.institution,
+FROM `{{ project_id }}.{{ dataset_id }}.book_product{{ release.strftime('%Y%m%d') }}`, UNNEST(months) as month, UNNEST(month.jstor_institution) as institution
+WHERE ARRAY_LENGTH(month.jstor_institution) > 0
+GROUP BY institution

--- a/oaebu_workflows/workflows/oapen_workflow.py
+++ b/oaebu_workflows/workflows/oapen_workflow.py
@@ -405,6 +405,11 @@ class OapenWorkflow(Workflow):
                 "file_type": "json",
             },
             {
+                "output_table": "institution_list",
+                "query_template": "export_institution_list.sql.jinja2",
+                "file_type": "json",
+            },
+            {
                 "output_table": "book_product_metrics_city",
                 "query_template": "export_book_metrics_city.sql.jinja2",
                 "file_type": "json",

--- a/oaebu_workflows/workflows/onix_workflow.py
+++ b/oaebu_workflows/workflows/onix_workflow.py
@@ -870,6 +870,11 @@ class OnixWorkflow(Workflow):
                 "file_type": "json",
             },
             {
+                "output_table": "institution_list",
+                "query_template": "export_institution_list.sql.jinja2",
+                "file_type": "json",
+            },
+            {
                 "output_table": "book_product_metrics_city",
                 "query_template": "export_book_metrics_city.sql.jinja2",
                 "file_type": "json",

--- a/oaebu_workflows/workflows/tests/test_oapen_workflow.py
+++ b/oaebu_workflows/workflows/tests/test_oapen_workflow.py
@@ -241,6 +241,7 @@ class TestOapenWorkflowFunctional(ObservatoryTestCase):
                     "book_product_metrics",
                     "book_product_metrics_country",
                     "book_product_metrics_institution",
+                    "institution_list",
                     "book_product_metrics_city",
                     "book_product_metrics_referrer",
                     "book_product_metrics_events",

--- a/oaebu_workflows/workflows/tests/test_oapen_workflow.py
+++ b/oaebu_workflows/workflows/tests/test_oapen_workflow.py
@@ -79,6 +79,9 @@ class TestOapenWorkflow(ObservatoryTestCase):
                         "export_oaebu_table.book_product_metrics_institution"
                     ],
                     "export_oaebu_table.book_product_metrics_institution": [
+                        "export_oaebu_table.institution_list"
+                    ],
+                    "export_oaebu_table.institution_list": [
                         "export_oaebu_table.book_product_metrics_city"
                     ],
                     "export_oaebu_table.book_product_metrics_city": [

--- a/oaebu_workflows/workflows/tests/test_onix_workflow.py
+++ b/oaebu_workflows/workflows/tests/test_onix_workflow.py
@@ -504,6 +504,9 @@ class TestOnixWorkflow(ObservatoryTestCase):
                         "export_oaebu_table.book_product_metrics_institution"
                     ],
                     "export_oaebu_table.book_product_metrics_institution": [
+                        "export_oaebu_table.institution_list"
+                    ],
+                    "export_oaebu_table.institution_list": [
                         "export_oaebu_table.book_product_metrics_city"
                     ],
                     "export_oaebu_table.book_product_metrics_city": [
@@ -1910,6 +1913,7 @@ class TestOnixWorkflowFunctional(ObservatoryTestCase):
                     "book_product_metrics",
                     "book_product_metrics_country",
                     "book_product_metrics_institution",
+                    "institution_list",
                     "book_product_metrics_city",
                     "book_product_metrics_referrer",
                     "book_product_metrics_events",

--- a/oaebu_workflows/workflows/tests/test_onix_workflow.py
+++ b/oaebu_workflows/workflows/tests/test_onix_workflow.py
@@ -667,6 +667,9 @@ class TestOnixWorkflow(ObservatoryTestCase):
                         "export_oaebu_table.book_product_metrics_institution"
                     ],
                     "export_oaebu_table.book_product_metrics_institution": [
+                        "export_oaebu_table.institution_list"
+                    ],
+                    "export_oaebu_table.institution_list": [
                         "export_oaebu_table.book_product_metrics_city"
                     ],
                     "export_oaebu_table.book_product_metrics_city": [


### PR DESCRIPTION
pushes out the list of unique institutions, similar to how the book_product_list works. The reason for this index, is because of the way kibana dropdown selectors work. Currently the institution tables is 400k~ rows, so using the institution field directly from that leads to issues. This will add another index, with only the unique list, using the same field name, allowing for the drop down list to be driven by this much smaller index