### PR TITLE
Ignore unknown fields

### DIFF
--- a/oaebu_workflows/workflows/doab_telescope.py
+++ b/oaebu_workflows/workflows/doab_telescope.py
@@ -190,6 +190,7 @@ class DoabTelescope(StreamTelescope):
             merge_partition_field,
             schema_folder,
             airflow_vars=airflow_vars,
+            load_bigquery_table_kwargs={"ignore_unknown_values": True}
         )
 
         self.add_setup_task(self.check_dependencies)

--- a/oaebu_workflows/workflows/oapen_metadata_telescope.py
+++ b/oaebu_workflows/workflows/oapen_metadata_telescope.py
@@ -181,6 +181,7 @@ class OapenMetadataTelescope(StreamTelescope):
             schema_folder,
             schema_prefix=schema_prefix,
             airflow_vars=airflow_vars,
+            load_bigquery_table_kwargs={"ignore_unknown_values": True}
         )
 
         self.add_setup_task(self.check_dependencies)


### PR DESCRIPTION
Set the ignore_unknown_values field to True for StreamTelescope subclasses, so that when new fields are added to source data, BigQuery loading will not break.