### PR TITLE
Fix JSTOR email filtering

### DIFF
--- a/oaebu_workflows/workflows/jstor_telescope.py
+++ b/oaebu_workflows/workflows/jstor_telescope.py
@@ -513,7 +513,7 @@ def list_reports(service: Resource, publisher_id: str) -> List[dict]:
     # List messages with specific query
     list_params = {
         "userId": "me",
-        "q": f"-label: {JstorTelescope.PROCESSED_LABEL_NAME} subject:'JSTOR Publisher Report Available'",
+        "q": f'-label:{JstorTelescope.PROCESSED_LABEL_NAME} subject:"JSTOR Publisher Report Available" from:no-reply@ithaka.org',
         "labelIds": ["INBOX"],
         "maxResults": 500,
     }


### PR DESCRIPTION
- Replace single quote with double quote to fix subject filtering
- Filter on sender as well