### PR TITLE
Mel 670/dataset release creation

### DIFF
--- a/oaebu_workflows/dags/doab_telescope.py
+++ b/oaebu_workflows/dags/doab_telescope.py
@@ -24,6 +24,6 @@ from observatory.platform.utils.api import make_observatory_api
 # Fetch all telescopes
 api = make_observatory_api()
 workflow_type = api.get_workflow_type(type_id=WorkflowTypes.doab)
-telescopes = api.get_telescopes(workflow_type_id=workflow_type.id, limit=1000)
-workflow = DoabTelescope(workflow_id=telescopes[0].id)
+workflows = api.get_workflows(workflow_type_id=workflow_type.id, limit=1000)
+workflow = DoabTelescope(workflow_id=workflows[0].id)
 globals()[workflow.dag_id] = workflow.make_dag()

--- a/oaebu_workflows/dags/doab_telescope.py
+++ b/oaebu_workflows/dags/doab_telescope.py
@@ -17,13 +17,13 @@
 # The keywords airflow and DAG are required to load the DAGs from this file, see bullet 2 in the Apache Airflow FAQ:
 # https://airflow.apache.org/docs/stable/faq.html
 
-from oaebu_workflows.identifiers import TelescopeTypes
+from oaebu_workflows.identifiers import WorkflowTypes
 from oaebu_workflows.workflows.doab_telescope import DoabTelescope
 from observatory.platform.utils.api import make_observatory_api
 
 # Fetch all telescopes
 api = make_observatory_api()
-telescope_type = api.get_telescope_type(type_id=TelescopeTypes.doab)
-telescopes = api.get_telescopes(telescope_type_id=telescope_type.id, limit=1000)
+workflow_type = api.get_workflow_type(type_id=WorkflowTypes.doab)
+telescopes = api.get_telescopes(workflow_type_id=workflow_type.id, limit=1000)
 workflow = DoabTelescope(workflow_id=telescopes[0].id)
 globals()[workflow.dag_id] = workflow.make_dag()

--- a/oaebu_workflows/dags/doab_telescope.py
+++ b/oaebu_workflows/dags/doab_telescope.py
@@ -17,7 +17,13 @@
 # The keywords airflow and DAG are required to load the DAGs from this file, see bullet 2 in the Apache Airflow FAQ:
 # https://airflow.apache.org/docs/stable/faq.html
 
+from oaebu_workflows.identifiers import TelescopeTypes
 from oaebu_workflows.workflows.doab_telescope import DoabTelescope
+from observatory.platform.utils.api import make_observatory_api
 
-workflow = DoabTelescope()
+# Fetch all telescopes
+api = make_observatory_api()
+telescope_type = api.get_telescope_type(type_id=TelescopeTypes.doab)
+telescopes = api.get_telescopes(telescope_type_id=telescope_type.id, limit=1000)
+workflow = DoabTelescope(workflow_id=telescopes[0].id)
 globals()[workflow.dag_id] = workflow.make_dag()

--- a/oaebu_workflows/dags/google_analytics_telescope.py
+++ b/oaebu_workflows/dags/google_analytics_telescope.py
@@ -32,5 +32,5 @@ telescopes = api.get_telescopes(telescope_type_id=telescope_type.id, limit=1000)
 for telescope in telescopes:
     view_id = telescope.extra.get("view_id")
     pagepath_regex = telescope.extra.get("pagepath_regex")
-    workflow = GoogleAnalyticsTelescope(telescope.organisation, view_id, pagepath_regex)
+    workflow = GoogleAnalyticsTelescope(telescope.organisation, view_id, pagepath_regex, workflow_id=telescope.id)
     globals()[workflow.dag_id] = workflow.make_dag()

--- a/oaebu_workflows/dags/google_analytics_telescope.py
+++ b/oaebu_workflows/dags/google_analytics_telescope.py
@@ -26,11 +26,11 @@ from observatory.platform.utils.api import make_observatory_api
 # Fetch all telescopes
 api = make_observatory_api()
 workflow_type = api.get_workflow_type(type_id=WorkflowTypes.google_analytics)
-telescopes = api.get_telescopes(workflow_type_id=workflow_type.id, limit=1000)
+workflows = api.get_workflows(workflow_type_id=workflow_type.id, limit=1000)
 
-# Make all telescopes
-for telescope in telescopes:
-    view_id = telescope.extra.get("view_id")
-    pagepath_regex = telescope.extra.get("pagepath_regex")
-    workflow = GoogleAnalyticsTelescope(telescope.organisation, view_id, pagepath_regex, workflow_id=telescope.id)
+# Make all workflows
+for workflow in workflows:
+    view_id = workflow.extra.get("view_id")
+    pagepath_regex = workflow.extra.get("pagepath_regex")
+    workflow = GoogleAnalyticsTelescope(workflow.organisation, view_id, pagepath_regex, workflow_id=workflow.id)
     globals()[workflow.dag_id] = workflow.make_dag()

--- a/oaebu_workflows/dags/google_analytics_telescope.py
+++ b/oaebu_workflows/dags/google_analytics_telescope.py
@@ -17,7 +17,7 @@
 # The keywords airflow and DAG are required to load the DAGs from this file, see bullet 2 in the Apache Airflow FAQ:
 # https://airflow.apache.org/docs/stable/faq.html
 
-from oaebu_workflows.identifiers import TelescopeTypes
+from oaebu_workflows.identifiers import WorkflowTypes
 from oaebu_workflows.workflows.google_analytics_telescope import (
     GoogleAnalyticsTelescope,
 )
@@ -25,8 +25,8 @@ from observatory.platform.utils.api import make_observatory_api
 
 # Fetch all telescopes
 api = make_observatory_api()
-telescope_type = api.get_telescope_type(type_id=TelescopeTypes.google_analytics)
-telescopes = api.get_telescopes(telescope_type_id=telescope_type.id, limit=1000)
+workflow_type = api.get_workflow_type(type_id=WorkflowTypes.google_analytics)
+telescopes = api.get_telescopes(workflow_type_id=workflow_type.id, limit=1000)
 
 # Make all telescopes
 for telescope in telescopes:

--- a/oaebu_workflows/dags/google_books_telescope.py
+++ b/oaebu_workflows/dags/google_books_telescope.py
@@ -29,5 +29,5 @@ telescopes = api.get_telescopes(telescope_type_id=telescope_type.id, limit=1000)
 # Make all telescopes
 for telescope in telescopes:
     accounts = telescope.extra.get("accounts") if telescope.extra else None
-    workflow = GoogleBooksTelescope(telescope.organisation, accounts)
+    workflow = GoogleBooksTelescope(telescope.organisation, accounts, workflow_id=telescope.id)
     globals()[workflow.dag_id] = workflow.make_dag()

--- a/oaebu_workflows/dags/google_books_telescope.py
+++ b/oaebu_workflows/dags/google_books_telescope.py
@@ -17,14 +17,14 @@
 # The keywords airflow and DAG are required to load the DAGs from this file, see bullet 2 in the Apache Airflow FAQ:
 # https://airflow.apache.org/docs/stable/faq.html
 
-from oaebu_workflows.identifiers import TelescopeTypes
+from oaebu_workflows.identifiers import WorkflowTypes
 from oaebu_workflows.workflows.google_books_telescope import GoogleBooksTelescope
 from observatory.platform.utils.api import make_observatory_api
 
 # Fetch all telescopes
 api = make_observatory_api()
-telescope_type = api.get_telescope_type(type_id=TelescopeTypes.google_books)
-telescopes = api.get_telescopes(telescope_type_id=telescope_type.id, limit=1000)
+workflow_type = api.get_workflow_type(type_id=WorkflowTypes.google_books)
+telescopes = api.get_telescopes(workflow_type_id=workflow_type.id, limit=1000)
 
 # Make all telescopes
 for telescope in telescopes:

--- a/oaebu_workflows/dags/google_books_telescope.py
+++ b/oaebu_workflows/dags/google_books_telescope.py
@@ -21,13 +21,13 @@ from oaebu_workflows.identifiers import WorkflowTypes
 from oaebu_workflows.workflows.google_books_telescope import GoogleBooksTelescope
 from observatory.platform.utils.api import make_observatory_api
 
-# Fetch all telescopes
+# Fetch all workflows
 api = make_observatory_api()
 workflow_type = api.get_workflow_type(type_id=WorkflowTypes.google_books)
-telescopes = api.get_telescopes(workflow_type_id=workflow_type.id, limit=1000)
+workflows = api.get_workflows(workflow_type_id=workflow_type.id, limit=1000)
 
-# Make all telescopes
-for telescope in telescopes:
-    accounts = telescope.extra.get("accounts") if telescope.extra else None
-    workflow = GoogleBooksTelescope(telescope.organisation, accounts, workflow_id=telescope.id)
+# Make all workflows
+for workflow in workflows:
+    accounts = workflow.extra.get("accounts") if workflow.extra else None
+    workflow = GoogleBooksTelescope(workflow.organisation, accounts, workflow_id=workflow.id)
     globals()[workflow.dag_id] = workflow.make_dag()

--- a/oaebu_workflows/dags/jstor_telescope.py
+++ b/oaebu_workflows/dags/jstor_telescope.py
@@ -28,5 +28,5 @@ telescopes = api.get_telescopes(telescope_type_id=telescope_type.id, limit=1000)
 
 # Make all telescopes
 for telescope in telescopes:
-    workflow = JstorTelescope(telescope.organisation, telescope.extra.get("publisher_id"))
+    workflow = JstorTelescope(telescope.organisation, telescope.extra.get("publisher_id"), workflow_id=telescope.id)
     globals()[workflow.dag_id] = workflow.make_dag()

--- a/oaebu_workflows/dags/jstor_telescope.py
+++ b/oaebu_workflows/dags/jstor_telescope.py
@@ -21,12 +21,12 @@ from oaebu_workflows.identifiers import WorkflowTypes
 from oaebu_workflows.workflows.jstor_telescope import JstorTelescope
 from observatory.platform.utils.api import make_observatory_api
 
-# Fetch all telescopes
+# Fetch all workflows
 api = make_observatory_api()
 workflow_type = api.get_workflow_type(type_id=WorkflowTypes.jstor)
-telescopes = api.get_telescopes(workflow_type_id=workflow_type.id, limit=1000)
+workflows = api.get_workflows(workflow_type_id=workflow_type.id, limit=1000)
 
-# Make all telescopes
-for telescope in telescopes:
-    workflow = JstorTelescope(telescope.organisation, telescope.extra.get("publisher_id"), workflow_id=telescope.id)
+# Make all workflows
+for workflow in workflows:
+    workflow = JstorTelescope(workflow.organisation, workflow.extra.get("publisher_id"), workflow_id=workflow.id)
     globals()[workflow.dag_id] = workflow.make_dag()

--- a/oaebu_workflows/dags/jstor_telescope.py
+++ b/oaebu_workflows/dags/jstor_telescope.py
@@ -17,14 +17,14 @@
 # The keywords airflow and DAG are required to load the DAGs from this file, see bullet 2 in the Apache Airflow FAQ:
 # https://airflow.apache.org/docs/stable/faq.html
 
-from oaebu_workflows.identifiers import TelescopeTypes
+from oaebu_workflows.identifiers import WorkflowTypes
 from oaebu_workflows.workflows.jstor_telescope import JstorTelescope
 from observatory.platform.utils.api import make_observatory_api
 
 # Fetch all telescopes
 api = make_observatory_api()
-telescope_type = api.get_telescope_type(type_id=TelescopeTypes.jstor)
-telescopes = api.get_telescopes(telescope_type_id=telescope_type.id, limit=1000)
+workflow_type = api.get_workflow_type(type_id=WorkflowTypes.jstor)
+telescopes = api.get_telescopes(workflow_type_id=workflow_type.id, limit=1000)
 
 # Make all telescopes
 for telescope in telescopes:

--- a/oaebu_workflows/dags/oapen_irus_uk_telescope.py
+++ b/oaebu_workflows/dags/oapen_irus_uk_telescope.py
@@ -32,5 +32,6 @@ for telescope in telescopes:
         telescope.organisation,
         telescope.extra.get("publisher_name_v4", ""),
         telescope.extra.get("publisher_uuid_v5", ""),
+        workflow_id=1,
     )
     globals()[workflow.dag_id] = workflow.make_dag()

--- a/oaebu_workflows/dags/oapen_irus_uk_telescope.py
+++ b/oaebu_workflows/dags/oapen_irus_uk_telescope.py
@@ -17,14 +17,14 @@
 # The keywords airflow and DAG are required to load the DAGs from this file, see bullet 2 in the Apache Airflow FAQ:
 # https://airflow.apache.org/docs/stable/faq.html
 
-from oaebu_workflows.identifiers import TelescopeTypes
+from oaebu_workflows.identifiers import WorkflowTypes
 from oaebu_workflows.workflows.oapen_irus_uk_telescope import OapenIrusUkTelescope
 from observatory.platform.utils.api import make_observatory_api
 
 # Fetch all telescopes
 api = make_observatory_api()
-telescope_type = api.get_telescope_type(type_id=TelescopeTypes.oapen_irus_uk)
-telescopes = api.get_telescopes(telescope_type_id=telescope_type.id, limit=1000)
+workflow_type = api.get_workflow_type(type_id=WorkflowTypes.oapen_irus_uk)
+telescopes = api.get_telescopes(workflow_type_id=workflow_type.id, limit=1000)
 
 # Make all telescopes
 for telescope in telescopes:

--- a/oaebu_workflows/dags/oapen_irus_uk_telescope.py
+++ b/oaebu_workflows/dags/oapen_irus_uk_telescope.py
@@ -21,17 +21,17 @@ from oaebu_workflows.identifiers import WorkflowTypes
 from oaebu_workflows.workflows.oapen_irus_uk_telescope import OapenIrusUkTelescope
 from observatory.platform.utils.api import make_observatory_api
 
-# Fetch all telescopes
+# Fetch all workflows
 api = make_observatory_api()
 workflow_type = api.get_workflow_type(type_id=WorkflowTypes.oapen_irus_uk)
-telescopes = api.get_telescopes(workflow_type_id=workflow_type.id, limit=1000)
+workflows = api.get_workflows(workflow_type_id=workflow_type.id, limit=1000)
 
-# Make all telescopes
-for telescope in telescopes:
+# Make all workflows
+for workflow in workflows:
     workflow = OapenIrusUkTelescope(
-        telescope.organisation,
-        telescope.extra.get("publisher_name_v4", ""),
-        telescope.extra.get("publisher_uuid_v5", ""),
+        workflow.organisation,
+        workflow.extra.get("publisher_name_v4", ""),
+        workflow.extra.get("publisher_uuid_v5", ""),
         workflow_id=1,
     )
     globals()[workflow.dag_id] = workflow.make_dag()

--- a/oaebu_workflows/dags/oapen_metadata_telescope.py
+++ b/oaebu_workflows/dags/oapen_metadata_telescope.py
@@ -19,11 +19,11 @@
 
 from oaebu_workflows.workflows.oapen_metadata_telescope import OapenMetadataTelescope
 from observatory.platform.utils.api import make_observatory_api
-from oaebu_workflows.identifiers import TelescopeTypes
+from oaebu_workflows.identifiers import WorkflowTypes
 
 # Fetch all telescopes
 api = make_observatory_api()
-telescope_type = api.get_telescope_type(type_id=TelescopeTypes.oapen_metadata)
-telescopes = api.get_telescopes(telescope_type_id=telescope_type.id, limit=1000)
+workflow_type = api.get_workflow_type(type_id=WorkflowTypes.oapen_metadata)
+telescopes = api.get_telescopes(workflow_type_id=workflow_type.id, limit=1000)
 workflow = OapenMetadataTelescope(workflow_id=telescopes[0].id)
 globals()[workflow.dag_id] = workflow.make_dag()

--- a/oaebu_workflows/dags/oapen_metadata_telescope.py
+++ b/oaebu_workflows/dags/oapen_metadata_telescope.py
@@ -21,9 +21,9 @@ from oaebu_workflows.workflows.oapen_metadata_telescope import OapenMetadataTele
 from observatory.platform.utils.api import make_observatory_api
 from oaebu_workflows.identifiers import WorkflowTypes
 
-# Fetch all telescopes
+# Fetch all workflows
 api = make_observatory_api()
 workflow_type = api.get_workflow_type(type_id=WorkflowTypes.oapen_metadata)
-telescopes = api.get_telescopes(workflow_type_id=workflow_type.id, limit=1000)
-workflow = OapenMetadataTelescope(workflow_id=telescopes[0].id)
+workflows = api.get_workflows(workflow_type_id=workflow_type.id, limit=1000)
+workflow = OapenMetadataTelescope(workflow_id=workflows[0].id)
 globals()[workflow.dag_id] = workflow.make_dag()

--- a/oaebu_workflows/dags/oapen_metadata_telescope.py
+++ b/oaebu_workflows/dags/oapen_metadata_telescope.py
@@ -18,6 +18,12 @@
 # https://airflow.apache.org/docs/stable/faq.html
 
 from oaebu_workflows.workflows.oapen_metadata_telescope import OapenMetadataTelescope
+from observatory.platform.utils.api import make_observatory_api
+from oaebu_workflows.identifiers import TelescopeTypes
 
-workflow = OapenMetadataTelescope()
+# Fetch all telescopes
+api = make_observatory_api()
+telescope_type = api.get_telescope_type(type_id=TelescopeTypes.oapen_metadata)
+telescopes = api.get_telescopes(telescope_type_id=telescope_type.id, limit=1000)
+workflow = OapenMetadataTelescope(workflow_id=telescopes[0].id)
 globals()[workflow.dag_id] = workflow.make_dag()

--- a/oaebu_workflows/dags/oapen_workflow.py
+++ b/oaebu_workflows/dags/oapen_workflow.py
@@ -21,10 +21,10 @@ from oaebu_workflows.workflows.oapen_workflow import OapenWorkflow
 from observatory.platform.utils.api import make_observatory_api
 from oaebu_workflows.identifiers import WorkflowTypes
 
-# Fetch all telescopes
+# Fetch all workflows
 api = make_observatory_api()
 workflow_type = api.get_workflow_type(type_id=WorkflowTypes.oapen_workflow)
-telescopes = api.get_telescopes(workflow_type_id=workflow_type.id, limit=1000)
+workflows = api.get_workflows(workflow_type_id=workflow_type.id, limit=1000)
 
-workflow = OapenWorkflow(workflow_id=telescopes[0].id)
+workflow = OapenWorkflow(workflow_id=workflows[0].id)
 globals()[workflow.dag_id] = workflow.make_dag()

--- a/oaebu_workflows/dags/oapen_workflow.py
+++ b/oaebu_workflows/dags/oapen_workflow.py
@@ -19,12 +19,12 @@
 
 from oaebu_workflows.workflows.oapen_workflow import OapenWorkflow
 from observatory.platform.utils.api import make_observatory_api
-from oaebu_workflows.identifiers import TelescopeTypes
+from oaebu_workflows.identifiers import WorkflowTypes
 
 # Fetch all telescopes
 api = make_observatory_api()
-telescope_type = api.get_telescope_type(type_id=TelescopeTypes.oapen_workflow)
-telescopes = api.get_telescopes(telescope_type_id=telescope_type.id, limit=1000)
+workflow_type = api.get_workflow_type(type_id=WorkflowTypes.oapen_workflow)
+telescopes = api.get_telescopes(workflow_type_id=workflow_type.id, limit=1000)
 
 workflow = OapenWorkflow(workflow_id=telescopes[0].id)
 globals()[workflow.dag_id] = workflow.make_dag()

--- a/oaebu_workflows/dags/oapen_workflow.py
+++ b/oaebu_workflows/dags/oapen_workflow.py
@@ -18,6 +18,13 @@
 # https://airflow.apache.org/docs/stable/faq.html
 
 from oaebu_workflows.workflows.oapen_workflow import OapenWorkflow
+from observatory.platform.utils.api import make_observatory_api
+from oaebu_workflows.identifiers import TelescopeTypes
 
-workflow = OapenWorkflow()
+# Fetch all telescopes
+api = make_observatory_api()
+telescope_type = api.get_telescope_type(type_id=TelescopeTypes.oapen_workflow)
+telescopes = api.get_telescopes(telescope_type_id=telescope_type.id, limit=1000)
+
+workflow = OapenWorkflow(workflow_id=telescopes[0].id)
 globals()[workflow.dag_id] = workflow.make_dag()

--- a/oaebu_workflows/dags/onix_telescope.py
+++ b/oaebu_workflows/dags/onix_telescope.py
@@ -21,21 +21,21 @@ from oaebu_workflows.identifiers import WorkflowTypes
 from oaebu_workflows.workflows.onix_telescope import OnixTelescope
 from observatory.platform.utils.api import make_observatory_api
 
-# Fetch all ONIX telescopes
+# Fetch all ONIX workflows
 api = make_observatory_api()
 workflow_type = api.get_workflow_type(type_id=WorkflowTypes.onix)
-telescopes = api.get_telescopes(workflow_type_id=workflow_type.id, limit=1000)
+workflows = api.get_workflows(workflow_type_id=workflow_type.id, limit=1000)
 
 # Make all ONIX telescopes
-for telescope in telescopes:
-    organisation = telescope.organisation
+for workflow in workflows:
+    organisation = workflow.organisation
     organisation_name = organisation.name
     project_id = organisation.gcp_project_id
     download_bucket = organisation.gcp_download_bucket
     transform_bucket = organisation.gcp_transform_bucket
     dataset_location = "us"
-    date_regex = telescope.extra.get("date_regex")
-    date_format = telescope.extra.get("date_format")
+    date_regex = workflow.extra.get("date_regex")
+    date_format = workflow.extra.get("date_format")
 
     workflow = OnixTelescope(
         organisation_name=organisation_name,
@@ -45,6 +45,6 @@ for telescope in telescopes:
         dataset_location=dataset_location,
         date_regex=date_regex,
         date_format=date_format,
-        workflow_id=telescope.id,
+        workflow_id=workflow.id,
     )
     globals()[workflow.dag_id] = workflow.make_dag()

--- a/oaebu_workflows/dags/onix_telescope.py
+++ b/oaebu_workflows/dags/onix_telescope.py
@@ -45,5 +45,6 @@ for telescope in telescopes:
         dataset_location=dataset_location,
         date_regex=date_regex,
         date_format=date_format,
+        workflow_id=telescope.id,
     )
     globals()[workflow.dag_id] = workflow.make_dag()

--- a/oaebu_workflows/dags/onix_telescope.py
+++ b/oaebu_workflows/dags/onix_telescope.py
@@ -17,14 +17,14 @@
 # The keywords airflow and DAG are required to load the DAGs from this file, see bullet 2 in the Apache Airflow FAQ:
 # https://airflow.apache.org/docs/stable/faq.html
 
-from oaebu_workflows.identifiers import TelescopeTypes
+from oaebu_workflows.identifiers import WorkflowTypes
 from oaebu_workflows.workflows.onix_telescope import OnixTelescope
 from observatory.platform.utils.api import make_observatory_api
 
 # Fetch all ONIX telescopes
 api = make_observatory_api()
-telescope_type = api.get_telescope_type(type_id=TelescopeTypes.onix)
-telescopes = api.get_telescopes(telescope_type_id=telescope_type.id, limit=1000)
+workflow_type = api.get_workflow_type(type_id=WorkflowTypes.onix)
+telescopes = api.get_telescopes(workflow_type_id=workflow_type.id, limit=1000)
 
 # Make all ONIX telescopes
 for telescope in telescopes:

--- a/oaebu_workflows/dags/onix_workflow.py
+++ b/oaebu_workflows/dags/onix_workflow.py
@@ -120,7 +120,7 @@ def get_oaebu_partner_data(organisation_id: int) -> List[OaebuPartner]:
 
             partners.append(
                 OaebuPartner(
-                    name=dataset.name,
+                    name=dataset.dataset_type.type_id,
                     dag_id_prefix=workflow.workflow_type.type_id,
                     gcp_project_id=gcp_project_id,
                     gcp_dataset_id=gcp_dataset_id,

--- a/oaebu_workflows/dags/onix_workflow.py
+++ b/oaebu_workflows/dags/onix_workflow.py
@@ -20,7 +20,7 @@
 from typing import List, Tuple
 
 from airflow.exceptions import AirflowException
-from oaebu_workflows.identifiers import TelescopeTypes
+from oaebu_workflows.identifiers import WorkflowTypes
 from oaebu_workflows.workflows.oaebu_partners import OaebuPartner
 from oaebu_workflows.workflows.onix_workflow import OnixWorkflow
 from observatory.api.client.model.dataset import Dataset
@@ -122,7 +122,7 @@ def get_oaebu_partner_data(organisation_id: int) -> List[OaebuPartner]:
             partners.append(
                 OaebuPartner(
                     name=dataset.name,
-                    dag_id_prefix=telescope.telescope_type.type_id,
+                    dag_id_prefix=telescope.workflow_type.type_id,
                     gcp_project_id=gcp_project_id,
                     gcp_dataset_id=gcp_dataset_id,
                     gcp_table_id=gcp_table_id,
@@ -137,8 +137,8 @@ def get_oaebu_partner_data(organisation_id: int) -> List[OaebuPartner]:
 
 # Fetch all ONIX telescopes
 api = make_observatory_api()
-telescope_type = api.get_telescope_type(type_id=TelescopeTypes.onix)
-telescopes = api.get_telescopes(telescope_type_id=telescope_type.id, limit=1000)
+workflow_type = api.get_workflow_type(type_id=WorkflowTypes.onix)
+telescopes = api.get_telescopes(workflow_type_id=workflow_type.id, limit=1000)
 
 # Create workflows for each organisation
 for telescope in telescopes:

--- a/oaebu_workflows/dags/onix_workflow.py
+++ b/oaebu_workflows/dags/onix_workflow.py
@@ -24,23 +24,22 @@ from oaebu_workflows.identifiers import WorkflowTypes
 from oaebu_workflows.workflows.oaebu_partners import OaebuPartner
 from oaebu_workflows.workflows.onix_workflow import OnixWorkflow
 from observatory.api.client.model.dataset import Dataset
-from observatory.api.client.model.dataset_release import DatasetRelease
-from observatory.api.client.model.telescope import Telescope
+from observatory.api.client.model.workflow import Workflow
 from observatory.platform.utils.api import make_observatory_api
 import json
 
 
-def is_oaebu_telescope(telescope: Telescope) -> bool:
-    """Determine whether a telescope is an OAEBU telescope.
+def is_oaebu_telescope(workflow: Workflow) -> bool:
+    """Determine whether a workflow is an OAEBU telescope.
 
-    :param telescope: Telescope to check.
-    :return: Whether the telescope is used for OAEBU.
+    :param workflow: workflow to check.
+    :return: Whether the workflow is used for OAEBU.
     """
 
-    if telescope.tags is None:
+    if workflow.tags is None:
         return False
 
-    tags = json.loads(telescope.tags)
+    tags = json.loads(workflow.tags)
     return "oaebu" in tags
 
 
@@ -108,21 +107,21 @@ def get_oaebu_partner_data(organisation_id: int) -> List[OaebuPartner]:
     :return: List of OAEBU partner dataset information.
     """
 
-    telescopes = api.get_telescopes(organisation_id=organisation_id, limit=1000)
+    workflows = api.get_workflows(organisation_id=organisation_id, limit=1000)
     partners = list()
 
-    for telescope in telescopes:
-        if not is_oaebu_telescope(telescope):
+    for workflow in workflows:
+        if not is_oaebu_telescope(workflow):
             continue
 
-        datasets = api.get_datasets(telescope_id=telescope.id, limit=1000)
+        datasets = api.get_datasets(workflow_id=workflow.id, limit=1000)
         for dataset in datasets:
             gcp_project_id, gcp_dataset_id, gcp_table_id = get_gcp_address(dataset)
 
             partners.append(
                 OaebuPartner(
                     name=dataset.name,
-                    dag_id_prefix=telescope.workflow_type.type_id,
+                    dag_id_prefix=workflow.workflow_type.type_id,
                     gcp_project_id=gcp_project_id,
                     gcp_dataset_id=gcp_dataset_id,
                     gcp_table_id=gcp_table_id,
@@ -138,21 +137,21 @@ def get_oaebu_partner_data(organisation_id: int) -> List[OaebuPartner]:
 # Fetch all ONIX telescopes
 api = make_observatory_api()
 workflow_type = api.get_workflow_type(type_id=WorkflowTypes.onix)
-telescopes = api.get_telescopes(workflow_type_id=workflow_type.id, limit=1000)
+workflows = api.get_workflows(workflow_type_id=workflow_type.id, limit=1000)
 
 # Create workflows for each organisation
-for telescope in telescopes:
-    org_name = telescope.organisation.name
-    gcp_project_id = telescope.organisation.gcp_project_id
-    gcp_bucket_name = telescope.organisation.gcp_transform_bucket
-    data_partners = get_oaebu_partner_data(telescope.organisation.id)
+for workflow in workflows:
+    org_name = workflow.organisation.name
+    gcp_project_id = workflow.organisation.gcp_project_id
+    gcp_bucket_name = workflow.organisation.gcp_transform_bucket
+    data_partners = get_oaebu_partner_data(workflow.organisation.id)
 
     workflow = OnixWorkflow(
         org_name=org_name,
         gcp_project_id=gcp_project_id,
         gcp_bucket_name=gcp_bucket_name,
         data_partners=data_partners,
-        workflow_id=telescope.id,
+        workflow_id=workflow.id,
     )
 
     globals()[workflow.dag_id] = workflow.make_dag()

--- a/oaebu_workflows/dags/onix_workflow.py
+++ b/oaebu_workflows/dags/onix_workflow.py
@@ -120,7 +120,7 @@ def get_oaebu_partner_data(organisation_id: int) -> List[OaebuPartner]:
 
             partners.append(
                 OaebuPartner(
-                    name=dataset.dataset_type.type_id,
+                    dataset_type_id=dataset.dataset_type.type_id,
                     dag_id_prefix=workflow.workflow_type.type_id,
                     gcp_project_id=gcp_project_id,
                     gcp_dataset_id=gcp_dataset_id,

--- a/oaebu_workflows/dags/ucl_discovery_telescope.py
+++ b/oaebu_workflows/dags/ucl_discovery_telescope.py
@@ -17,14 +17,14 @@
 # The keywords airflow and DAG are required to load the DAGs from this file, see bullet 2 in the Apache Airflow FAQ:
 # https://airflow.apache.org/docs/stable/faq.html
 
-from oaebu_workflows.identifiers import TelescopeTypes
+from oaebu_workflows.identifiers import WorkflowTypes
 from oaebu_workflows.workflows.ucl_discovery_telescope import UclDiscoveryTelescope
 from observatory.platform.utils.api import make_observatory_api
 
 # Fetch all telescopes
 api = make_observatory_api()
-telescope_type = api.get_telescope_type(type_id=TelescopeTypes.ucl_discovery)
-telescopes = api.get_telescopes(telescope_type_id=telescope_type.id, limit=1000)
+workflow_type = api.get_workflow_type(type_id=WorkflowTypes.ucl_discovery)
+telescopes = api.get_telescopes(workflow_type_id=workflow_type.id, limit=1000)
 
 # Make all telescopes
 for telescope in telescopes:

--- a/oaebu_workflows/dags/ucl_discovery_telescope.py
+++ b/oaebu_workflows/dags/ucl_discovery_telescope.py
@@ -28,5 +28,5 @@ telescopes = api.get_telescopes(telescope_type_id=telescope_type.id, limit=1000)
 
 # Make all telescopes
 for telescope in telescopes:
-    workflow = UclDiscoveryTelescope(telescope.organisation)
+    workflow = UclDiscoveryTelescope(telescope.organisation, workflow_id=telescope.id)
     globals()[workflow.dag_id] = workflow.make_dag()

--- a/oaebu_workflows/dags/ucl_discovery_telescope.py
+++ b/oaebu_workflows/dags/ucl_discovery_telescope.py
@@ -21,12 +21,12 @@ from oaebu_workflows.identifiers import WorkflowTypes
 from oaebu_workflows.workflows.ucl_discovery_telescope import UclDiscoveryTelescope
 from observatory.platform.utils.api import make_observatory_api
 
-# Fetch all telescopes
+# Fetch all workflows
 api = make_observatory_api()
 workflow_type = api.get_workflow_type(type_id=WorkflowTypes.ucl_discovery)
-telescopes = api.get_telescopes(workflow_type_id=workflow_type.id, limit=1000)
+workflows = api.get_workflows(workflow_type_id=workflow_type.id, limit=1000)
 
-# Make all telescopes
-for telescope in telescopes:
-    workflow = UclDiscoveryTelescope(telescope.organisation, workflow_id=telescope.id)
+# Make all workflows
+for workflow in workflows:
+    workflow = UclDiscoveryTelescope(workflow.organisation, workflow_id=workflow.id)
     globals()[workflow.dag_id] = workflow.make_dag()

--- a/oaebu_workflows/identifiers.py
+++ b/oaebu_workflows/identifiers.py
@@ -22,6 +22,7 @@ class TelescopeTypes:
     google_books = "google_books"
     jstor = "jstor"
     oapen_irus_uk = "oapen_irus_uk"
+    oapen_metadata = "oapen_metadata"
     onix = "onix"
     onix_workflow = "onix_workflow"
     ucl_discovery = "ucl_discovery"

--- a/oaebu_workflows/identifiers.py
+++ b/oaebu_workflows/identifiers.py
@@ -26,3 +26,4 @@ class TelescopeTypes:
     onix = "onix"
     onix_workflow = "onix_workflow"
     ucl_discovery = "ucl_discovery"
+    doab = "doab"

--- a/oaebu_workflows/identifiers.py
+++ b/oaebu_workflows/identifiers.py
@@ -15,8 +15,8 @@
 # Author: James Diprose
 
 
-class TelescopeTypes:
-    """The type_id's for known TelescopeTypes"""
+class WorkflowTypes:
+    """The type_id's for known WorkflowTypes"""
 
     google_analytics = "google_analytics"
     google_books = "google_books"

--- a/oaebu_workflows/identifiers.py
+++ b/oaebu_workflows/identifiers.py
@@ -27,3 +27,4 @@ class TelescopeTypes:
     onix_workflow = "onix_workflow"
     ucl_discovery = "ucl_discovery"
     doab = "doab"
+    oapen_workflow = "oapen_workflow"

--- a/oaebu_workflows/workflows/google_books_telescope.py
+++ b/oaebu_workflows/workflows/google_books_telescope.py
@@ -170,6 +170,7 @@ class GoogleBooksTelescope(OrganisationTelescope):
         catchup: bool = False,
         airflow_vars=None,
         airflow_conns=None,
+        workflow_id: int = None,
     ):
         """Construct a GoogleBooksTelescope instance.
 
@@ -182,6 +183,7 @@ class GoogleBooksTelescope(OrganisationTelescope):
         :param catchup: whether to catchup the DAG or not.
         :param airflow_vars: list of airflow variable keys, for each variable it is checked if it exists in airflow
         :param airflow_conns: list of airflow connection keys, for each connection it is checked if it exists in airflow
+        :param workflow_id: api workflow id.
         """
         if airflow_vars is None:
             airflow_vars = [
@@ -207,6 +209,7 @@ class GoogleBooksTelescope(OrganisationTelescope):
             catchup=catchup,
             airflow_vars=airflow_vars,
             airflow_conns=airflow_conns,
+            workflow_id=workflow_id,
         )
         self.sftp_folders = SftpFolders(dag_id, organisation.name)
         self.sftp_regex = r"^Google(SalesTransaction|BooksTraffic)Report_\d{4}_\d{2}.csv$"
@@ -230,6 +233,7 @@ class GoogleBooksTelescope(OrganisationTelescope):
                 self.bq_load_partition,
                 self.move_files_to_finished,
                 self.cleanup,
+                self.add_new_dataset_releases,
             ]
         )
 

--- a/oaebu_workflows/workflows/oaebu_partners.py
+++ b/oaebu_workflows/workflows/oaebu_partners.py
@@ -21,9 +21,9 @@ from dataclasses import dataclass
 
 @dataclass
 class OaebuPartner:
-    """Temporary class for storing information about data sources we are using to produce oaebu intermediate tables for.  Change or remove this later when Observatory API is more mature.
+    """Class for storing information about data sources we are using to produce oaebu intermediate tables for.
 
-    :param name: Name of the data partner.
+    :param dataset_type_id: the dataset type id.
     :param dag_id_prefix: The prefix of the DAG id that the data originates from.
     :param gcp_project_id: GCP Project ID.
     :param gcp_dataset_id: GCP Dataset ID.
@@ -33,7 +33,7 @@ class OaebuPartner:
     :param sharded: whether the table is sharded or not.
     """
 
-    name: str
+    dataset_type_id: str
     dag_id_prefix: str
     gcp_project_id: str
     gcp_dataset_id: str

--- a/oaebu_workflows/workflows/oaebu_partners.py
+++ b/oaebu_workflows/workflows/oaebu_partners.py
@@ -19,18 +19,6 @@
 from dataclasses import dataclass
 
 
-class OaebuDatasetType:
-    """OAEBU partner name constants."""
-
-    google_analytics = "google_analytics"
-    google_books_sales = "google_books_sales"
-    google_books_traffic = "google_books_traffic"
-    jstor_country = "jstor_country"
-    jstor_institution = "jstor_institution"
-    oapen_irus_uk = "oapen_irus_uk"
-    ucl_discovery = "ucl_discovery"
-
-
 @dataclass
 class OaebuPartner:
     """Temporary class for storing information about data sources we are using to produce oaebu intermediate tables for.  Change or remove this later when Observatory API is more mature.

--- a/oaebu_workflows/workflows/oaebu_partners.py
+++ b/oaebu_workflows/workflows/oaebu_partners.py
@@ -19,16 +19,16 @@
 from dataclasses import dataclass
 
 
-class OaebuPartnerName:
+class OaebuDatasetType:
     """OAEBU partner name constants."""
 
-    google_analytics = "Google Analytics"
-    google_books_sales = "Google Books Sales"
-    google_books_traffic = "Google Books Traffic"
-    jstor_country = "JSTOR Country"
-    jstor_institution = "JSTOR Institution"
-    oapen_irus_uk = "OAPEN IRUS UK"
-    ucl_discovery = "UCL Discovery"
+    google_analytics = "google_analytics"
+    google_books_sales = "google_books_sales"
+    google_books_traffic = "google_books_traffic"
+    jstor_country = "jstor_country"
+    jstor_institution = "jstor_institution"
+    oapen_irus_uk = "oapen_irus_uk"
+    ucl_discovery = "ucl_discovery"
 
 
 @dataclass

--- a/oaebu_workflows/workflows/oapen_irus_uk_telescope.py
+++ b/oaebu_workflows/workflows/oapen_irus_uk_telescope.py
@@ -243,6 +243,7 @@ class OapenIrusUkTelescope(OrganisationTelescope):
         airflow_conns: List = None,
         max_active_runs=5,
         max_cloud_function_instances: int = 0,
+        workflow_id: int = None,
     ):
 
         """The OAPEN irus uk telescope.
@@ -260,6 +261,7 @@ class OapenIrusUkTelescope(OrganisationTelescope):
         :param airflow_vars: list of airflow variable keys, for each variable it is checked if it exists in airflow.
         :param airflow_conns: list of airflow connection keys, for each connection it is checked if it exists in airflow
         :param max_cloud_function_instances: the maximum cloud function instances.
+        :param workflow_id: api workflow id.
         """
 
         if airflow_vars is None:
@@ -301,6 +303,7 @@ class OapenIrusUkTelescope(OrganisationTelescope):
             airflow_vars=airflow_vars,
             airflow_conns=airflow_conns,
             max_active_runs=max_active_runs,
+            workflow_id=workflow_id,
             table_descriptions=table_descriptions,
         )
         self.max_cloud_function_instances = max_cloud_function_instances
@@ -316,6 +319,7 @@ class OapenIrusUkTelescope(OrganisationTelescope):
         self.add_task(self.upload_transformed)
         self.add_task(self.bq_load_partition)
         self.add_task(self.cleanup)
+        self.add_task(self.add_new_dataset_releases)
 
     def make_release(self, **kwargs) -> List[OapenIrusUkRelease]:
         """Create a list of OapenIrusUkRelease instances for a given month.

--- a/oaebu_workflows/workflows/oapen_workflow.py
+++ b/oaebu_workflows/workflows/oapen_workflow.py
@@ -97,6 +97,7 @@ class OapenWorkflow(Workflow):
         schedule_interval: Optional[str] = "@weekly",
         catchup: Optional[bool] = False,
         airflow_vars: List = None,
+        workflow_id: int = None,
     ):
         """Initialises the workflow object.
         :param ao_gcp_project_id: GCP project ID for the Academic Observatory.
@@ -115,6 +116,7 @@ class OapenWorkflow(Workflow):
         :param schedule_interval: Scheduled interval for running the DAG.
         :param catchup: Whether to catch up missed DAG runs.
         :param airflow_vars: list of airflow variable keys, for each variable it is checked if it exists in airflow.
+        :param workflow_id: api workflow id.
         """
 
         self.dag_id = dag_id
@@ -165,6 +167,7 @@ class OapenWorkflow(Workflow):
             schedule_interval=schedule_interval,
             catchup=catchup,
             airflow_vars=airflow_vars,
+            workflow_id=workflow_id,
         )
 
         with self.parallel_tasks():
@@ -206,6 +209,9 @@ class OapenWorkflow(Workflow):
 
         # Cleanup tasks
         self.add_task(self.cleanup)
+
+        # DatasetRelease creation
+        self.add_task(self.add_new_dataset_releases)
 
     def make_release(self, **kwargs) -> OapenWorkflowRelease:
         """Creates a release object.

--- a/oaebu_workflows/workflows/onix_telescope.py
+++ b/oaebu_workflows/workflows/onix_telescope.py
@@ -220,6 +220,7 @@ class OnixTelescope(SnapshotTelescope):
         catchup: bool = False,
         airflow_vars: List = None,
         airflow_conns: List = None,
+        workflow_id: int = None,
     ):
         """Construct an OnixTelescope instance.
 
@@ -241,6 +242,7 @@ class OnixTelescope(SnapshotTelescope):
         :param catchup: whether to catchup the DAG or not.
         :param airflow_vars: list of airflow variable keys, for each variable, it is checked if it exists in airflow.
         :param airflow_conns: list of airflow connection keys, for each connection, it is checked if it exists in airflow.
+        :param workflow_id: api workflow id.
         """
 
         if airflow_vars is None:
@@ -278,6 +280,7 @@ class OnixTelescope(SnapshotTelescope):
             catchup=catchup,
             airflow_vars=airflow_vars,
             airflow_conns=airflow_conns,
+            workflow_id=workflow_id,
         )
 
         # self.organisation = organisation
@@ -291,6 +294,7 @@ class OnixTelescope(SnapshotTelescope):
         self.add_task(self.bq_load)
         self.add_task(self.move_files_to_finished)
         self.add_task(self.cleanup)
+        self.add_task(self.add_new_dataset_releases)
 
     def list_release_info(self, **kwargs):
         """Lists all ONIX releases and publishes their file names as an XCom.

--- a/oaebu_workflows/workflows/onix_workflow.py
+++ b/oaebu_workflows/workflows/onix_workflow.py
@@ -233,6 +233,7 @@ class OnixWorkflow(Workflow):
         schedule_interval: Optional[str] = "@weekly",
         catchup: Optional[bool] = False,
         data_partners: List[OaebuPartner] = None,
+        workflow_id: int = None,
     ):
         """Initialises the workflow object.
         :param org_name: Organisation name.
@@ -246,6 +247,7 @@ class OnixWorkflow(Workflow):
         :param schedule_interval: Scheduled interval for running the DAG.
         :param catchup: Whether to catch up missed DAG runs.
         :param data_partners: OAEBU data sources.
+        :param workflow_id: api workflow id.
         """
 
         self.dag_id = dag_id
@@ -271,7 +273,11 @@ class OnixWorkflow(Workflow):
 
         # Initialise Telesecope base class
         super().__init__(
-            dag_id=self.dag_id, start_date=start_date, schedule_interval=schedule_interval, catchup=catchup
+            dag_id=self.dag_id,
+            start_date=start_date,
+            schedule_interval=schedule_interval,
+            catchup=catchup,
+            workflow_id=workflow_id,
         )
 
         # Wait for data partner workflows to finish
@@ -312,6 +318,9 @@ class OnixWorkflow(Workflow):
 
         # Cleanup tasks
         self.add_task(self.cleanup)
+
+        # Create DatasetRelease records
+        self.add_task(self.add_new_dataset_releases)
 
     def get_isbn_utils_sql_string(self) -> str:
         """Load the ISBN utils sql functions.

--- a/oaebu_workflows/workflows/onix_workflow.py
+++ b/oaebu_workflows/workflows/onix_workflow.py
@@ -27,7 +27,7 @@ from airflow.exceptions import AirflowException
 from google.cloud.bigquery import SourceFormat
 from oaebu_workflows.config import schema_folder as default_schema_folder
 from oaebu_workflows.config import sql_folder
-from oaebu_workflows.workflows.oaebu_partners import OaebuPartner, OaebuPartnerName
+from oaebu_workflows.workflows.oaebu_partners import OaebuPartner, OaebuDatasetType
 from oaebu_workflows.workflows.onix_telescope import OnixTelescope
 from oaebu_workflows.workflows.onix_work_aggregation import (
     BookWorkAggregator,
@@ -714,16 +714,16 @@ class OnixWorkflow(Workflow):
         # Book Product
         fn = partial(
             self.create_oaebu_book_product_table,
-            include_google_analytics=OaebuPartnerName.google_analytics in data_partner_datasets,
-            include_google_books=OaebuPartnerName.google_books_traffic in data_partner_datasets,
-            include_jstor=OaebuPartnerName.jstor_country in data_partner_datasets,
-            include_oapen=OaebuPartnerName.oapen_irus_uk in data_partner_datasets,
-            include_ucl=OaebuPartnerName.ucl_discovery in data_partner_datasets,
-            google_analytics_dataset=data_partner_datasets.get(OaebuPartnerName.google_analytics, None),
-            google_books_dataset=data_partner_datasets.get(OaebuPartnerName.google_books_traffic, None),
-            jstor_dataset=data_partner_datasets.get(OaebuPartnerName.jstor_country, None),
-            oapen_dataset=data_partner_datasets.get(OaebuPartnerName.oapen_irus_uk, None),
-            ucl_dataset=data_partner_datasets.get(OaebuPartnerName.ucl_discovery, None),
+            include_google_analytics=OaebuDatasetType.google_analytics in data_partner_datasets,
+            include_google_books=OaebuDatasetType.google_books_traffic in data_partner_datasets,
+            include_jstor=OaebuDatasetType.jstor_country in data_partner_datasets,
+            include_oapen=OaebuDatasetType.oapen_irus_uk in data_partner_datasets,
+            include_ucl=OaebuDatasetType.ucl_discovery in data_partner_datasets,
+            google_analytics_dataset=data_partner_datasets.get(OaebuDatasetType.google_analytics, None),
+            google_books_dataset=data_partner_datasets.get(OaebuDatasetType.google_books_traffic, None),
+            jstor_dataset=data_partner_datasets.get(OaebuDatasetType.jstor_country, None),
+            oapen_dataset=data_partner_datasets.get(OaebuDatasetType.oapen_irus_uk, None),
+            ucl_dataset=data_partner_datasets.get(OaebuDatasetType.ucl_discovery, None),
         )
 
         # Populate the __name__ attribute of the partial object (it lacks one by default).
@@ -957,21 +957,21 @@ class OnixWorkflow(Workflow):
         # Export QA Metrics
         fn = partial(
             self.export_oaebu_qa_metrics,
-            include_google_analytics=OaebuPartnerName.google_analytics in data_partner_tables,
-            include_google_books=OaebuPartnerName.google_books_traffic in data_partner_tables,
-            include_jstor=OaebuPartnerName.jstor_country in data_partner_tables,
-            include_oapen=OaebuPartnerName.oapen_irus_uk in data_partner_tables,
-            include_ucl=OaebuPartnerName.ucl_discovery in data_partner_tables,
-            google_analytics_table=data_partner_tables.get(OaebuPartnerName.google_analytics, None),
-            google_books_table=data_partner_tables.get(OaebuPartnerName.google_books_traffic, None),
-            jstor_table=data_partner_tables.get(OaebuPartnerName.jstor_country, None),
-            oapen_table=data_partner_tables.get(OaebuPartnerName.oapen_irus_uk, None),
-            ucl_table=data_partner_tables.get(OaebuPartnerName.ucl_discovery, None),
-            google_analytics_isbn=data_partner_isbns.get(OaebuPartnerName.google_analytics, None),
-            google_books_isbn=data_partner_isbns.get(OaebuPartnerName.google_books_traffic, None),
-            jstor_isbn=data_partner_isbns.get(OaebuPartnerName.jstor_country, None),
-            oapen_isbn=data_partner_isbns.get(OaebuPartnerName.oapen_irus_uk, None),
-            ucl_isbn=data_partner_isbns.get(OaebuPartnerName.ucl_discovery, None),
+            include_google_analytics=OaebuDatasetType.google_analytics in data_partner_tables,
+            include_google_books=OaebuDatasetType.google_books_traffic in data_partner_tables,
+            include_jstor=OaebuDatasetType.jstor_country in data_partner_tables,
+            include_oapen=OaebuDatasetType.oapen_irus_uk in data_partner_tables,
+            include_ucl=OaebuDatasetType.ucl_discovery in data_partner_tables,
+            google_analytics_table=data_partner_tables.get(OaebuDatasetType.google_analytics, None),
+            google_books_table=data_partner_tables.get(OaebuDatasetType.google_books_traffic, None),
+            jstor_table=data_partner_tables.get(OaebuDatasetType.jstor_country, None),
+            oapen_table=data_partner_tables.get(OaebuDatasetType.oapen_irus_uk, None),
+            ucl_table=data_partner_tables.get(OaebuDatasetType.ucl_discovery, None),
+            google_analytics_isbn=data_partner_isbns.get(OaebuDatasetType.google_analytics, None),
+            google_books_isbn=data_partner_isbns.get(OaebuDatasetType.google_books_traffic, None),
+            jstor_isbn=data_partner_isbns.get(OaebuDatasetType.jstor_country, None),
+            oapen_isbn=data_partner_isbns.get(OaebuDatasetType.oapen_irus_uk, None),
+            ucl_isbn=data_partner_isbns.get(OaebuDatasetType.ucl_discovery, None),
         )
 
         # Populate the __name__ attribute of the partial object (it lacks one by default).
@@ -989,17 +989,17 @@ class OnixWorkflow(Workflow):
         for data_partner in data_partners:
 
             if (
-                data_partner.name == OaebuPartnerName.jstor_country
-                or data_partner.name == OaebuPartnerName.jstor_institution
+                data_partner.name == OaebuDatasetType.jstor_country
+                or data_partner.name == OaebuDatasetType.jstor_institution
             ):
                 self.create_oaebu_data_qa_jstor_tasks(data_partner)
-            elif data_partner.name == OaebuPartnerName.oapen_irus_uk:
+            elif data_partner.name == OaebuDatasetType.oapen_irus_uk:
                 self.create_oaebu_data_qa_oapen_irus_uk_tasks(data_partner)
-            elif data_partner.name == OaebuPartnerName.google_books_sales:
+            elif data_partner.name == OaebuDatasetType.google_books_sales:
                 self.create_oaebu_data_qa_google_books_sales_tasks(data_partner)
-            elif data_partner.name == OaebuPartnerName.google_books_traffic:
+            elif data_partner.name == OaebuDatasetType.google_books_traffic:
                 self.create_oaebu_data_qa_google_books_traffic_tasks(data_partner)
-            elif data_partner.name == OaebuPartnerName.google_analytics:
+            elif data_partner.name == OaebuDatasetType.google_analytics:
                 self.create_oaebu_data_qa_google_analytics_tasks(data_partner)
 
             self.create_oaebu_data_qa_intermediate_tasks(data_partner)

--- a/oaebu_workflows/workflows/onix_workflow.py
+++ b/oaebu_workflows/workflows/onix_workflow.py
@@ -710,7 +710,7 @@ class OnixWorkflow(Workflow):
         :param data_partners: List of oaebu partner data.
         """
 
-        data_partner_datasets = {data.name: data.gcp_dataset_id for data in data_partners}
+        data_partner_datasets = {data.dataset_type_id: data.gcp_dataset_id for data in data_partners}
 
         # Book Product
         fn = partial(
@@ -952,8 +952,8 @@ class OnixWorkflow(Workflow):
             self.add_task(fn)
 
         # Export QA Metrics
-        data_partner_tables = {data.name: data.gcp_table_id for data in data_partners}
-        data_partner_isbns = {data.name: data.isbn_field_name for data in data_partners}
+        data_partner_tables = {data.dataset_type_id: data.gcp_table_id for data in data_partners}
+        data_partner_isbns = {data.dataset_type_id: data.isbn_field_name for data in data_partners}
 
         # Export QA Metrics
         fn = partial(
@@ -990,17 +990,17 @@ class OnixWorkflow(Workflow):
         for data_partner in data_partners:
 
             if (
-                data_partner.name == DatasetTypeId.jstor_country
-                or data_partner.name == DatasetTypeId.jstor_institution
+                data_partner.dataset_type_id == DatasetTypeId.jstor_country
+                or data_partner.dataset_type_id == DatasetTypeId.jstor_institution
             ):
                 self.create_oaebu_data_qa_jstor_tasks(data_partner)
-            elif data_partner.name == DatasetTypeId.oapen_irus_uk:
+            elif data_partner.dataset_type_id == DatasetTypeId.oapen_irus_uk:
                 self.create_oaebu_data_qa_oapen_irus_uk_tasks(data_partner)
-            elif data_partner.name == DatasetTypeId.google_books_sales:
+            elif data_partner.dataset_type_id == DatasetTypeId.google_books_sales:
                 self.create_oaebu_data_qa_google_books_sales_tasks(data_partner)
-            elif data_partner.name == DatasetTypeId.google_books_traffic:
+            elif data_partner.dataset_type_id == DatasetTypeId.google_books_traffic:
                 self.create_oaebu_data_qa_google_books_traffic_tasks(data_partner)
-            elif data_partner.name == DatasetTypeId.google_analytics:
+            elif data_partner.dataset_type_id == DatasetTypeId.google_analytics:
                 self.create_oaebu_data_qa_google_analytics_tasks(data_partner)
 
             self.create_oaebu_data_qa_intermediate_tasks(data_partner)

--- a/oaebu_workflows/workflows/onix_workflow.py
+++ b/oaebu_workflows/workflows/onix_workflow.py
@@ -27,7 +27,8 @@ from airflow.exceptions import AirflowException
 from google.cloud.bigquery import SourceFormat
 from oaebu_workflows.config import schema_folder as default_schema_folder
 from oaebu_workflows.config import sql_folder
-from oaebu_workflows.workflows.oaebu_partners import OaebuPartner, OaebuDatasetType
+from oaebu_workflows.workflows.oaebu_partners import OaebuPartner
+from observatory.api.server.dataset_type import DatasetTypeId
 from oaebu_workflows.workflows.onix_telescope import OnixTelescope
 from oaebu_workflows.workflows.onix_work_aggregation import (
     BookWorkAggregator,
@@ -714,16 +715,16 @@ class OnixWorkflow(Workflow):
         # Book Product
         fn = partial(
             self.create_oaebu_book_product_table,
-            include_google_analytics=OaebuDatasetType.google_analytics in data_partner_datasets,
-            include_google_books=OaebuDatasetType.google_books_traffic in data_partner_datasets,
-            include_jstor=OaebuDatasetType.jstor_country in data_partner_datasets,
-            include_oapen=OaebuDatasetType.oapen_irus_uk in data_partner_datasets,
-            include_ucl=OaebuDatasetType.ucl_discovery in data_partner_datasets,
-            google_analytics_dataset=data_partner_datasets.get(OaebuDatasetType.google_analytics, None),
-            google_books_dataset=data_partner_datasets.get(OaebuDatasetType.google_books_traffic, None),
-            jstor_dataset=data_partner_datasets.get(OaebuDatasetType.jstor_country, None),
-            oapen_dataset=data_partner_datasets.get(OaebuDatasetType.oapen_irus_uk, None),
-            ucl_dataset=data_partner_datasets.get(OaebuDatasetType.ucl_discovery, None),
+            include_google_analytics=DatasetTypeId.google_analytics in data_partner_datasets,
+            include_google_books=DatasetTypeId.google_books_traffic in data_partner_datasets,
+            include_jstor=DatasetTypeId.jstor_country in data_partner_datasets,
+            include_oapen=DatasetTypeId.oapen_irus_uk in data_partner_datasets,
+            include_ucl=DatasetTypeId.ucl_discovery in data_partner_datasets,
+            google_analytics_dataset=data_partner_datasets.get(DatasetTypeId.google_analytics, None),
+            google_books_dataset=data_partner_datasets.get(DatasetTypeId.google_books_traffic, None),
+            jstor_dataset=data_partner_datasets.get(DatasetTypeId.jstor_country, None),
+            oapen_dataset=data_partner_datasets.get(DatasetTypeId.oapen_irus_uk, None),
+            ucl_dataset=data_partner_datasets.get(DatasetTypeId.ucl_discovery, None),
         )
 
         # Populate the __name__ attribute of the partial object (it lacks one by default).
@@ -957,21 +958,21 @@ class OnixWorkflow(Workflow):
         # Export QA Metrics
         fn = partial(
             self.export_oaebu_qa_metrics,
-            include_google_analytics=OaebuDatasetType.google_analytics in data_partner_tables,
-            include_google_books=OaebuDatasetType.google_books_traffic in data_partner_tables,
-            include_jstor=OaebuDatasetType.jstor_country in data_partner_tables,
-            include_oapen=OaebuDatasetType.oapen_irus_uk in data_partner_tables,
-            include_ucl=OaebuDatasetType.ucl_discovery in data_partner_tables,
-            google_analytics_table=data_partner_tables.get(OaebuDatasetType.google_analytics, None),
-            google_books_table=data_partner_tables.get(OaebuDatasetType.google_books_traffic, None),
-            jstor_table=data_partner_tables.get(OaebuDatasetType.jstor_country, None),
-            oapen_table=data_partner_tables.get(OaebuDatasetType.oapen_irus_uk, None),
-            ucl_table=data_partner_tables.get(OaebuDatasetType.ucl_discovery, None),
-            google_analytics_isbn=data_partner_isbns.get(OaebuDatasetType.google_analytics, None),
-            google_books_isbn=data_partner_isbns.get(OaebuDatasetType.google_books_traffic, None),
-            jstor_isbn=data_partner_isbns.get(OaebuDatasetType.jstor_country, None),
-            oapen_isbn=data_partner_isbns.get(OaebuDatasetType.oapen_irus_uk, None),
-            ucl_isbn=data_partner_isbns.get(OaebuDatasetType.ucl_discovery, None),
+            include_google_analytics=DatasetTypeId.google_analytics in data_partner_tables,
+            include_google_books=DatasetTypeId.google_books_traffic in data_partner_tables,
+            include_jstor=DatasetTypeId.jstor_country in data_partner_tables,
+            include_oapen=DatasetTypeId.oapen_irus_uk in data_partner_tables,
+            include_ucl=DatasetTypeId.ucl_discovery in data_partner_tables,
+            google_analytics_table=data_partner_tables.get(DatasetTypeId.google_analytics, None),
+            google_books_table=data_partner_tables.get(DatasetTypeId.google_books_traffic, None),
+            jstor_table=data_partner_tables.get(DatasetTypeId.jstor_country, None),
+            oapen_table=data_partner_tables.get(DatasetTypeId.oapen_irus_uk, None),
+            ucl_table=data_partner_tables.get(DatasetTypeId.ucl_discovery, None),
+            google_analytics_isbn=data_partner_isbns.get(DatasetTypeId.google_analytics, None),
+            google_books_isbn=data_partner_isbns.get(DatasetTypeId.google_books_traffic, None),
+            jstor_isbn=data_partner_isbns.get(DatasetTypeId.jstor_country, None),
+            oapen_isbn=data_partner_isbns.get(DatasetTypeId.oapen_irus_uk, None),
+            ucl_isbn=data_partner_isbns.get(DatasetTypeId.ucl_discovery, None),
         )
 
         # Populate the __name__ attribute of the partial object (it lacks one by default).
@@ -989,17 +990,17 @@ class OnixWorkflow(Workflow):
         for data_partner in data_partners:
 
             if (
-                data_partner.name == OaebuDatasetType.jstor_country
-                or data_partner.name == OaebuDatasetType.jstor_institution
+                data_partner.name == DatasetTypeId.jstor_country
+                or data_partner.name == DatasetTypeId.jstor_institution
             ):
                 self.create_oaebu_data_qa_jstor_tasks(data_partner)
-            elif data_partner.name == OaebuDatasetType.oapen_irus_uk:
+            elif data_partner.name == DatasetTypeId.oapen_irus_uk:
                 self.create_oaebu_data_qa_oapen_irus_uk_tasks(data_partner)
-            elif data_partner.name == OaebuDatasetType.google_books_sales:
+            elif data_partner.name == DatasetTypeId.google_books_sales:
                 self.create_oaebu_data_qa_google_books_sales_tasks(data_partner)
-            elif data_partner.name == OaebuDatasetType.google_books_traffic:
+            elif data_partner.name == DatasetTypeId.google_books_traffic:
                 self.create_oaebu_data_qa_google_books_traffic_tasks(data_partner)
-            elif data_partner.name == OaebuDatasetType.google_analytics:
+            elif data_partner.name == DatasetTypeId.google_analytics:
                 self.create_oaebu_data_qa_google_analytics_tasks(data_partner)
 
             self.create_oaebu_data_qa_intermediate_tasks(data_partner)

--- a/oaebu_workflows/workflows/tests/test_doab_telescope.py
+++ b/oaebu_workflows/workflows/tests/test_doab_telescope.py
@@ -126,7 +126,7 @@ class TestDoabTelescope(ObservatoryTestCase):
             name="Doab Dataset",
             address="project.dataset.table",
             service="bigquery",
-            connection=Workflow(id=1),
+            workflow=Workflow(id=1),
             dataset_type=DatasetType(id=1),
         )
         self.api.put_dataset(dataset)

--- a/oaebu_workflows/workflows/tests/test_doab_telescope.py
+++ b/oaebu_workflows/workflows/tests/test_doab_telescope.py
@@ -47,7 +47,7 @@ from observatory.api.client import ApiClient, Configuration
 from observatory.api.client.api.observatory_api import ObservatoryApi  # noqa: E501
 from observatory.api.client.model.organisation import Organisation
 from observatory.api.client.model.telescope import Telescope
-from observatory.api.client.model.telescope_type import TelescopeType
+from observatory.api.client.model.workflow_type import WorkflowType
 from observatory.api.client.model.dataset import Dataset
 from observatory.api.client.model.dataset_release import DatasetRelease
 from observatory.api.client.model.dataset_type import DatasetType
@@ -90,8 +90,8 @@ class TestDoabTelescope(ObservatoryTestCase):
         dt = pendulum.now("UTC")
 
         name = "Doab Telescope"
-        telescope_type = TelescopeType(name=name, type_id=DoabTelescope.DAG_ID)
-        self.api.put_telescope_type(telescope_type)
+        workflow_type = WorkflowType(name=name, type_id=DoabTelescope.DAG_ID)
+        self.api.put_workflow_type(workflow_type)
 
         organisation = Organisation(
             name=self.org_name,
@@ -103,7 +103,7 @@ class TestDoabTelescope(ObservatoryTestCase):
 
         telescope = Telescope(
             name=name,
-            telescope_type=TelescopeType(id=1),
+            workflow_type=WorkflowType(id=1),
             organisation=Organisation(id=1),
             extra={},
         )

--- a/oaebu_workflows/workflows/tests/test_doab_telescope.py
+++ b/oaebu_workflows/workflows/tests/test_doab_telescope.py
@@ -46,10 +46,9 @@ from observatory.api.testing import ObservatoryApiEnvironment
 from observatory.api.client import ApiClient, Configuration
 from observatory.api.client.api.observatory_api import ObservatoryApi  # noqa: E501
 from observatory.api.client.model.organisation import Organisation
-from observatory.api.client.model.telescope import Telescope
+from observatory.api.client.model.workflow import Workflow
 from observatory.api.client.model.workflow_type import WorkflowType
 from observatory.api.client.model.dataset import Dataset
-from observatory.api.client.model.dataset_release import DatasetRelease
 from observatory.api.client.model.dataset_type import DatasetType
 from observatory.api.client.model.table_type import TableType
 from observatory.platform.utils.release_utils import get_dataset_releases
@@ -101,13 +100,13 @@ class TestDoabTelescope(ObservatoryTestCase):
         )
         self.api.put_organisation(organisation)
 
-        telescope = Telescope(
+        telescope = Workflow(
             name=name,
             workflow_type=WorkflowType(id=1),
             organisation=Organisation(id=1),
             extra={},
         )
-        self.api.put_telescope(telescope)
+        self.api.put_workflow(telescope)
 
         table_type = TableType(
             type_id="partitioned",
@@ -127,7 +126,7 @@ class TestDoabTelescope(ObservatoryTestCase):
             name="Doab Dataset",
             address="project.dataset.table",
             service="bigquery",
-            connection=Telescope(id=1),
+            connection=Workflow(id=1),
             dataset_type=DatasetType(id=1),
         )
         self.api.put_dataset(dataset)

--- a/oaebu_workflows/workflows/tests/test_doab_telescope.py
+++ b/oaebu_workflows/workflows/tests/test_doab_telescope.py
@@ -42,6 +42,21 @@ from observatory.platform.utils.workflow_utils import (
     create_date_table_id,
     table_ids_from_path,
 )
+from observatory.api.testing import ObservatoryApiEnvironment
+from observatory.api.client import ApiClient, Configuration
+from observatory.api.client.api.observatory_api import ObservatoryApi  # noqa: E501
+from observatory.api.client.model.organisation import Organisation
+from observatory.api.client.model.telescope import Telescope
+from observatory.api.client.model.telescope_type import TelescopeType
+from observatory.api.client.model.dataset import Dataset
+from observatory.api.client.model.dataset_release import DatasetRelease
+from observatory.api.client.model.dataset_type import DatasetType
+from observatory.api.client.model.table_type import TableType
+from observatory.platform.utils.release_utils import get_dataset_releases
+from observatory.platform.utils.airflow_utils import AirflowConns
+from airflow.models import Connection
+from airflow.utils.state import State
+import responses
 
 
 class TestDoabTelescope(ObservatoryTestCase):
@@ -57,10 +72,70 @@ class TestDoabTelescope(ObservatoryTestCase):
         self.data_location = os.getenv("TEST_GCP_DATA_LOCATION")
 
         self.first_download_path = test_fixtures_folder("doab", "doab1.csv")
-        self.first_execution_date = pendulum.datetime(year=2021, month=2, day=1)
+        self.first_execution_date = pendulum.datetime(year=2021, month=2, day=2)
 
         self.second_download_path = test_fixtures_folder("doab", "doab2.csv")
-        self.second_execution_date = pendulum.datetime(year=2021, month=3, day=1)
+        self.second_execution_date = pendulum.datetime(year=2021, month=3, day=2)
+
+        # API environment
+        self.host = "localhost"
+        self.port = 5001
+        configuration = Configuration(host=f"http://{self.host}:{self.port}")
+        api_client = ApiClient(configuration)
+        self.api = ObservatoryApi(api_client=api_client)  # noqa: E501
+        self.env = ObservatoryApiEnvironment(host=self.host, port=self.port)
+        self.org_name = "UCL Press"
+
+    def setup_api(self):
+        dt = pendulum.now("UTC")
+
+        name = "Doab Telescope"
+        telescope_type = TelescopeType(name=name, type_id=DoabTelescope.DAG_ID)
+        self.api.put_telescope_type(telescope_type)
+
+        organisation = Organisation(
+            name=self.org_name,
+            gcp_project_id="project",
+            gcp_download_bucket="download_bucket",
+            gcp_transform_bucket="transform_bucket",
+        )
+        self.api.put_organisation(organisation)
+
+        telescope = Telescope(
+            name=name,
+            telescope_type=TelescopeType(id=1),
+            organisation=Organisation(id=1),
+            extra={},
+        )
+        self.api.put_telescope(telescope)
+
+        table_type = TableType(
+            type_id="partitioned",
+            name="partitioned bq table",
+        )
+        self.api.put_table_type(table_type)
+
+        dataset_type = DatasetType(
+            type_id=DoabTelescope.DAG_ID,
+            name="ds type",
+            extra={},
+            table_type=TableType(id=1),
+        )
+        self.api.put_dataset_type(dataset_type)
+
+        dataset = Dataset(
+            name="Doab Dataset",
+            address="project.dataset.table",
+            service="bigquery",
+            connection=Telescope(id=1),
+            dataset_type=DatasetType(id=1),
+        )
+        self.api.put_dataset(dataset)
+
+    def setup_connections(self, env):
+        # Add Observatory API connection
+        conn = Connection(conn_id=AirflowConns.OBSERVATORY_API, uri=f"http://:password@{self.host}:{self.port}")
+        env.add_connection(conn)
 
     def test_dag_structure(self):
         """Test that the DOAB DAG has the correct structure.
@@ -78,7 +153,8 @@ class TestDoabTelescope(ObservatoryTestCase):
                 "bq_load_partition": ["bq_delete_old"],
                 "bq_delete_old": ["bq_append_new"],
                 "bq_append_new": ["cleanup"],
-                "cleanup": [],
+                "cleanup": ["add_new_dataset_releases"],
+                "add_new_dataset_releases": [],
             },
             dag,
         )
@@ -88,7 +164,11 @@ class TestDoabTelescope(ObservatoryTestCase):
         :return: None
         """
 
-        with ObservatoryEnvironment().create():
+        env = ObservatoryEnvironment(self.project_id, self.data_location, api_host=self.host, api_port=self.port)
+
+        with env.create():
+            self.setup_connections(env)
+            self.setup_api()
             dag_file = os.path.join(module_file_path("oaebu_workflows.dags"), "doab_telescope.py")
             self.assert_dag_load("doab", dag_file)
 
@@ -97,33 +177,35 @@ class TestDoabTelescope(ObservatoryTestCase):
         :return: None.
         """
         # Setup Observatory environment
-        env = ObservatoryEnvironment(self.project_id, self.data_location)
+        env = ObservatoryEnvironment(self.project_id, self.data_location, api_host=self.host, api_port=self.port)
         dataset_id = env.add_dataset()
 
         # Setup Telescope
-        telescope = DoabTelescope(dataset_id=dataset_id)
+        telescope = DoabTelescope(dataset_id=dataset_id, workflow_id=1)
         dag = telescope.make_dag()
 
         # Create the Observatory environment and run tests
         with env.create():
+            self.setup_connections(env)
+            self.setup_api()
             # first run
             with env.create_dag_run(dag, self.first_execution_date) as m_dagrun:
                 # Test that all dependencies are specified: no error should be thrown
                 env.run_task(telescope.check_dependencies.__name__)
 
                 start_date, end_date, first_release = telescope.get_release_info(
-                    execution_date=self.first_execution_date,
-                    dag_run=m_dagrun,
                     dag=dag,
-                    next_execution_date=pendulum.datetime(2021, 3, 1),
+                    data_interval_end=pendulum.datetime(2021, 2, 1),
                 )
 
                 # use release info for other tasks
                 release = DoabRelease(telescope.dag_id, start_date, end_date, first_release)
 
                 # Test download task
-                with httpretty.enabled():
-                    self.setup_mock_file_download(DoabTelescope.CSV_URL, self.first_download_path)
+                with responses.RequestsMock() as rsps:
+                    with open(self.first_download_path, "rb") as f:
+                        body = f.read()
+                    rsps.add(responses.GET, DoabTelescope.CSV_URL, body=body, status=200)
                     env.run_task(telescope.download.__name__)
 
                 self.assertEqual(1, len(release.download_files))
@@ -149,12 +231,12 @@ class TestDoabTelescope(ObservatoryTestCase):
 
                 # Test that load partition task is skipped for the first release
                 ti = env.run_task(telescope.bq_load_partition.__name__)
-                self.assertEqual(ti.state, "skipped")
+                self.assertEqual(ti.state, State.SUCCESS)
 
                 # Test delete old task is skipped for the first release
                 with patch("observatory.platform.utils.gc_utils.bq_query_bytes_daily_limit_check"):
                     ti = env.run_task(telescope.bq_delete_old.__name__)
-                self.assertEqual(ti.state, "skipped")
+                self.assertEqual(ti.state, State.SUCCESS)
 
                 # Test append new creates table
                 env.run_task(telescope.bq_append_new.__name__)
@@ -172,28 +254,36 @@ class TestDoabTelescope(ObservatoryTestCase):
                 env.run_task(telescope.cleanup.__name__)
                 self.assert_cleanup(download_folder, extract_folder, transform_folder)
 
+                # add_dataset_release_task
+                dataset_releases = get_dataset_releases(dataset_id=1)
+                self.assertEqual(len(dataset_releases), 0)
+                ti = env.run_task("add_new_dataset_releases")
+                self.assertEqual(ti.state, State.SUCCESS)
+                dataset_releases = get_dataset_releases(dataset_id=1)
+                self.assertEqual(len(dataset_releases), 1)
+
             # second run
             with env.create_dag_run(dag, self.second_execution_date) as m_dag_run:
                 # Test that all dependencies are specified: no error should be thrown
                 env.run_task(telescope.check_dependencies.__name__)
 
                 start_date, end_date, first_release = telescope.get_release_info(
-                    execution_date=self.second_execution_date,
-                    dag_run=m_dag_run,
                     dag=dag,
-                    next_execution_date=pendulum.datetime(2021, 4, 1),
+                    data_interval_end=pendulum.datetime(2021, 3, 1),
                 )
 
-                self.assertEqual(release.end_date + timedelta(days=1), start_date)
-                self.assertEqual(pendulum.today("UTC") - timedelta(days=1), end_date)
+                self.assertEqual(release.end_date, start_date)
+                self.assertEqual(pendulum.datetime(2021, 3, 1), end_date)
                 self.assertFalse(first_release)
 
                 # use release info for other tasks
                 release = DoabRelease(telescope.dag_id, start_date, end_date, first_release)
 
                 # Test download task
-                with httpretty.enabled():
-                    self.setup_mock_file_download(DoabTelescope.CSV_URL, self.second_download_path)
+                with responses.RequestsMock() as rsps:
+                    with open(self.second_download_path, "rb") as f:
+                        body = f.read()
+                    rsps.add(responses.GET, DoabTelescope.CSV_URL, body=body, status=200)
                     env.run_task(telescope.download.__name__)
 
                 self.assertEqual(1, len(release.download_files))
@@ -246,6 +336,14 @@ class TestDoabTelescope(ObservatoryTestCase):
                 )
                 env.run_task(telescope.cleanup.__name__)
                 self.assert_cleanup(download_folder, extract_folder, transform_folder)
+
+                # add_dataset_release_task
+                dataset_releases = get_dataset_releases(dataset_id=1)
+                self.assertEqual(len(dataset_releases), 1)
+                ti = env.run_task("add_new_dataset_releases")
+                self.assertEqual(ti.state, State.SUCCESS)
+                dataset_releases = get_dataset_releases(dataset_id=1)
+                self.assertEqual(len(dataset_releases), 2)
 
     def test_airflow_vars(self):
         """Cover case when airflow_vars is given."""

--- a/oaebu_workflows/workflows/tests/test_doab_telescope.py
+++ b/oaebu_workflows/workflows/tests/test_doab_telescope.py
@@ -95,9 +95,9 @@ class TestDoabTelescope(ObservatoryTestCase):
 
         organisation = Organisation(
             name=self.org_name,
-            gcp_project_id="project",
-            gcp_download_bucket="download_bucket",
-            gcp_transform_bucket="transform_bucket",
+            project_id="project",
+            download_bucket="download_bucket",
+            transform_bucket="transform_bucket",
         )
         self.api.put_organisation(organisation)
 

--- a/oaebu_workflows/workflows/tests/test_google_analytics_telescope.py
+++ b/oaebu_workflows/workflows/tests/test_google_analytics_telescope.py
@@ -25,9 +25,7 @@ from airflow.models.connection import Connection
 from croniter import croniter
 from googleapiclient.discovery import build
 from googleapiclient.http import HttpMockSequence
-from oaebu_workflows.identifiers import WorkflowTypes
 from observatory.api.client.model.organisation import Organisation
-from observatory.api.server import orm
 from oaebu_workflows.workflows.google_analytics_telescope import (
     GoogleAnalyticsRelease,
     GoogleAnalyticsTelescope,
@@ -43,10 +41,9 @@ from observatory.api.testing import ObservatoryApiEnvironment
 from observatory.api.client import ApiClient, Configuration
 from observatory.api.client.api.observatory_api import ObservatoryApi  # noqa: E501
 from observatory.api.client.model.organisation import Organisation
-from observatory.api.client.model.telescope import Telescope
+from observatory.api.client.model.workflow import Workflow
 from observatory.api.client.model.workflow_type import WorkflowType
 from observatory.api.client.model.dataset import Dataset
-from observatory.api.client.model.dataset_release import DatasetRelease
 from observatory.api.client.model.dataset_type import DatasetType
 from observatory.api.client.model.table_type import TableType
 from observatory.platform.utils.release_utils import get_dataset_releases
@@ -93,13 +90,13 @@ class TestGoogleAnalyticsTelescope(ObservatoryTestCase):
         )
         self.api.put_organisation(organisation)
 
-        telescope = Telescope(
+        telescope = Workflow(
             name=name,
             workflow_type=WorkflowType(id=1),
             organisation=Organisation(id=1),
             extra={},
         )
-        self.api.put_telescope(telescope)
+        self.api.put_workflow(telescope)
 
         table_type = TableType(
             type_id="partitioned",
@@ -119,7 +116,7 @@ class TestGoogleAnalyticsTelescope(ObservatoryTestCase):
             name="Google Analytics Dataset",
             address="project.dataset.table",
             service="bigquery",
-            connection=Telescope(id=1),
+            connection=Workflow(id=1),
             dataset_type=DatasetType(id=1),
         )
         self.api.put_dataset(dataset)

--- a/oaebu_workflows/workflows/tests/test_google_analytics_telescope.py
+++ b/oaebu_workflows/workflows/tests/test_google_analytics_telescope.py
@@ -25,7 +25,7 @@ from airflow.models.connection import Connection
 from croniter import croniter
 from googleapiclient.discovery import build
 from googleapiclient.http import HttpMockSequence
-from oaebu_workflows.identifiers import TelescopeTypes
+from oaebu_workflows.identifiers import WorkflowTypes
 from observatory.api.client.model.organisation import Organisation
 from observatory.api.server import orm
 from oaebu_workflows.workflows.google_analytics_telescope import (
@@ -44,7 +44,7 @@ from observatory.api.client import ApiClient, Configuration
 from observatory.api.client.api.observatory_api import ObservatoryApi  # noqa: E501
 from observatory.api.client.model.organisation import Organisation
 from observatory.api.client.model.telescope import Telescope
-from observatory.api.client.model.telescope_type import TelescopeType
+from observatory.api.client.model.workflow_type import WorkflowType
 from observatory.api.client.model.dataset import Dataset
 from observatory.api.client.model.dataset_release import DatasetRelease
 from observatory.api.client.model.dataset_type import DatasetType
@@ -80,8 +80,8 @@ class TestGoogleAnalyticsTelescope(ObservatoryTestCase):
         dt = pendulum.now("UTC")
 
         name = "Google Analytics Telescope"
-        telescope_type = TelescopeType(name=name, type_id=GoogleAnalyticsTelescope.DAG_ID_PREFIX)
-        self.api.put_telescope_type(telescope_type)
+        workflow_type = WorkflowType(name=name, type_id=GoogleAnalyticsTelescope.DAG_ID_PREFIX)
+        self.api.put_workflow_type(workflow_type)
 
         org_name_ = self.org_name if org_name is None else org_name
 
@@ -95,7 +95,7 @@ class TestGoogleAnalyticsTelescope(ObservatoryTestCase):
 
         telescope = Telescope(
             name=name,
-            telescope_type=TelescopeType(id=1),
+            workflow_type=WorkflowType(id=1),
             organisation=Organisation(id=1),
             extra={},
         )

--- a/oaebu_workflows/workflows/tests/test_google_analytics_telescope.py
+++ b/oaebu_workflows/workflows/tests/test_google_analytics_telescope.py
@@ -116,7 +116,7 @@ class TestGoogleAnalyticsTelescope(ObservatoryTestCase):
             name="Google Analytics Dataset",
             address="project.dataset.table",
             service="bigquery",
-            connection=Workflow(id=1),
+            workflow=Workflow(id=1),
             dataset_type=DatasetType(id=1),
         )
         self.api.put_dataset(dataset)

--- a/oaebu_workflows/workflows/tests/test_google_analytics_telescope.py
+++ b/oaebu_workflows/workflows/tests/test_google_analytics_telescope.py
@@ -39,6 +39,20 @@ from observatory.platform.utils.test_utils import (
     ObservatoryTestCase,
     module_file_path,
 )
+from observatory.api.testing import ObservatoryApiEnvironment
+from observatory.api.client import ApiClient, Configuration
+from observatory.api.client.api.observatory_api import ObservatoryApi  # noqa: E501
+from observatory.api.client.model.organisation import Organisation
+from observatory.api.client.model.telescope import Telescope
+from observatory.api.client.model.telescope_type import TelescopeType
+from observatory.api.client.model.dataset import Dataset
+from observatory.api.client.model.dataset_release import DatasetRelease
+from observatory.api.client.model.dataset_type import DatasetType
+from observatory.api.client.model.table_type import TableType
+from observatory.platform.utils.release_utils import get_dataset_releases
+from observatory.platform.utils.airflow_utils import AirflowConns
+from airflow.models import Connection
+from airflow.utils.state import State
 
 
 class TestGoogleAnalyticsTelescope(ObservatoryTestCase):
@@ -52,8 +66,68 @@ class TestGoogleAnalyticsTelescope(ObservatoryTestCase):
         super(TestGoogleAnalyticsTelescope, self).__init__(*args, **kwargs)
         self.project_id = os.getenv("TEST_GCP_PROJECT_ID")
         self.data_location = os.getenv("TEST_GCP_DATA_LOCATION")
+
+        # API environment
         self.host = "localhost"
-        self.api_port = 5000
+        self.port = 5001
+        configuration = Configuration(host=f"http://{self.host}:{self.port}")
+        api_client = ApiClient(configuration)
+        self.api = ObservatoryApi(api_client=api_client)  # noqa: E501
+        self.env = ObservatoryApiEnvironment(host=self.host, port=self.port)
+        self.org_name = "UCL Press"
+
+    def setup_api(self, org_name=None):
+        dt = pendulum.now("UTC")
+
+        name = "Google Analytics Telescope"
+        telescope_type = TelescopeType(name=name, type_id=GoogleAnalyticsTelescope.DAG_ID_PREFIX)
+        self.api.put_telescope_type(telescope_type)
+
+        org_name_ = self.org_name if org_name is None else org_name
+
+        organisation = Organisation(
+            name=org_name_,
+            gcp_project_id="project",
+            gcp_download_bucket="download_bucket",
+            gcp_transform_bucket="transform_bucket",
+        )
+        self.api.put_organisation(organisation)
+
+        telescope = Telescope(
+            name=name,
+            telescope_type=TelescopeType(id=1),
+            organisation=Organisation(id=1),
+            extra={},
+        )
+        self.api.put_telescope(telescope)
+
+        table_type = TableType(
+            type_id="partitioned",
+            name="partitioned bq table",
+        )
+        self.api.put_table_type(table_type)
+
+        dataset_type = DatasetType(
+            type_id=GoogleAnalyticsTelescope.DAG_ID_PREFIX,
+            name="ds type",
+            extra={},
+            table_type=TableType(id=1),
+        )
+        self.api.put_dataset_type(dataset_type)
+
+        dataset = Dataset(
+            name="Google Analytics Dataset",
+            address="project.dataset.table",
+            service="bigquery",
+            connection=Telescope(id=1),
+            dataset_type=DatasetType(id=1),
+        )
+        self.api.put_dataset(dataset)
+
+    def setup_connections(self, env):
+        # Add Observatory API connection
+        conn = Connection(conn_id=AirflowConns.OBSERVATORY_API, uri=f"http://:password@{self.host}:{self.port}")
+        env.add_connection(conn)
 
     def test_dag_structure(self):
         """Test that the Google Analytics DAG has the correct structure.
@@ -67,7 +141,8 @@ class TestGoogleAnalyticsTelescope(ObservatoryTestCase):
                 "download_transform": ["upload_transformed"],
                 "upload_transformed": ["bq_load_partition"],
                 "bq_load_partition": ["cleanup"],
-                "cleanup": [],
+                "cleanup": ["add_new_dataset_releases"],
+                "add_new_dataset_releases": [],
             },
             dag,
         )
@@ -77,31 +152,10 @@ class TestGoogleAnalyticsTelescope(ObservatoryTestCase):
         :return: None
         """
 
-        env = ObservatoryEnvironment(self.project_id, self.data_location)
+        env = ObservatoryEnvironment(self.project_id, self.data_location, api_host=self.host, api_port=self.port)
         with env.create():
-            # Add Observatory API connection
-            conn = Connection(conn_id=AirflowConns.OBSERVATORY_API, uri=f"http://:password@{self.host}:{self.api_port}")
-            env.add_connection(conn)
-
-            # Add a telescope
-            dt = pendulum.now("UTC")
-            telescope_type = orm.TelescopeType(
-                name="Google Analytics Telescope", type_id=TelescopeTypes.google_analytics, created=dt, modified=dt
-            )
-            env.api_session.add(telescope_type)
-            organisation = orm.Organisation(name="UCL Press", created=dt, modified=dt)
-            env.api_session.add(organisation)
-            telescope = orm.Telescope(
-                name="UCL Press Google Analytics Telescope",
-                telescope_type=telescope_type,
-                organisation=organisation,
-                modified=dt,
-                created=dt,
-                extra={"view_id": "11235141", "pagepath_regex": r".*regex$"},
-            )
-            env.api_session.add(telescope)
-            env.api_session.commit()
-
+            self.setup_connections(env)
+            self.setup_api()
             dag_file = os.path.join(module_file_path("oaebu_workflows.dags"), "google_analytics_telescope.py")
             self.assert_dag_load("google_analytics_ucl_press", dag_file)
 
@@ -124,7 +178,7 @@ class TestGoogleAnalyticsTelescope(ObservatoryTestCase):
         mock_build.return_value = build("analyticsreporting", "v4", http=http)
 
         # Setup Observatory environment
-        env = ObservatoryEnvironment(self.project_id, self.data_location)
+        env = ObservatoryEnvironment(self.project_id, self.data_location, api_host=self.host, api_port=self.port)
         dataset_id = env.add_dataset()
 
         # Setup Telescope
@@ -136,12 +190,18 @@ class TestGoogleAnalyticsTelescope(ObservatoryTestCase):
             gcp_transform_bucket=env.transform_bucket,
         )
         telescope = GoogleAnalyticsTelescope(
-            organisation=organisation, view_id=self.view_id, pagepath_regex=self.pagepath_regex, dataset_id=dataset_id
+            organisation=organisation,
+            view_id=self.view_id,
+            pagepath_regex=self.pagepath_regex,
+            dataset_id=dataset_id,
+            workflow_id=1,
         )
         dag = telescope.make_dag()
 
         # Create the Observatory environment and run tests
         with env.create():
+            self.setup_connections(env)
+            self.setup_api()
             with env.create_dag_run(dag, execution_date):
                 # Add OAEBU service account connection connection
                 conn = Connection(
@@ -252,6 +312,14 @@ class TestGoogleAnalyticsTelescope(ObservatoryTestCase):
                 env.run_task(telescope.cleanup.__name__)
                 self.assert_cleanup(download_folder, extract_folder, transform_folder)
 
+                # add_dataset_release_task
+                dataset_releases = get_dataset_releases(dataset_id=1)
+                self.assertEqual(len(dataset_releases), 0)
+                ti = env.run_task("add_new_dataset_releases")
+                self.assertEqual(ti.state, State.SUCCESS)
+                dataset_releases = get_dataset_releases(dataset_id=1)
+                self.assertEqual(len(dataset_releases), 1)
+
     @patch("oaebu_workflows.workflows.google_analytics_telescope.build")
     @patch("oaebu_workflows.workflows.google_analytics_telescope.ServiceAccountCredentials")
     def test_telescope_anu(self, mock_account_credentials, mock_build):
@@ -271,7 +339,7 @@ class TestGoogleAnalyticsTelescope(ObservatoryTestCase):
         mock_build.return_value = build("analyticsreporting", "v4", http=http)
 
         # Setup Observatory environment
-        env = ObservatoryEnvironment(self.project_id, self.data_location)
+        env = ObservatoryEnvironment(self.project_id, self.data_location, api_host=self.host, api_port=self.port)
         dataset_id = env.add_dataset()
 
         # Setup Telescope
@@ -283,12 +351,18 @@ class TestGoogleAnalyticsTelescope(ObservatoryTestCase):
             gcp_transform_bucket=env.transform_bucket,
         )
         telescope = GoogleAnalyticsTelescope(
-            organisation=organisation, view_id=self.view_id, pagepath_regex=self.pagepath_regex, dataset_id=dataset_id
+            organisation=organisation,
+            view_id=self.view_id,
+            pagepath_regex=self.pagepath_regex,
+            dataset_id=dataset_id,
+            workflow_id=1,
         )
         dag = telescope.make_dag()
 
         # Create the Observatory environment and run tests
         with env.create():
+            self.setup_connections(env)
+            self.setup_api(org_name=self.organisation_name)
             with env.create_dag_run(dag, execution_date):
                 # Add OAEBU service account connection connection
                 conn = Connection(
@@ -416,6 +490,14 @@ class TestGoogleAnalyticsTelescope(ObservatoryTestCase):
                 )
                 env.run_task(telescope.cleanup.__name__)
                 self.assert_cleanup(download_folder, extract_folder, transform_folder)
+
+                # add_dataset_release_task
+                dataset_releases = get_dataset_releases(dataset_id=1)
+                self.assertEqual(len(dataset_releases), 0)
+                ti = env.run_task("add_new_dataset_releases")
+                self.assertEqual(ti.state, State.SUCCESS)
+                dataset_releases = get_dataset_releases(dataset_id=1)
+                self.assertEqual(len(dataset_releases), 1)
 
 
 def create_http_mock_sequence(organisation_name: str) -> list:

--- a/oaebu_workflows/workflows/tests/test_google_analytics_telescope.py
+++ b/oaebu_workflows/workflows/tests/test_google_analytics_telescope.py
@@ -87,9 +87,9 @@ class TestGoogleAnalyticsTelescope(ObservatoryTestCase):
 
         organisation = Organisation(
             name=org_name_,
-            gcp_project_id="project",
-            gcp_download_bucket="download_bucket",
-            gcp_transform_bucket="transform_bucket",
+            project_id="project",
+            download_bucket="download_bucket",
+            transform_bucket="transform_bucket",
         )
         self.api.put_organisation(organisation)
 
@@ -185,9 +185,9 @@ class TestGoogleAnalyticsTelescope(ObservatoryTestCase):
         execution_date = pendulum.datetime(year=2020, month=4, day=1)
         organisation = Organisation(
             name=self.organisation_name,
-            gcp_project_id=self.project_id,
-            gcp_download_bucket=env.download_bucket,
-            gcp_transform_bucket=env.transform_bucket,
+            project_id=self.project_id,
+            download_bucket=env.download_bucket,
+            transform_bucket=env.transform_bucket,
         )
         telescope = GoogleAnalyticsTelescope(
             organisation=organisation,
@@ -346,9 +346,9 @@ class TestGoogleAnalyticsTelescope(ObservatoryTestCase):
         execution_date = pendulum.datetime(year=2020, month=4, day=1)
         organisation = Organisation(
             name=self.organisation_name,
-            gcp_project_id=self.project_id,
-            gcp_download_bucket=env.download_bucket,
-            gcp_transform_bucket=env.transform_bucket,
+            project_id=self.project_id,
+            download_bucket=env.download_bucket,
+            transform_bucket=env.transform_bucket,
         )
         telescope = GoogleAnalyticsTelescope(
             organisation=organisation,

--- a/oaebu_workflows/workflows/tests/test_google_books_telescope.py
+++ b/oaebu_workflows/workflows/tests/test_google_books_telescope.py
@@ -124,7 +124,7 @@ class TestGoogleBooksTelescope(ObservatoryTestCase):
             name="Google Books Dataset",
             address="project.dataset.table",
             service="bigquery",
-            connection=Workflow(id=1),
+            workflow=Workflow(id=1),
             dataset_type=DatasetType(id=1),
         )
         self.api.put_dataset(dataset)

--- a/oaebu_workflows/workflows/tests/test_google_books_telescope.py
+++ b/oaebu_workflows/workflows/tests/test_google_books_telescope.py
@@ -45,10 +45,9 @@ from observatory.api.testing import ObservatoryApiEnvironment
 from observatory.api.client import ApiClient, Configuration
 from observatory.api.client.api.observatory_api import ObservatoryApi  # noqa: E501
 from observatory.api.client.model.organisation import Organisation
-from observatory.api.client.model.telescope import Telescope
+from observatory.api.client.model.workflow import Workflow
 from observatory.api.client.model.workflow_type import WorkflowType
 from observatory.api.client.model.dataset import Dataset
-from observatory.api.client.model.dataset_release import DatasetRelease
 from observatory.api.client.model.dataset_type import DatasetType
 from observatory.api.client.model.table_type import TableType
 from observatory.platform.utils.release_utils import get_dataset_releases
@@ -99,13 +98,13 @@ class TestGoogleBooksTelescope(ObservatoryTestCase):
         )
         self.api.put_organisation(organisation)
 
-        telescope = Telescope(
+        telescope = Workflow(
             name=name,
             workflow_type=WorkflowType(id=1),
             organisation=Organisation(id=1),
             extra={},
         )
-        self.api.put_telescope(telescope)
+        self.api.put_workflow(telescope)
 
         table_type = TableType(
             type_id="partitioned",
@@ -125,7 +124,7 @@ class TestGoogleBooksTelescope(ObservatoryTestCase):
             name="Google Books Dataset",
             address="project.dataset.table",
             service="bigquery",
-            connection=Telescope(id=1),
+            connection=Workflow(id=1),
             dataset_type=DatasetType(id=1),
         )
         self.api.put_dataset(dataset)

--- a/oaebu_workflows/workflows/tests/test_google_books_telescope.py
+++ b/oaebu_workflows/workflows/tests/test_google_books_telescope.py
@@ -30,7 +30,7 @@ from oaebu_workflows.workflows.google_books_telescope import (
     GoogleBooksRelease,
     GoogleBooksTelescope,
 )
-from oaebu_workflows.identifiers import TelescopeTypes
+from oaebu_workflows.identifiers import WorkflowTypes
 from observatory.api.client.model.organisation import Organisation
 from observatory.platform.utils.airflow_utils import AirflowConns
 from observatory.platform.utils.test_utils import (
@@ -46,7 +46,7 @@ from observatory.api.client import ApiClient, Configuration
 from observatory.api.client.api.observatory_api import ObservatoryApi  # noqa: E501
 from observatory.api.client.model.organisation import Organisation
 from observatory.api.client.model.telescope import Telescope
-from observatory.api.client.model.telescope_type import TelescopeType
+from observatory.api.client.model.workflow_type import WorkflowType
 from observatory.api.client.model.dataset import Dataset
 from observatory.api.client.model.dataset_release import DatasetRelease
 from observatory.api.client.model.dataset_type import DatasetType
@@ -88,8 +88,8 @@ class TestGoogleBooksTelescope(ObservatoryTestCase):
         dt = pendulum.now("UTC")
 
         name = "Google Books Telescope"
-        telescope_type = TelescopeType(name=name, type_id=GoogleBooksTelescope.DAG_ID_PREFIX)
-        self.api.put_telescope_type(telescope_type)
+        workflow_type = WorkflowType(name=name, type_id=GoogleBooksTelescope.DAG_ID_PREFIX)
+        self.api.put_workflow_type(workflow_type)
 
         organisation = Organisation(
             name=self.org_name,
@@ -101,7 +101,7 @@ class TestGoogleBooksTelescope(ObservatoryTestCase):
 
         telescope = Telescope(
             name=name,
-            telescope_type=TelescopeType(id=1),
+            workflow_type=WorkflowType(id=1),
             organisation=Organisation(id=1),
             extra={},
         )

--- a/oaebu_workflows/workflows/tests/test_google_books_telescope.py
+++ b/oaebu_workflows/workflows/tests/test_google_books_telescope.py
@@ -93,9 +93,9 @@ class TestGoogleBooksTelescope(ObservatoryTestCase):
 
         organisation = Organisation(
             name=self.org_name,
-            gcp_project_id="project",
-            gcp_download_bucket="download_bucket",
-            gcp_transform_bucket="transform_bucket",
+            project_id="project",
+            download_bucket="download_bucket",
+            transform_bucket="transform_bucket",
         )
         self.api.put_organisation(organisation)
 
@@ -244,9 +244,9 @@ class TestGoogleBooksTelescope(ObservatoryTestCase):
                         execution_date = pendulum.datetime(year=2021, month=3, day=31)
                         org = Organisation(
                             name=self.organisation_name,
-                            gcp_project_id=self.project_id,
-                            gcp_download_bucket=env.download_bucket,
-                            gcp_transform_bucket=env.transform_bucket,
+                            project_id=self.project_id,
+                            download_bucket=env.download_bucket,
+                            transform_bucket=env.transform_bucket,
                         )
                         telescope = GoogleBooksTelescope(
                             org, accounts=setup["accounts"], dataset_id=dataset_id, workflow_id=1
@@ -404,9 +404,9 @@ class TestGoogleBooksTelescope(ObservatoryTestCase):
             # Objects to create release instance
             org = Organisation(
                 name=self.organisation_name,
-                gcp_project_id=self.project_id,
-                gcp_download_bucket="download_bucket",
-                gcp_transform_bucket="transform_bucket",
+                project_id=self.project_id,
+                download_bucket="download_bucket",
+                transform_bucket="transform_bucket",
             )
             telescope = GoogleBooksTelescope(org, accounts=None, dataset_id="dataset_id")
             file_path = test_fixtures_folder("google_books", "GoogleSalesTransactionReport_2020_02.csv")

--- a/oaebu_workflows/workflows/tests/test_jstor_telescope.py
+++ b/oaebu_workflows/workflows/tests/test_jstor_telescope.py
@@ -29,9 +29,7 @@ from googleapiclient.http import HttpMockSequence
 
 from oaebu_workflows.config import test_fixtures_folder
 from oaebu_workflows.workflows.jstor_telescope import JstorRelease, JstorTelescope, get_label_id, get_release_date
-from oaebu_workflows.identifiers import WorkflowTypes
 from observatory.api.client.model.organisation import Organisation
-from observatory.api.server import orm
 from observatory.platform.utils.airflow_utils import AirflowConns
 from observatory.platform.utils.test_utils import ObservatoryEnvironment, ObservatoryTestCase, module_file_path
 from observatory.platform.utils.workflow_utils import blob_name, table_ids_from_path
@@ -39,10 +37,9 @@ from observatory.api.testing import ObservatoryApiEnvironment
 from observatory.api.client import ApiClient, Configuration
 from observatory.api.client.api.observatory_api import ObservatoryApi  # noqa: E501
 from observatory.api.client.model.organisation import Organisation
-from observatory.api.client.model.telescope import Telescope
+from observatory.api.client.model.workflow import Workflow
 from observatory.api.client.model.workflow_type import WorkflowType
 from observatory.api.client.model.dataset import Dataset
-from observatory.api.client.model.dataset_release import DatasetRelease
 from observatory.api.client.model.dataset_type import DatasetType
 from observatory.api.client.model.table_type import TableType
 from observatory.platform.utils.release_utils import get_dataset_releases
@@ -125,13 +122,13 @@ class TestJstorTelescope(ObservatoryTestCase):
         )
         self.api.put_organisation(organisation)
 
-        telescope = Telescope(
+        telescope = Workflow(
             name=name,
             workflow_type=WorkflowType(id=1),
             organisation=Organisation(id=1),
             extra={},
         )
-        self.api.put_telescope(telescope)
+        self.api.put_workflow(telescope)
 
         table_type = TableType(
             type_id="partitioned",
@@ -151,7 +148,7 @@ class TestJstorTelescope(ObservatoryTestCase):
             name="Jstor Dataset",
             address="project.dataset.table",
             service="bigquery",
-            connection=Telescope(id=1),
+            connection=Workflow(id=1),
             dataset_type=DatasetType(id=1),
         )
         self.api.put_dataset(dataset)

--- a/oaebu_workflows/workflows/tests/test_jstor_telescope.py
+++ b/oaebu_workflows/workflows/tests/test_jstor_telescope.py
@@ -148,7 +148,7 @@ class TestJstorTelescope(ObservatoryTestCase):
             name="Jstor Dataset",
             address="project.dataset.table",
             service="bigquery",
-            connection=Workflow(id=1),
+            workflow=Workflow(id=1),
             dataset_type=DatasetType(id=1),
         )
         self.api.put_dataset(dataset)

--- a/oaebu_workflows/workflows/tests/test_jstor_telescope.py
+++ b/oaebu_workflows/workflows/tests/test_jstor_telescope.py
@@ -29,7 +29,7 @@ from googleapiclient.http import HttpMockSequence
 
 from oaebu_workflows.config import test_fixtures_folder
 from oaebu_workflows.workflows.jstor_telescope import JstorRelease, JstorTelescope, get_label_id, get_release_date
-from oaebu_workflows.identifiers import TelescopeTypes
+from oaebu_workflows.identifiers import WorkflowTypes
 from observatory.api.client.model.organisation import Organisation
 from observatory.api.server import orm
 from observatory.platform.utils.airflow_utils import AirflowConns
@@ -40,7 +40,7 @@ from observatory.api.client import ApiClient, Configuration
 from observatory.api.client.api.observatory_api import ObservatoryApi  # noqa: E501
 from observatory.api.client.model.organisation import Organisation
 from observatory.api.client.model.telescope import Telescope
-from observatory.api.client.model.telescope_type import TelescopeType
+from observatory.api.client.model.workflow_type import WorkflowType
 from observatory.api.client.model.dataset import Dataset
 from observatory.api.client.model.dataset_release import DatasetRelease
 from observatory.api.client.model.dataset_type import DatasetType
@@ -114,8 +114,8 @@ class TestJstorTelescope(ObservatoryTestCase):
         dt = pendulum.now("UTC")
 
         name = "Jstor Telescope"
-        telescope_type = TelescopeType(name=name, type_id=JstorTelescope.DAG_ID_PREFIX)
-        self.api.put_telescope_type(telescope_type)
+        workflow_type = WorkflowType(name=name, type_id=JstorTelescope.DAG_ID_PREFIX)
+        self.api.put_workflow_type(workflow_type)
 
         organisation = Organisation(
             name=self.org_name,
@@ -127,7 +127,7 @@ class TestJstorTelescope(ObservatoryTestCase):
 
         telescope = Telescope(
             name=name,
-            telescope_type=TelescopeType(id=1),
+            workflow_type=WorkflowType(id=1),
             organisation=Organisation(id=1),
             extra={},
         )

--- a/oaebu_workflows/workflows/tests/test_jstor_telescope.py
+++ b/oaebu_workflows/workflows/tests/test_jstor_telescope.py
@@ -35,6 +35,20 @@ from observatory.api.server import orm
 from observatory.platform.utils.airflow_utils import AirflowConns
 from observatory.platform.utils.test_utils import ObservatoryEnvironment, ObservatoryTestCase, module_file_path
 from observatory.platform.utils.workflow_utils import blob_name, table_ids_from_path
+from observatory.api.testing import ObservatoryApiEnvironment
+from observatory.api.client import ApiClient, Configuration
+from observatory.api.client.api.observatory_api import ObservatoryApi  # noqa: E501
+from observatory.api.client.model.organisation import Organisation
+from observatory.api.client.model.telescope import Telescope
+from observatory.api.client.model.telescope_type import TelescopeType
+from observatory.api.client.model.dataset import Dataset
+from observatory.api.client.model.dataset_release import DatasetRelease
+from observatory.api.client.model.dataset_type import DatasetType
+from observatory.api.client.model.table_type import TableType
+from observatory.platform.utils.release_utils import get_dataset_releases
+from observatory.platform.utils.airflow_utils import AirflowConns
+from airflow.models import Connection
+from airflow.utils.state import State
 
 
 class TestJstorTelescope(ObservatoryTestCase):
@@ -87,6 +101,66 @@ class TestJstorTelescope(ObservatoryTestCase):
             },
         }
 
+        # API environment
+        self.host = "localhost"
+        self.port = 5001
+        configuration = Configuration(host=f"http://{self.host}:{self.port}")
+        api_client = ApiClient(configuration)
+        self.api = ObservatoryApi(api_client=api_client)  # noqa: E501
+        self.env = ObservatoryApiEnvironment(host=self.host, port=self.port)
+        self.org_name = "Curtin Press"
+
+    def setup_api(self):
+        dt = pendulum.now("UTC")
+
+        name = "Jstor Telescope"
+        telescope_type = TelescopeType(name=name, type_id=JstorTelescope.DAG_ID_PREFIX)
+        self.api.put_telescope_type(telescope_type)
+
+        organisation = Organisation(
+            name=self.org_name,
+            gcp_project_id="project",
+            gcp_download_bucket="download_bucket",
+            gcp_transform_bucket="transform_bucket",
+        )
+        self.api.put_organisation(organisation)
+
+        telescope = Telescope(
+            name=name,
+            telescope_type=TelescopeType(id=1),
+            organisation=Organisation(id=1),
+            extra={},
+        )
+        self.api.put_telescope(telescope)
+
+        table_type = TableType(
+            type_id="partitioned",
+            name="partitioned bq table",
+        )
+        self.api.put_table_type(table_type)
+
+        dataset_type = DatasetType(
+            type_id=JstorTelescope.DAG_ID_PREFIX,
+            name="ds type",
+            extra={},
+            table_type=TableType(id=1),
+        )
+        self.api.put_dataset_type(dataset_type)
+
+        dataset = Dataset(
+            name="Jstor Dataset",
+            address="project.dataset.table",
+            service="bigquery",
+            connection=Telescope(id=1),
+            dataset_type=DatasetType(id=1),
+        )
+        self.api.put_dataset(dataset)
+
+    def setup_connections(self, env):
+        # Add Observatory API connection
+        conn = Connection(conn_id=AirflowConns.OBSERVATORY_API, uri=f"http://:password@{self.host}:{self.port}")
+        env.add_connection(conn)
+
     def test_dag_structure(self):
         """Test that the Jstor DAG has the correct structure.
 
@@ -103,7 +177,8 @@ class TestJstorTelescope(ObservatoryTestCase):
                 "transform": ["upload_transformed"],
                 "upload_transformed": ["bq_load_partition"],
                 "bq_load_partition": ["cleanup"],
-                "cleanup": [],
+                "cleanup": ["add_new_dataset_releases"],
+                "add_new_dataset_releases": [],
             },
             dag,
         )
@@ -114,31 +189,10 @@ class TestJstorTelescope(ObservatoryTestCase):
         :return: None
         """
 
-        env = ObservatoryEnvironment(self.project_id, self.data_location)
+        env = ObservatoryEnvironment(self.project_id, self.data_location, api_host=self.host, api_port=self.port)
         with env.create():
-            # Add Observatory API connection
-            conn = Connection(conn_id=AirflowConns.OBSERVATORY_API, uri=f"http://:password@{self.host}:{self.api_port}")
-            env.add_connection(conn)
-
-            # Add a telescope
-            dt = pendulum.now("UTC")
-            telescope_type = orm.TelescopeType(
-                name="Jstor Telescope", type_id=TelescopeTypes.jstor, created=dt, modified=dt
-            )
-            env.api_session.add(telescope_type)
-            organisation = orm.Organisation(name="Curtin Press", created=dt, modified=dt)
-            env.api_session.add(organisation)
-            telescope = orm.Telescope(
-                name="Curtin Press Jstor Telescope",
-                telescope_type=telescope_type,
-                organisation=organisation,
-                modified=dt,
-                created=dt,
-                extra=self.extra,
-            )
-            env.api_session.add(telescope)
-            env.api_session.commit()
-
+            self.setup_connections(env)
+            self.setup_api()
             dag_file = os.path.join(module_file_path("oaebu_workflows.dags"), "jstor_telescope.py")
             self.assert_dag_load("jstor_curtin_press", dag_file)
 
@@ -160,7 +214,7 @@ class TestJstorTelescope(ObservatoryTestCase):
         mock_build.return_value = build("gmail", "v1", http=http)
 
         # Setup Observatory environment
-        env = ObservatoryEnvironment(self.project_id, self.data_location)
+        env = ObservatoryEnvironment(self.project_id, self.data_location, api_host=self.host, api_port=self.port)
         dataset_id = env.add_dataset()
 
         # Setup Telescope
@@ -172,12 +226,14 @@ class TestJstorTelescope(ObservatoryTestCase):
             gcp_transform_bucket=env.transform_bucket,
         )
         telescope = JstorTelescope(
-            organisation=organisation, publisher_id=self.extra.get("publisher_id"), dataset_id=dataset_id
+            organisation=organisation, publisher_id=self.extra.get("publisher_id"), dataset_id=dataset_id, workflow_id=1
         )
         dag = telescope.make_dag()
 
         # Create the Observatory environment and run tests
         with env.create(task_logging=True):
+            self.setup_connections(env)
+            self.setup_api()
             with env.create_dag_run(dag, execution_date):
                 # add gmail connection
                 conn = Connection(
@@ -275,6 +331,14 @@ class TestJstorTelescope(ObservatoryTestCase):
                 )
                 env.run_task(telescope.cleanup.__name__)
                 self.assert_cleanup(download_folder, extract_folder, transform_folder)
+
+                # add_dataset_release_task
+                dataset_releases = get_dataset_releases(dataset_id=1)
+                self.assertEqual(len(dataset_releases), 0)
+                ti = env.run_task("add_new_dataset_releases")
+                self.assertEqual(ti.state, State.SUCCESS)
+                dataset_releases = get_dataset_releases(dataset_id=1)
+                self.assertEqual(len(dataset_releases), 1)
 
     def test_get_label_id(self):
         """Test getting label id both when label already exists and does not exist yet.

--- a/oaebu_workflows/workflows/tests/test_jstor_telescope.py
+++ b/oaebu_workflows/workflows/tests/test_jstor_telescope.py
@@ -119,9 +119,9 @@ class TestJstorTelescope(ObservatoryTestCase):
 
         organisation = Organisation(
             name=self.org_name,
-            gcp_project_id="project",
-            gcp_download_bucket="download_bucket",
-            gcp_transform_bucket="transform_bucket",
+            project_id="project",
+            download_bucket="download_bucket",
+            transform_bucket="transform_bucket",
         )
         self.api.put_organisation(organisation)
 
@@ -221,9 +221,9 @@ class TestJstorTelescope(ObservatoryTestCase):
         execution_date = pendulum.datetime(year=2020, month=11, day=1)
         organisation = Organisation(
             name=self.organisation_name,
-            gcp_project_id=self.project_id,
-            gcp_download_bucket=env.download_bucket,
-            gcp_transform_bucket=env.transform_bucket,
+            project_id=self.project_id,
+            download_bucket=env.download_bucket,
+            transform_bucket=env.transform_bucket,
         )
         telescope = JstorTelescope(
             organisation=organisation, publisher_id=self.extra.get("publisher_id"), dataset_id=dataset_id, workflow_id=1

--- a/oaebu_workflows/workflows/tests/test_oapen_irus_uk_telescope.py
+++ b/oaebu_workflows/workflows/tests/test_oapen_irus_uk_telescope.py
@@ -39,6 +39,20 @@ from observatory.platform.utils.test_utils import (
 )
 from observatory.platform.utils.workflow_utils import blob_name, table_ids_from_path
 from requests import Response
+from observatory.api.testing import ObservatoryApiEnvironment
+from observatory.api.client import ApiClient, Configuration
+from observatory.api.client.api.observatory_api import ObservatoryApi  # noqa: E501
+from observatory.api.client.model.organisation import Organisation
+from observatory.api.client.model.telescope import Telescope
+from observatory.api.client.model.telescope_type import TelescopeType
+from observatory.api.client.model.dataset import Dataset
+from observatory.api.client.model.dataset_release import DatasetRelease
+from observatory.api.client.model.dataset_type import DatasetType
+from observatory.api.client.model.table_type import TableType
+from observatory.platform.utils.release_utils import get_dataset_releases
+from observatory.platform.utils.airflow_utils import AirflowConns
+from airflow.models import Connection
+from airflow.utils.state import State
 
 from oaebu_workflows.config import test_fixtures_folder
 from oaebu_workflows.identifiers import TelescopeTypes
@@ -73,6 +87,69 @@ class TestOapenIrusUkTelescope(ObservatoryTestCase):
         self.download_path = test_fixtures_folder("oapen_irus_uk", "download.jsonl.gz")
         self.transform_hash = "0b111b2f"
 
+        # API environment
+        self.host = "localhost"
+        self.port = 5001
+        configuration = Configuration(host=f"http://{self.host}:{self.port}")
+        api_client = ApiClient(configuration)
+        self.api = ObservatoryApi(api_client=api_client)  # noqa: E501
+        self.env = ObservatoryApiEnvironment(host=self.host, port=self.port)
+        self.org_name = "UCL Press"
+
+    def setup_api(self, env=None):
+        dt = pendulum.now("UTC")
+
+        name = "Oapen Metadata Telescope"
+        telescope_type = TelescopeType(name=name, type_id=OapenIrusUkTelescope.DAG_ID_PREFIX)
+        self.api.put_telescope_type(telescope_type)
+
+        gcp_download_bucket = env.download_bucket if env else "download_bucket"
+        gcp_transform_bucket = env.transform_bucket if env else "transform_bucket"
+
+        organisation = Organisation(
+            name=self.org_name,
+            gcp_project_id=self.project_id,
+            gcp_download_bucket=gcp_download_bucket,
+            gcp_transform_bucket=gcp_transform_bucket,
+        )
+        self.api.put_organisation(organisation)
+
+        telescope = Telescope(
+            name=name,
+            telescope_type=TelescopeType(id=1),
+            organisation=Organisation(id=1),
+            extra={},
+        )
+        self.api.put_telescope(telescope)
+
+        table_type = TableType(
+            type_id="partitioned",
+            name="partitioned bq table",
+        )
+        self.api.put_table_type(table_type)
+
+        dataset_type = DatasetType(
+            type_id=OapenIrusUkTelescope.DAG_ID_PREFIX,
+            name="ds type",
+            extra={},
+            table_type=TableType(id=1),
+        )
+        self.api.put_dataset_type(dataset_type)
+
+        dataset = Dataset(
+            name="Oapen Metadata Dataset",
+            address="project.dataset.table",
+            service="bigquery",
+            connection=Telescope(id=1),
+            dataset_type=DatasetType(id=1),
+        )
+        self.api.put_dataset(dataset)
+
+    def setup_connections(self, env):
+        # Add Observatory API connection
+        conn = Connection(conn_id=AirflowConns.OBSERVATORY_API, uri=f"http://:password@{self.host}:{self.port}")
+        env.add_connection(conn)
+
     def test_dag_structure(self):
         """Test that the Oapen Irus Uk DAG has the correct structure.
         :return: None
@@ -90,7 +167,8 @@ class TestOapenIrusUkTelescope(ObservatoryTestCase):
                 "download_transform": ["upload_transformed"],
                 "upload_transformed": ["bq_load_partition"],
                 "bq_load_partition": ["cleanup"],
-                "cleanup": [],
+                "cleanup": ["add_new_dataset_releases"],
+                "add_new_dataset_releases": [],
             },
             dag,
         )
@@ -100,31 +178,11 @@ class TestOapenIrusUkTelescope(ObservatoryTestCase):
         :return: None
         """
 
-        env = ObservatoryEnvironment(self.project_id, self.data_location)
+        env = ObservatoryEnvironment(self.project_id, self.data_location, api_host=self.host, api_port=self.port)
+
         with env.create():
-            # Add Observatory API connection
-            conn = Connection(conn_id=AirflowConns.OBSERVATORY_API, uri=f"http://:password@{self.host}:{self.api_port}")
-            env.add_connection(conn)
-
-            # Add a telescope
-            dt = pendulum.now("UTC")
-            telescope_type = orm.TelescopeType(
-                name="OAPEN Irus UK Telescope", type_id=TelescopeTypes.oapen_irus_uk, created=dt, modified=dt
-            )
-            env.api_session.add(telescope_type)
-            organisation = orm.Organisation(name="UCL Press", created=dt, modified=dt)
-            env.api_session.add(organisation)
-            telescope = orm.Telescope(
-                name="UCL Press OAPEN Irus UK Telescope",
-                telescope_type=telescope_type,
-                organisation=organisation,
-                modified=dt,
-                created=dt,
-                extra=self.extra,
-            )
-            env.api_session.add(telescope)
-            env.api_session.commit()
-
+            self.setup_connections(env)
+            self.setup_api()
             dag_file = os.path.join(module_file_path("oaebu_workflows.dags"), "oapen_irus_uk_telescope.py")
             self.assert_dag_load("oapen_irus_uk_ucl_press", dag_file)
 
@@ -136,7 +194,7 @@ class TestOapenIrusUkTelescope(ObservatoryTestCase):
         :return: None.
         """
         # Setup Observatory environment
-        env = ObservatoryEnvironment(self.project_id, self.data_location)
+        env = ObservatoryEnvironment(self.project_id, self.data_location, api_host=self.host, api_port=self.port)
         dataset_id = env.add_dataset()
 
         # Setup Telescope
@@ -152,6 +210,7 @@ class TestOapenIrusUkTelescope(ObservatoryTestCase):
             publisher_name_v4=self.extra.get("publisher_name_v4"),
             publisher_uuid_v5=self.extra.get("publisher_uuid_v5"),
             dataset_id=dataset_id,
+            workflow_id=1,
         )
         # Fake oapen project and bucket
         OapenIrusUkTelescope.OAPEN_PROJECT_ID = env.project_id
@@ -198,6 +257,8 @@ class TestOapenIrusUkTelescope(ObservatoryTestCase):
 
         # Create the Observatory environment and run tests
         with env.create(task_logging=True):
+            self.setup_connections(env)
+            self.setup_api(env=env)
             with env.create_dag_run(dag, execution_date):
                 # Add airflow connections
                 conn = Connection(conn_id=AirflowConns.GEOIP_LICENSE_KEY, uri="http://email_address:password@")
@@ -267,6 +328,14 @@ class TestOapenIrusUkTelescope(ObservatoryTestCase):
 
                 # Delete oapen bucket
                 env._delete_bucket(OapenIrusUkTelescope.OAPEN_BUCKET)
+
+                # add_dataset_release_task
+                dataset_releases = get_dataset_releases(dataset_id=1)
+                self.assertEqual(len(dataset_releases), 0)
+                ti = env.run_task("add_new_dataset_releases")
+                self.assertEqual(ti.state, State.SUCCESS)
+                dataset_releases = get_dataset_releases(dataset_id=1)
+                self.assertEqual(len(dataset_releases), 1)
 
     @patch("observatory.platform.utils.workflow_utils.Variable.get")
     @patch("oaebu_workflows.workflows.oapen_irus_uk_telescope.upload_source_code_to_bucket")

--- a/oaebu_workflows/workflows/tests/test_oapen_irus_uk_telescope.py
+++ b/oaebu_workflows/workflows/tests/test_oapen_irus_uk_telescope.py
@@ -28,7 +28,6 @@ from click.testing import CliRunner
 from googleapiclient.discovery import build
 from googleapiclient.http import RequestMockBuilder
 from oaebu_workflows.config import test_fixtures_folder
-from oaebu_workflows.identifiers import WorkflowTypes
 from oaebu_workflows.workflows.oapen_irus_uk_telescope import (
     OapenIrusUkRelease,
     OapenIrusUkTelescope,
@@ -53,10 +52,9 @@ from observatory.api.testing import ObservatoryApiEnvironment
 from observatory.api.client import ApiClient, Configuration
 from observatory.api.client.api.observatory_api import ObservatoryApi  # noqa: E501
 from observatory.api.client.model.organisation import Organisation
-from observatory.api.client.model.telescope import Telescope
+from observatory.api.client.model.workflow import Workflow
 from observatory.api.client.model.workflow_type import WorkflowType
 from observatory.api.client.model.dataset import Dataset
-from observatory.api.client.model.dataset_release import DatasetRelease
 from observatory.api.client.model.dataset_type import DatasetType
 from observatory.api.client.model.table_type import TableType
 from observatory.platform.utils.release_utils import get_dataset_releases
@@ -124,13 +122,13 @@ class TestOapenIrusUkTelescope(ObservatoryTestCase):
         )
         self.api.put_organisation(organisation)
 
-        telescope = Telescope(
+        telescope = Workflow(
             name=name,
             workflow_type=WorkflowType(id=1),
             organisation=Organisation(id=1),
             extra={},
         )
-        self.api.put_telescope(telescope)
+        self.api.put_workflow(telescope)
 
         table_type = TableType(
             type_id="partitioned",
@@ -150,7 +148,7 @@ class TestOapenIrusUkTelescope(ObservatoryTestCase):
             name="Oapen Metadata Dataset",
             address="project.dataset.table",
             service="bigquery",
-            connection=Telescope(id=1),
+            connection=Workflow(id=1),
             dataset_type=DatasetType(id=1),
         )
         self.api.put_dataset(dataset)

--- a/oaebu_workflows/workflows/tests/test_oapen_irus_uk_telescope.py
+++ b/oaebu_workflows/workflows/tests/test_oapen_irus_uk_telescope.py
@@ -108,9 +108,9 @@ class TestOapenIrusUkTelescope(ObservatoryTestCase):
 
         organisation = Organisation(
             name=self.org_name,
-            gcp_project_id=self.project_id,
-            gcp_download_bucket=gcp_download_bucket,
-            gcp_transform_bucket=gcp_transform_bucket,
+            project_id=self.project_id,
+            download_bucket=gcp_download_bucket,
+            transform_bucket=gcp_transform_bucket,
         )
         self.api.put_organisation(organisation)
 
@@ -201,9 +201,9 @@ class TestOapenIrusUkTelescope(ObservatoryTestCase):
         execution_date = pendulum.datetime(year=2021, month=2, day=14)
         organisation = Organisation(
             name=self.organisation_name,
-            gcp_project_id=self.project_id,
-            gcp_download_bucket=env.download_bucket,
-            gcp_transform_bucket=env.transform_bucket,
+            project_id=self.project_id,
+            download_bucket=env.download_bucket,
+            transform_bucket=env.transform_bucket,
         )
         telescope = OapenIrusUkTelescope(
             organisation=organisation,
@@ -381,9 +381,9 @@ class TestOapenIrusUkTelescope(ObservatoryTestCase):
             # Create release instance
             org = Organisation(
                 name=self.organisation_name,
-                gcp_project_id=self.project_id,
-                gcp_download_bucket="download_bucket",
-                gcp_transform_bucket="transform_bucket",
+                project_id=self.project_id,
+                download_bucket="download_bucket",
+                transform_bucket="transform_bucket",
             )
             telescope = OapenIrusUkTelescope(
                 org, publisher_name_v4="publisher", publisher_uuid_v5="publisherUUID", dataset_id="dataset_id"
@@ -460,9 +460,9 @@ class TestOapenIrusUkTelescope(ObservatoryTestCase):
             mock_variable_get.return_value = os.path.join(os.getcwd(), "data")
             org = Organisation(
                 name=self.organisation_name,
-                gcp_project_id=self.project_id,
-                gcp_download_bucket="download_bucket",
-                gcp_transform_bucket="transform_bucket",
+                project_id=self.project_id,
+                download_bucket="download_bucket",
+                transform_bucket="transform_bucket",
             )
 
             # Test new platform and old platform

--- a/oaebu_workflows/workflows/tests/test_oapen_irus_uk_telescope.py
+++ b/oaebu_workflows/workflows/tests/test_oapen_irus_uk_telescope.py
@@ -27,6 +27,16 @@ from airflow.models.connection import Connection
 from click.testing import CliRunner
 from googleapiclient.discovery import build
 from googleapiclient.http import RequestMockBuilder
+from oaebu_workflows.config import test_fixtures_folder
+from oaebu_workflows.identifiers import WorkflowTypes
+from oaebu_workflows.workflows.oapen_irus_uk_telescope import (
+    OapenIrusUkRelease,
+    OapenIrusUkTelescope,
+    call_cloud_function,
+    cloud_function_exists,
+    create_cloud_function,
+    upload_source_code_to_bucket,
+)
 from observatory.api.client.model.organisation import Organisation
 from observatory.api.server import orm
 from observatory.platform.utils.airflow_utils import AirflowConns
@@ -44,7 +54,7 @@ from observatory.api.client import ApiClient, Configuration
 from observatory.api.client.api.observatory_api import ObservatoryApi  # noqa: E501
 from observatory.api.client.model.organisation import Organisation
 from observatory.api.client.model.telescope import Telescope
-from observatory.api.client.model.telescope_type import TelescopeType
+from observatory.api.client.model.workflow_type import WorkflowType
 from observatory.api.client.model.dataset import Dataset
 from observatory.api.client.model.dataset_release import DatasetRelease
 from observatory.api.client.model.dataset_type import DatasetType
@@ -100,8 +110,8 @@ class TestOapenIrusUkTelescope(ObservatoryTestCase):
         dt = pendulum.now("UTC")
 
         name = "Oapen Metadata Telescope"
-        telescope_type = TelescopeType(name=name, type_id=OapenIrusUkTelescope.DAG_ID_PREFIX)
-        self.api.put_telescope_type(telescope_type)
+        workflow_type = WorkflowType(name=name, type_id=OapenIrusUkTelescope.DAG_ID_PREFIX)
+        self.api.put_workflow_type(workflow_type)
 
         gcp_download_bucket = env.download_bucket if env else "download_bucket"
         gcp_transform_bucket = env.transform_bucket if env else "transform_bucket"
@@ -116,7 +126,7 @@ class TestOapenIrusUkTelescope(ObservatoryTestCase):
 
         telescope = Telescope(
             name=name,
-            telescope_type=TelescopeType(id=1),
+            workflow_type=WorkflowType(id=1),
             organisation=Organisation(id=1),
             extra={},
         )

--- a/oaebu_workflows/workflows/tests/test_oapen_irus_uk_telescope.py
+++ b/oaebu_workflows/workflows/tests/test_oapen_irus_uk_telescope.py
@@ -148,7 +148,7 @@ class TestOapenIrusUkTelescope(ObservatoryTestCase):
             name="Oapen Metadata Dataset",
             address="project.dataset.table",
             service="bigquery",
-            connection=Workflow(id=1),
+            workflow=Workflow(id=1),
             dataset_type=DatasetType(id=1),
         )
         self.api.put_dataset(dataset)

--- a/oaebu_workflows/workflows/tests/test_oapen_irus_uk_telescope.py
+++ b/oaebu_workflows/workflows/tests/test_oapen_irus_uk_telescope.py
@@ -63,7 +63,6 @@ from airflow.models import Connection
 from airflow.utils.state import State
 
 from oaebu_workflows.config import test_fixtures_folder
-from oaebu_workflows.identifiers import TelescopeTypes
 from oaebu_workflows.workflows.oapen_irus_uk_telescope import (
     OapenIrusUkRelease,
     OapenIrusUkTelescope,

--- a/oaebu_workflows/workflows/tests/test_oapen_metadata_telescope.py
+++ b/oaebu_workflows/workflows/tests/test_oapen_metadata_telescope.py
@@ -131,7 +131,7 @@ class TestOapenMetadataTelescope(ObservatoryTestCase):
             name="Oapen Metadata Dataset",
             address="project.dataset.table",
             service="bigquery",
-            connection=Workflow(id=1),
+            workflow=Workflow(id=1),
             dataset_type=DatasetType(id=1),
         )
         self.api.put_dataset(dataset)

--- a/oaebu_workflows/workflows/tests/test_oapen_metadata_telescope.py
+++ b/oaebu_workflows/workflows/tests/test_oapen_metadata_telescope.py
@@ -41,6 +41,21 @@ from observatory.platform.utils.workflow_utils import (
     create_date_table_id,
     table_ids_from_path,
 )
+from observatory.api.testing import ObservatoryApiEnvironment
+from observatory.api.client import ApiClient, Configuration
+from observatory.api.client.api.observatory_api import ObservatoryApi  # noqa: E501
+from observatory.api.client.model.organisation import Organisation
+from observatory.api.client.model.telescope import Telescope
+from observatory.api.client.model.telescope_type import TelescopeType
+from observatory.api.client.model.dataset import Dataset
+from observatory.api.client.model.dataset_release import DatasetRelease
+from observatory.api.client.model.dataset_type import DatasetType
+from observatory.api.client.model.table_type import TableType
+from observatory.platform.utils.release_utils import get_dataset_releases
+from observatory.platform.utils.airflow_utils import AirflowConns
+from airflow.models import Connection
+from airflow.utils.state import State
+import responses
 
 
 class TestOapenMetadataTelescope(ObservatoryTestCase):
@@ -60,13 +75,73 @@ class TestOapenMetadataTelescope(ObservatoryTestCase):
         self.first_execution_date = pendulum.datetime(year=2021, month=2, day=1)
 
         self.second_download_path = test_fixtures_folder("oapen_metadata", "oapen_metadata2.csv")
-        self.second_execution_date = pendulum.datetime(year=2021, month=2, day=7)
+        self.second_execution_date = pendulum.datetime(year=2021, month=2, day=8)
+
+        # API environment
+        self.host = "localhost"
+        self.port = 5001
+        configuration = Configuration(host=f"http://{self.host}:{self.port}")
+        api_client = ApiClient(configuration)
+        self.api = ObservatoryApi(api_client=api_client)  # noqa: E501
+        self.env = ObservatoryApiEnvironment(host=self.host, port=self.port)
+        self.org_name = "Curtin Press"
 
     def setup_environment(self) -> ObservatoryEnvironment:
         """Setup observatory environment"""
-        env = ObservatoryEnvironment(self.project_id, self.data_location)
+        env = ObservatoryEnvironment(self.project_id, self.data_location, api_host=self.host, api_port=self.port)
         self.dataset_id = env.add_dataset()
         return env
+
+    def setup_api(self):
+        dt = pendulum.now("UTC")
+
+        name = "Oapen Metadata Telescope"
+        telescope_type = TelescopeType(name=name, type_id=OapenMetadataTelescope.DAG_ID)
+        self.api.put_telescope_type(telescope_type)
+
+        organisation = Organisation(
+            name=self.org_name,
+            gcp_project_id="project",
+            gcp_download_bucket="download_bucket",
+            gcp_transform_bucket="transform_bucket",
+        )
+        self.api.put_organisation(organisation)
+
+        telescope = Telescope(
+            name=name,
+            telescope_type=TelescopeType(id=1),
+            organisation=Organisation(id=1),
+            extra={},
+        )
+        self.api.put_telescope(telescope)
+
+        table_type = TableType(
+            type_id="partitioned",
+            name="partitioned bq table",
+        )
+        self.api.put_table_type(table_type)
+
+        dataset_type = DatasetType(
+            type_id=OapenMetadataTelescope.DAG_ID,
+            name="ds type",
+            extra={},
+            table_type=TableType(id=1),
+        )
+        self.api.put_dataset_type(dataset_type)
+
+        dataset = Dataset(
+            name="Oapen Metadata Dataset",
+            address="project.dataset.table",
+            service="bigquery",
+            connection=Telescope(id=1),
+            dataset_type=DatasetType(id=1),
+        )
+        self.api.put_dataset(dataset)
+
+    def setup_connections(self, env):
+        # Add Observatory API connection
+        conn = Connection(conn_id=AirflowConns.OBSERVATORY_API, uri=f"http://:password@{self.host}:{self.port}")
+        env.add_connection(conn)
 
     def test_dag_structure(self):
         """Test that the Oapen Metadata DAG has the correct structure.
@@ -84,7 +159,8 @@ class TestOapenMetadataTelescope(ObservatoryTestCase):
                 "bq_load_partition": ["bq_delete_old"],
                 "bq_delete_old": ["bq_append_new"],
                 "bq_append_new": ["cleanup"],
-                "cleanup": [],
+                "cleanup": ["add_new_dataset_releases"],
+                "add_new_dataset_releases": [],
             },
             dag,
         )
@@ -94,9 +170,11 @@ class TestOapenMetadataTelescope(ObservatoryTestCase):
 
         :return: None
         """
+        env = ObservatoryEnvironment(self.project_id, self.data_location, api_host=self.host, api_port=self.port)
 
-        env = ObservatoryEnvironment(self.project_id, self.data_location)
         with env.create():
+            self.setup_connections(env)
+            self.setup_api()
             dag_file = os.path.join(module_file_path("oaebu_workflows.dags"), "oapen_metadata_telescope.py")
             self.assert_dag_load("oapen_metadata", dag_file)
 
@@ -104,28 +182,30 @@ class TestOapenMetadataTelescope(ObservatoryTestCase):
         """Test telescope task execution."""
 
         env = self.setup_environment()
-        telescope = OapenMetadataTelescope(dataset_id=self.dataset_id)
+        telescope = OapenMetadataTelescope(dataset_id=self.dataset_id, workflow_id=1)
         dag = telescope.make_dag()
 
         with env.create(task_logging=True):
+            self.setup_connections(env)
+            self.setup_api()
             # first run
             with env.create_dag_run(dag, self.first_execution_date) as first_dagrun:
                 # Test that all dependencies are specified: no error should be thrown
                 env.run_task(telescope.check_dependencies.__name__)
 
                 start_date, end_date, first_release = telescope.get_release_info(
-                    execution_date=self.first_execution_date,
-                    dag_run=first_dagrun,
                     dag=dag,
-                    next_execution_date=self.second_execution_date,
+                    data_interval_end=pendulum.datetime(2021, 1, 31),
                 )
 
                 # Use release info for other tasks
                 release = OapenMetadataRelease(telescope.dag_id, start_date, end_date, first_release)
 
                 # Test download task
-                with httpretty.enabled():
-                    self.setup_mock_file_download(OapenMetadataTelescope.CSV_URL, self.first_download_path)
+                with responses.RequestsMock() as rsps:
+                    with open(self.first_download_path, "rb") as f:
+                        body = f.read()
+                    rsps.add(responses.GET, OapenMetadataTelescope.CSV_URL, body=body, status=200)
                     env.run_task(telescope.download.__name__)
 
                 self.assertEqual(1, len(release.download_files))
@@ -151,12 +231,12 @@ class TestOapenMetadataTelescope(ObservatoryTestCase):
 
                 # Test that load partition task is skipped for the first release
                 ti = env.run_task(telescope.bq_load_partition.__name__)
-                self.assertEqual(ti.state, "skipped")
+                self.assertEqual(ti.state, State.SUCCESS)
 
                 # Test delete old task is skipped for the first release
                 with patch("observatory.platform.utils.gc_utils.bq_query_bytes_daily_limit_check"):
                     ti = env.run_task(telescope.bq_delete_old.__name__)
-                self.assertEqual(ti.state, "skipped")
+                self.assertEqual(ti.state, State.SUCCESS)
 
                 # Test append new creates table
                 env.run_task(telescope.bq_append_new.__name__)
@@ -174,28 +254,36 @@ class TestOapenMetadataTelescope(ObservatoryTestCase):
                 env.run_task(telescope.cleanup.__name__)
                 self.assert_cleanup(download_folder, extract_folder, transform_folder)
 
-                # second run
+                # add_dataset_release_task
+                dataset_releases = get_dataset_releases(dataset_id=1)
+                self.assertEqual(len(dataset_releases), 0)
+                ti = env.run_task("add_new_dataset_releases")
+                self.assertEqual(ti.state, State.SUCCESS)
+                dataset_releases = get_dataset_releases(dataset_id=1)
+                self.assertEqual(len(dataset_releases), 1)
+
+            # second run
             with env.create_dag_run(dag, self.second_execution_date) as second_dagrun:
                 # Test that all dependencies are specified: no error should be thrown
                 env.run_task(telescope.check_dependencies.__name__)
 
                 start_date, end_date, first_release = telescope.get_release_info(
-                    execution_date=self.second_execution_date,
-                    dag_run=second_dagrun,
                     dag=dag,
-                    next_execution_date=pendulum.datetime(2021, 2, 14),
+                    data_interval_end=pendulum.datetime(2021, 2, 7),
                 )
 
-                self.assertEqual(release.end_date + timedelta(days=1), start_date)
-                self.assertEqual(pendulum.today("UTC") - timedelta(days=1), end_date)
+                self.assertEqual(release.end_date, start_date)
+                self.assertEqual(pendulum.datetime(2021, 2, 7), end_date)
                 self.assertFalse(first_release)
 
                 # use release info for other tasks
                 release = OapenMetadataRelease(telescope.dag_id, start_date, end_date, first_release)
 
                 # Test download task
-                with httpretty.enabled():
-                    self.setup_mock_file_download(OapenMetadataTelescope.CSV_URL, self.second_download_path)
+                with responses.RequestsMock() as rsps:
+                    with open(self.second_download_path, "rb") as f:
+                        body = f.read()
+                    rsps.add(responses.GET, OapenMetadataTelescope.CSV_URL, body=body, status=200)
                     env.run_task(telescope.download.__name__)
 
                 self.assertEqual(1, len(release.download_files))
@@ -248,6 +336,14 @@ class TestOapenMetadataTelescope(ObservatoryTestCase):
                 )
                 env.run_task(telescope.cleanup.__name__)
                 self.assert_cleanup(download_folder, extract_folder, transform_folder)
+
+                # add_dataset_release_task
+                dataset_releases = get_dataset_releases(dataset_id=1)
+                self.assertEqual(len(dataset_releases), 1)
+                ti = env.run_task("add_new_dataset_releases")
+                self.assertEqual(ti.state, State.SUCCESS)
+                dataset_releases = get_dataset_releases(dataset_id=1)
+                self.assertEqual(len(dataset_releases), 2)
 
     def test_airflow_vars(self):
         """Cover case when airflow_vars is given."""

--- a/oaebu_workflows/workflows/tests/test_oapen_metadata_telescope.py
+++ b/oaebu_workflows/workflows/tests/test_oapen_metadata_telescope.py
@@ -15,7 +15,6 @@
 # Author: Aniek Roelofs, Tuan Chien
 
 import os
-from datetime import timedelta
 from unittest.mock import patch
 
 import httpretty
@@ -45,10 +44,9 @@ from observatory.api.testing import ObservatoryApiEnvironment
 from observatory.api.client import ApiClient, Configuration
 from observatory.api.client.api.observatory_api import ObservatoryApi  # noqa: E501
 from observatory.api.client.model.organisation import Organisation
-from observatory.api.client.model.telescope import Telescope
+from observatory.api.client.model.workflow import Workflow
 from observatory.api.client.model.workflow_type import WorkflowType
 from observatory.api.client.model.dataset import Dataset
-from observatory.api.client.model.dataset_release import DatasetRelease
 from observatory.api.client.model.dataset_type import DatasetType
 from observatory.api.client.model.table_type import TableType
 from observatory.platform.utils.release_utils import get_dataset_releases
@@ -107,13 +105,13 @@ class TestOapenMetadataTelescope(ObservatoryTestCase):
         )
         self.api.put_organisation(organisation)
 
-        telescope = Telescope(
+        telescope = Workflow(
             name=name,
             workflow_type=WorkflowType(id=1),
             organisation=Organisation(id=1),
             extra={},
         )
-        self.api.put_telescope(telescope)
+        self.api.put_workflow(telescope)
 
         table_type = TableType(
             type_id="partitioned",
@@ -133,7 +131,7 @@ class TestOapenMetadataTelescope(ObservatoryTestCase):
             name="Oapen Metadata Dataset",
             address="project.dataset.table",
             service="bigquery",
-            connection=Telescope(id=1),
+            connection=Workflow(id=1),
             dataset_type=DatasetType(id=1),
         )
         self.api.put_dataset(dataset)

--- a/oaebu_workflows/workflows/tests/test_oapen_metadata_telescope.py
+++ b/oaebu_workflows/workflows/tests/test_oapen_metadata_telescope.py
@@ -101,9 +101,9 @@ class TestOapenMetadataTelescope(ObservatoryTestCase):
 
         organisation = Organisation(
             name=self.org_name,
-            gcp_project_id="project",
-            gcp_download_bucket="download_bucket",
-            gcp_transform_bucket="transform_bucket",
+            project_id="project",
+            download_bucket="download_bucket",
+            transform_bucket="transform_bucket",
         )
         self.api.put_organisation(organisation)
 

--- a/oaebu_workflows/workflows/tests/test_oapen_metadata_telescope.py
+++ b/oaebu_workflows/workflows/tests/test_oapen_metadata_telescope.py
@@ -46,7 +46,7 @@ from observatory.api.client import ApiClient, Configuration
 from observatory.api.client.api.observatory_api import ObservatoryApi  # noqa: E501
 from observatory.api.client.model.organisation import Organisation
 from observatory.api.client.model.telescope import Telescope
-from observatory.api.client.model.telescope_type import TelescopeType
+from observatory.api.client.model.workflow_type import WorkflowType
 from observatory.api.client.model.dataset import Dataset
 from observatory.api.client.model.dataset_release import DatasetRelease
 from observatory.api.client.model.dataset_type import DatasetType
@@ -96,8 +96,8 @@ class TestOapenMetadataTelescope(ObservatoryTestCase):
         dt = pendulum.now("UTC")
 
         name = "Oapen Metadata Telescope"
-        telescope_type = TelescopeType(name=name, type_id=OapenMetadataTelescope.DAG_ID)
-        self.api.put_telescope_type(telescope_type)
+        workflow_type = WorkflowType(name=name, type_id=OapenMetadataTelescope.DAG_ID)
+        self.api.put_workflow_type(workflow_type)
 
         organisation = Organisation(
             name=self.org_name,
@@ -109,7 +109,7 @@ class TestOapenMetadataTelescope(ObservatoryTestCase):
 
         telescope = Telescope(
             name=name,
-            telescope_type=TelescopeType(id=1),
+            workflow_type=WorkflowType(id=1),
             organisation=Organisation(id=1),
             extra={},
         )

--- a/oaebu_workflows/workflows/tests/test_oapen_workflow.py
+++ b/oaebu_workflows/workflows/tests/test_oapen_workflow.py
@@ -43,7 +43,7 @@ from observatory.api.client import ApiClient, Configuration
 from observatory.api.client.api.observatory_api import ObservatoryApi  # noqa: E501
 from observatory.api.client.model.organisation import Organisation
 from observatory.api.client.model.telescope import Telescope
-from observatory.api.client.model.telescope_type import TelescopeType
+from observatory.api.client.model.workflow_type import WorkflowType
 from observatory.api.client.model.dataset import Dataset
 from observatory.api.client.model.dataset_release import DatasetRelease
 from observatory.api.client.model.dataset_type import DatasetType
@@ -171,8 +171,8 @@ class TestOapenWorkflowFunctional(ObservatoryTestCase):
         dt = pendulum.now("UTC")
 
         name = "Oapen Workflow"
-        telescope_type = TelescopeType(name=name, type_id=OapenWorkflow.DAG_ID_PREFIX)
-        self.api.put_telescope_type(telescope_type)
+        workflow_type = WorkflowType(name=name, type_id=OapenWorkflow.DAG_ID_PREFIX)
+        self.api.put_workflow_type(workflow_type)
 
         organisation = Organisation(
             name=self.org_name,
@@ -184,7 +184,7 @@ class TestOapenWorkflowFunctional(ObservatoryTestCase):
 
         telescope = Telescope(
             name=name,
-            telescope_type=TelescopeType(id=1),
+            workflow_type=WorkflowType(id=1),
             organisation=Organisation(id=1),
             extra={},
         )

--- a/oaebu_workflows/workflows/tests/test_oapen_workflow.py
+++ b/oaebu_workflows/workflows/tests/test_oapen_workflow.py
@@ -176,9 +176,9 @@ class TestOapenWorkflowFunctional(ObservatoryTestCase):
 
         organisation = Organisation(
             name=self.org_name,
-            gcp_project_id="project",
-            gcp_download_bucket="download_bucket",
-            gcp_transform_bucket="transform_bucket",
+            project_id="project",
+            download_bucket="download_bucket",
+            transform_bucket="transform_bucket",
         )
         self.api.put_organisation(organisation)
 

--- a/oaebu_workflows/workflows/tests/test_oapen_workflow.py
+++ b/oaebu_workflows/workflows/tests/test_oapen_workflow.py
@@ -207,7 +207,7 @@ class TestOapenWorkflowFunctional(ObservatoryTestCase):
             name="Oapen Example Dataset",
             address="project.dataset.table",
             service="bigquery",
-            connection=Workflow(id=1),
+            workflow=Workflow(id=1),
             dataset_type=DatasetType(id=1),
         )
         self.api.put_dataset(dataset)

--- a/oaebu_workflows/workflows/tests/test_oapen_workflow.py
+++ b/oaebu_workflows/workflows/tests/test_oapen_workflow.py
@@ -42,10 +42,9 @@ from observatory.api.testing import ObservatoryApiEnvironment
 from observatory.api.client import ApiClient, Configuration
 from observatory.api.client.api.observatory_api import ObservatoryApi  # noqa: E501
 from observatory.api.client.model.organisation import Organisation
-from observatory.api.client.model.telescope import Telescope
+from observatory.api.client.model.workflow import Workflow
 from observatory.api.client.model.workflow_type import WorkflowType
 from observatory.api.client.model.dataset import Dataset
-from observatory.api.client.model.dataset_release import DatasetRelease
 from observatory.api.client.model.dataset_type import DatasetType
 from observatory.api.client.model.table_type import TableType
 from observatory.platform.utils.release_utils import get_dataset_releases
@@ -182,13 +181,13 @@ class TestOapenWorkflowFunctional(ObservatoryTestCase):
         )
         self.api.put_organisation(organisation)
 
-        telescope = Telescope(
+        telescope = Workflow(
             name=name,
             workflow_type=WorkflowType(id=1),
             organisation=Organisation(id=1),
             extra={},
         )
-        self.api.put_telescope(telescope)
+        self.api.put_workflow(telescope)
 
         table_type = TableType(
             type_id="partitioned",
@@ -208,7 +207,7 @@ class TestOapenWorkflowFunctional(ObservatoryTestCase):
             name="Oapen Example Dataset",
             address="project.dataset.table",
             service="bigquery",
-            connection=Telescope(id=1),
+            connection=Workflow(id=1),
             dataset_type=DatasetType(id=1),
         )
         self.api.put_dataset(dataset)

--- a/oaebu_workflows/workflows/tests/test_oapen_workflow.py
+++ b/oaebu_workflows/workflows/tests/test_oapen_workflow.py
@@ -38,6 +38,20 @@ from observatory.platform.utils.test_utils import (
 from observatory.platform.utils.workflow_utils import (
     make_dag_id,
 )
+from observatory.api.testing import ObservatoryApiEnvironment
+from observatory.api.client import ApiClient, Configuration
+from observatory.api.client.api.observatory_api import ObservatoryApi  # noqa: E501
+from observatory.api.client.model.organisation import Organisation
+from observatory.api.client.model.telescope import Telescope
+from observatory.api.client.model.telescope_type import TelescopeType
+from observatory.api.client.model.dataset import Dataset
+from observatory.api.client.model.dataset_release import DatasetRelease
+from observatory.api.client.model.dataset_type import DatasetType
+from observatory.api.client.model.table_type import TableType
+from observatory.platform.utils.release_utils import get_dataset_releases
+from observatory.platform.utils.airflow_utils import AirflowConns
+from airflow.models import Connection
+from airflow.utils.state import State
 
 
 class TestOapenWorkflow(ObservatoryTestCase):
@@ -112,7 +126,8 @@ class TestOapenWorkflow(ObservatoryTestCase):
                         "export_oaebu_table.book_product_author_metrics"
                     ],
                     "export_oaebu_table.book_product_author_metrics": ["cleanup"],
-                    "cleanup": [],
+                    "cleanup": ["add_new_dataset_releases"],
+                    "add_new_dataset_releases": [],
                 },
                 dag,
             )
@@ -144,6 +159,65 @@ class TestOapenWorkflowFunctional(ObservatoryTestCase):
 
         self.irus_uk_dataset_id = "fixtures"
 
+        # API environment
+        self.host = "localhost"
+        self.port = 5001
+        configuration = Configuration(host=f"http://{self.host}:{self.port}")
+        api_client = ApiClient(configuration)
+        self.api = ObservatoryApi(api_client=api_client)  # noqa: E501
+        self.env = ObservatoryApiEnvironment(host=self.host, port=self.port)
+
+    def setup_api(self):
+        dt = pendulum.now("UTC")
+
+        name = "Oapen Workflow"
+        telescope_type = TelescopeType(name=name, type_id=OapenWorkflow.DAG_ID_PREFIX)
+        self.api.put_telescope_type(telescope_type)
+
+        organisation = Organisation(
+            name=self.org_name,
+            gcp_project_id="project",
+            gcp_download_bucket="download_bucket",
+            gcp_transform_bucket="transform_bucket",
+        )
+        self.api.put_organisation(organisation)
+
+        telescope = Telescope(
+            name=name,
+            telescope_type=TelescopeType(id=1),
+            organisation=Organisation(id=1),
+            extra={},
+        )
+        self.api.put_telescope(telescope)
+
+        table_type = TableType(
+            type_id="partitioned",
+            name="partitioned bq table",
+        )
+        self.api.put_table_type(table_type)
+
+        dataset_type = DatasetType(
+            type_id=OapenWorkflow.DAG_ID_PREFIX,
+            name="ds type",
+            extra={},
+            table_type=TableType(id=1),
+        )
+        self.api.put_dataset_type(dataset_type)
+
+        dataset = Dataset(
+            name="Oapen Example Dataset",
+            address="project.dataset.table",
+            service="bigquery",
+            connection=Telescope(id=1),
+            dataset_type=DatasetType(id=1),
+        )
+        self.api.put_dataset(dataset)
+
+    def setup_connections(self, env):
+        # Add Observatory API connection
+        conn = Connection(conn_id=AirflowConns.OBSERVATORY_API, uri=f"http://:password@{self.host}:{self.port}")
+        env.add_connection(conn)
+
     def setup_fake_data(self, settings_dataset_id: str, release_date: pendulum.DateTime):
         country = load_jsonl(test_fixtures_folder("onix_workflow", "country.jsonl"))
         schema_path = test_fixtures_folder("onix_workflow", "schema")
@@ -159,14 +233,18 @@ class TestOapenWorkflowFunctional(ObservatoryTestCase):
         ]
 
         bq_load_tables(
-            tables=tables, bucket_name=self.gcp_bucket_name, release_date=release_date, data_location=self.data_location
+            tables=tables,
+            bucket_name=self.gcp_bucket_name,
+            release_date=release_date,
+            data_location=self.data_location,
+            project_id=self.gcp_project_id,
         )
 
     def test_run_workflow_tests(self):
         """Functional test of the OAPEN workflow"""
 
         # Setup Observatory environment
-        env = ObservatoryEnvironment(self.gcp_project_id, self.data_location, enable_api=False)
+        env = ObservatoryEnvironment(self.gcp_project_id, self.data_location, api_port=self.port, api_host=self.host)
         org_name = self.org_name
 
         # Create datasets
@@ -179,6 +257,8 @@ class TestOapenWorkflowFunctional(ObservatoryTestCase):
         # Create the Observatory environment and run tests
         with env.create(task_logging=True):
             self.gcp_bucket_name = env.transform_bucket
+            self.setup_connections(env)
+            self.setup_api()
 
             # Setup workflow
             start_date = pendulum.datetime(year=2021, month=5, day=9)
@@ -191,6 +271,7 @@ class TestOapenWorkflowFunctional(ObservatoryTestCase):
                 start_date=start_date,
                 country_project_id=self.gcp_project_id,
                 country_dataset_id=oaebu_settings_dataset_id,
+                workflow_id=1,
             )
 
             # Override sensor grace period and dag check
@@ -300,9 +381,9 @@ class TestOapenWorkflowFunctional(ObservatoryTestCase):
                 # Ensure there are no duplicates
                 sql = f"""  SELECT
                                 count
-                            FROM(SELECT 
+                            FROM(SELECT
                                 COUNT(*) as count
-                                FROM {self.gcp_project_id}.{oaebu_elastic_dataset_id}.{self.gcp_project_id.replace('-', '_')}_book_product_metrics{release_suffix} 
+                                FROM {self.gcp_project_id}.{oaebu_elastic_dataset_id}.{self.gcp_project_id.replace('-', '_')}_book_product_metrics{release_suffix}
                                 GROUP BY product_id, month)
                             WHERE count > 1"""
                 records = run_bigquery_query(sql)
@@ -310,3 +391,11 @@ class TestOapenWorkflowFunctional(ObservatoryTestCase):
 
                 # Cleanup
                 env.run_task(workflow.cleanup.__name__)
+
+                # add_dataset_release_task
+                dataset_releases = get_dataset_releases(dataset_id=1)
+                self.assertEqual(len(dataset_releases), 0)
+                ti = env.run_task("add_new_dataset_releases")
+                self.assertEqual(ti.state, State.SUCCESS)
+                dataset_releases = get_dataset_releases(dataset_id=1)
+                self.assertEqual(len(dataset_releases), 1)

--- a/oaebu_workflows/workflows/tests/test_onix_telescope.py
+++ b/oaebu_workflows/workflows/tests/test_onix_telescope.py
@@ -175,15 +175,12 @@ class TestOnixTelescope(ObservatoryTestCase):
         :return: None
         """
 
-        env = ObservatoryEnvironment(self.project_id, self.data_location, api_host=self.host, api_port=self.api_port)
+        env = ObservatoryEnvironment(self.project_id, self.data_location, api_host=self.host, api_port=self.port)
         with env.create():
-            env = ObservatoryEnvironment(self.project_id, self.data_location, api_host=self.host, api_port=self.port)
-
-            with env.create():
-                self.setup_connections(env)
-                self.setup_api()
-                dag_file = os.path.join(module_file_path("oaebu_workflows.dags"), "onix_telescope.py")
-                self.assert_dag_load("onix_curtin_press", dag_file)
+            self.setup_connections(env)
+            self.setup_api()
+            dag_file = os.path.join(module_file_path("oaebu_workflows.dags"), "onix_telescope.py")
+            self.assert_dag_load("onix_curtin_press", dag_file)
 
     def test_telescope(self):
         """Test the ONIX telescope end to end.

--- a/oaebu_workflows/workflows/tests/test_onix_telescope.py
+++ b/oaebu_workflows/workflows/tests/test_onix_telescope.py
@@ -17,12 +17,10 @@
 import os
 import shutil
 
-import observatory.api.server.orm as orm
 import pendulum
 from airflow.models.connection import Connection
 from airflow.utils.state import State
 from oaebu_workflows.config import test_fixtures_folder
-from oaebu_workflows.identifiers import WorkflowTypes
 from oaebu_workflows.workflows.onix_telescope import OnixTelescope
 from observatory.platform.utils.airflow_utils import AirflowConns
 from observatory.platform.utils.file_utils import get_file_hash
@@ -43,10 +41,9 @@ from observatory.api.testing import ObservatoryApiEnvironment
 from observatory.api.client import ApiClient, Configuration
 from observatory.api.client.api.observatory_api import ObservatoryApi  # noqa: E501
 from observatory.api.client.model.organisation import Organisation
-from observatory.api.client.model.telescope import Telescope
+from observatory.api.client.model.workflow import Workflow
 from observatory.api.client.model.workflow_type import WorkflowType
 from observatory.api.client.model.dataset import Dataset
-from observatory.api.client.model.dataset_release import DatasetRelease
 from observatory.api.client.model.dataset_type import DatasetType
 from observatory.api.client.model.table_type import TableType
 from observatory.platform.utils.release_utils import get_dataset_releases
@@ -101,13 +98,13 @@ class TestOnixTelescope(ObservatoryTestCase):
         )
         self.api.put_organisation(organisation)
 
-        telescope = Telescope(
+        telescope = Workflow(
             name=name,
             workflow_type=WorkflowType(id=1),
             organisation=Organisation(id=1),
             extra={},
         )
-        self.api.put_telescope(telescope)
+        self.api.put_workflow(telescope)
 
         table_type = TableType(
             type_id="partitioned",
@@ -127,7 +124,7 @@ class TestOnixTelescope(ObservatoryTestCase):
             name="Ucl Discovery Dataset",
             address="project.dataset.table",
             service="bigquery",
-            connection=Telescope(id=1),
+            connection=Workflow(id=1),
             dataset_type=DatasetType(id=1),
         )
         self.api.put_dataset(dataset)

--- a/oaebu_workflows/workflows/tests/test_onix_telescope.py
+++ b/oaebu_workflows/workflows/tests/test_onix_telescope.py
@@ -95,9 +95,9 @@ class TestOnixTelescope(ObservatoryTestCase):
 
         organisation = Organisation(
             name=self.org_name,
-            gcp_project_id="project",
-            gcp_download_bucket="download_bucket",
-            gcp_transform_bucket="transform_bucket",
+            project_id="project",
+            download_bucket="download_bucket",
+            transform_bucket="transform_bucket",
         )
         self.api.put_organisation(organisation)
 

--- a/oaebu_workflows/workflows/tests/test_onix_telescope.py
+++ b/oaebu_workflows/workflows/tests/test_onix_telescope.py
@@ -124,7 +124,7 @@ class TestOnixTelescope(ObservatoryTestCase):
             name="Ucl Discovery Dataset",
             address="project.dataset.table",
             service="bigquery",
-            connection=Workflow(id=1),
+            workflow=Workflow(id=1),
             dataset_type=DatasetType(id=1),
         )
         self.api.put_dataset(dataset)

--- a/oaebu_workflows/workflows/tests/test_onix_telescope.py
+++ b/oaebu_workflows/workflows/tests/test_onix_telescope.py
@@ -22,7 +22,7 @@ import pendulum
 from airflow.models.connection import Connection
 from airflow.utils.state import State
 from oaebu_workflows.config import test_fixtures_folder
-from oaebu_workflows.identifiers import TelescopeTypes
+from oaebu_workflows.identifiers import WorkflowTypes
 from oaebu_workflows.workflows.onix_telescope import OnixTelescope
 from observatory.platform.utils.airflow_utils import AirflowConns
 from observatory.platform.utils.file_utils import get_file_hash
@@ -44,7 +44,7 @@ from observatory.api.client import ApiClient, Configuration
 from observatory.api.client.api.observatory_api import ObservatoryApi  # noqa: E501
 from observatory.api.client.model.organisation import Organisation
 from observatory.api.client.model.telescope import Telescope
-from observatory.api.client.model.telescope_type import TelescopeType
+from observatory.api.client.model.workflow_type import WorkflowType
 from observatory.api.client.model.dataset import Dataset
 from observatory.api.client.model.dataset_release import DatasetRelease
 from observatory.api.client.model.dataset_type import DatasetType
@@ -90,8 +90,8 @@ class TestOnixTelescope(ObservatoryTestCase):
         dt = pendulum.now("UTC")
 
         name = "Ucl Discovery Telescope"
-        telescope_type = TelescopeType(name=name, type_id=OnixTelescope.DAG_ID_PREFIX)
-        self.api.put_telescope_type(telescope_type)
+        workflow_type = WorkflowType(name=name, type_id=OnixTelescope.DAG_ID_PREFIX)
+        self.api.put_workflow_type(workflow_type)
 
         organisation = Organisation(
             name=self.org_name,
@@ -103,7 +103,7 @@ class TestOnixTelescope(ObservatoryTestCase):
 
         telescope = Telescope(
             name=name,
-            telescope_type=TelescopeType(id=1),
+            workflow_type=WorkflowType(id=1),
             organisation=Organisation(id=1),
             extra={},
         )

--- a/oaebu_workflows/workflows/tests/test_onix_workflow.py
+++ b/oaebu_workflows/workflows/tests/test_onix_workflow.py
@@ -31,7 +31,7 @@ from google.cloud.bigquery import SourceFormat
 import observatory.api.server.orm as orm
 from oaebu_workflows.config import schema_folder as default_schema_folder
 from oaebu_workflows.config import test_fixtures_folder
-from oaebu_workflows.identifiers import TelescopeTypes
+from oaebu_workflows.identifiers import WorkflowTypes
 from oaebu_workflows.workflows.oaebu_partners import OaebuPartner, OaebuPartnerName
 from oaebu_workflows.workflows.onix_workflow import OnixWorkflow, OnixWorkflowRelease
 from observatory.api.server.orm import (
@@ -66,7 +66,7 @@ from observatory.api.client import ApiClient, Configuration
 from observatory.api.client.api.observatory_api import ObservatoryApi  # noqa: E501
 from observatory.api.client.model.organisation import Organisation
 from observatory.api.client.model.telescope import Telescope
-from observatory.api.client.model.telescope_type import TelescopeType
+from observatory.api.client.model.workflow_type import WorkflowType
 from observatory.api.client.model.dataset import Dataset
 from observatory.api.client.model.dataset_release import DatasetRelease
 from observatory.api.client.model.dataset_type import DatasetType
@@ -1586,11 +1586,11 @@ class TestOnixWorkflowFunctional(ObservatoryTestCase):
         dt = pendulum.now("UTC")
 
         name = "Onix Workflow"
-        telescope_type = TelescopeType(name=name, type_id=OnixWorkflow.DAG_ID_PREFIX)
-        self.api.put_telescope_type(telescope_type)
+        workflow_type = WorkflowType(name=name, type_id=OnixWorkflow.DAG_ID_PREFIX)
+        self.api.put_workflow_type(workflow_type)
 
-        telescope_type = TelescopeType(name="onix telescope", type_id="onix")
-        self.api.put_telescope_type(telescope_type)
+        workflow_type = WorkflowType(name="onix telescope", type_id="onix")
+        self.api.put_workflow_type(workflow_type)
 
         table_type = TableType(
             type_id="partitioned",
@@ -1620,7 +1620,7 @@ class TestOnixWorkflowFunctional(ObservatoryTestCase):
 
             telescope = Telescope(
                 name=name,
-                telescope_type=TelescopeType(id=2),  # onix telescope
+                workflow_type=WorkflowType(id=2),  # onix telescope
                 organisation=Organisation(id=organisation.id),
                 extra={},
             )
@@ -1628,7 +1628,7 @@ class TestOnixWorkflowFunctional(ObservatoryTestCase):
 
             telescope = Telescope(
                 name=name,
-                telescope_type=TelescopeType(id=1),
+                workflow_type=WorkflowType(id=1),
                 organisation=Organisation(id=organisation.id),
                 extra={},
             )

--- a/oaebu_workflows/workflows/tests/test_onix_workflow.py
+++ b/oaebu_workflows/workflows/tests/test_onix_workflow.py
@@ -28,10 +28,8 @@ from click.testing import CliRunner
 from google.cloud import bigquery
 from google.cloud.bigquery import SourceFormat
 
-import observatory.api.server.orm as orm
 from oaebu_workflows.config import schema_folder as default_schema_folder
 from oaebu_workflows.config import test_fixtures_folder
-from oaebu_workflows.identifiers import WorkflowTypes
 from oaebu_workflows.workflows.oaebu_partners import OaebuPartner, OaebuPartnerName
 from oaebu_workflows.workflows.onix_workflow import OnixWorkflow, OnixWorkflowRelease
 from observatory.api.server.orm import (
@@ -65,10 +63,9 @@ from observatory.api.testing import ObservatoryApiEnvironment
 from observatory.api.client import ApiClient, Configuration
 from observatory.api.client.api.observatory_api import ObservatoryApi  # noqa: E501
 from observatory.api.client.model.organisation import Organisation
-from observatory.api.client.model.telescope import Telescope
+from observatory.api.client.model.workflow import Workflow
 from observatory.api.client.model.workflow_type import WorkflowType
 from observatory.api.client.model.dataset import Dataset
-from observatory.api.client.model.dataset_release import DatasetRelease
 from observatory.api.client.model.dataset_type import DatasetType
 from observatory.api.client.model.table_type import TableType
 from observatory.platform.utils.release_utils import get_dataset_releases
@@ -1618,27 +1615,27 @@ class TestOnixWorkflowFunctional(ObservatoryTestCase):
             )
             organisation = self.api.put_organisation(organisation)
 
-            telescope = Telescope(
+            telescope = Workflow(
                 name=name,
                 workflow_type=WorkflowType(id=2),  # onix telescope
                 organisation=Organisation(id=organisation.id),
                 extra={},
             )
-            self.api.put_telescope(telescope)
+            self.api.put_workflow(telescope)
 
-            telescope = Telescope(
+            telescope = Workflow(
                 name=name,
                 workflow_type=WorkflowType(id=1),
                 organisation=Organisation(id=organisation.id),
                 extra={},
             )
-            telescope = self.api.put_telescope(telescope)
+            telescope = self.api.put_workflow(telescope)
 
             dataset = Dataset(
                 name="Onix Workflow Example Dataset",
                 address="project.dataset.table",
                 service="bigquery",
-                connection=Telescope(id=telescope.id),
+                connection=Workflow(id=telescope.id),
                 dataset_type=DatasetType(id=1),
             )
             self.api.put_dataset(dataset)

--- a/oaebu_workflows/workflows/tests/test_onix_workflow.py
+++ b/oaebu_workflows/workflows/tests/test_onix_workflow.py
@@ -30,7 +30,7 @@ from google.cloud.bigquery import SourceFormat
 
 from oaebu_workflows.config import schema_folder as default_schema_folder
 from oaebu_workflows.config import test_fixtures_folder
-from oaebu_workflows.workflows.oaebu_partners import OaebuPartner, OaebuPartnerName
+from oaebu_workflows.workflows.oaebu_partners import OaebuPartner, OaebuDatasetType
 from oaebu_workflows.workflows.onix_workflow import OnixWorkflow, OnixWorkflowRelease
 from observatory.api.server.orm import (
     Dataset,
@@ -420,7 +420,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
     def test_dag_structure_ignore_google_analytics(self):
         data_partners = [
             OaebuPartner(
-                name=OaebuPartnerName.jstor_country,
+                name=OaebuDatasetType.jstor_country,
                 dag_id_prefix="jstor",
                 gcp_project_id="project",
                 gcp_dataset_id="dataset",
@@ -430,7 +430,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
                 sharded=False,
             ),
             OaebuPartner(
-                name=OaebuPartnerName.oapen_irus_uk,
+                name=OaebuDatasetType.oapen_irus_uk,
                 dag_id_prefix="oapen_irus_uk",
                 gcp_project_id="project",
                 gcp_dataset_id="dataset",
@@ -440,7 +440,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
                 sharded=False,
             ),
             OaebuPartner(
-                name=OaebuPartnerName.google_books_sales,
+                name=OaebuDatasetType.google_books_sales,
                 dag_id_prefix="google_books",
                 gcp_project_id="project",
                 gcp_dataset_id="dataset",
@@ -450,7 +450,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
                 sharded=False,
             ),
             OaebuPartner(
-                name=OaebuPartnerName.google_books_traffic,
+                name=OaebuDatasetType.google_books_traffic,
                 dag_id_prefix="google_books",
                 gcp_project_id="project",
                 gcp_dataset_id="dataset",
@@ -557,7 +557,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
     def test_dag_structure_with_google_analytics(self):
         data_partners = [
             OaebuPartner(
-                name=OaebuPartnerName.jstor_country,
+                name=OaebuDatasetType.jstor_country,
                 dag_id_prefix="jstor",
                 gcp_project_id="project",
                 gcp_dataset_id="dataset",
@@ -567,7 +567,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
                 sharded=False,
             ),
             OaebuPartner(
-                name=OaebuPartnerName.oapen_irus_uk,
+                name=OaebuDatasetType.oapen_irus_uk,
                 dag_id_prefix="oapen_irus_uk",
                 gcp_project_id="project",
                 gcp_dataset_id="dataset",
@@ -577,7 +577,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
                 sharded=False,
             ),
             OaebuPartner(
-                name=OaebuPartnerName.google_books_sales,
+                name=OaebuDatasetType.google_books_sales,
                 dag_id_prefix="google_books",
                 gcp_project_id="project",
                 gcp_dataset_id="dataset",
@@ -587,7 +587,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
                 sharded=False,
             ),
             OaebuPartner(
-                name=OaebuPartnerName.google_books_traffic,
+                name=OaebuDatasetType.google_books_traffic,
                 dag_id_prefix="google_books",
                 gcp_project_id="project",
                 gcp_dataset_id="dataset",
@@ -597,7 +597,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
                 sharded=False,
             ),
             OaebuPartner(
-                name=OaebuPartnerName.google_analytics,
+                name=OaebuDatasetType.google_analytics,
                 dag_id_prefix="google_analytics",
                 gcp_project_id="project",
                 gcp_dataset_id="dataset",
@@ -1121,7 +1121,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
 
         data_partners = [
             OaebuPartner(
-                name=OaebuPartnerName.jstor_country,
+                name=OaebuDatasetType.jstor_country,
                 dag_id_prefix="jstor",
                 gcp_project_id="project",
                 gcp_dataset_id="jstor",
@@ -1195,7 +1195,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
 
         data_partners = [
             OaebuPartner(
-                name=OaebuPartnerName.google_books_sales,
+                name=OaebuDatasetType.google_books_sales,
                 dag_id_prefix="google_books",
                 gcp_project_id="project",
                 gcp_dataset_id="google_books",
@@ -1269,7 +1269,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
 
         data_partners = [
             OaebuPartner(
-                name=OaebuPartnerName.google_books_traffic,
+                name=OaebuDatasetType.google_books_traffic,
                 dag_id_prefix="google_books",
                 gcp_project_id="project",
                 gcp_dataset_id="google_books",
@@ -1341,7 +1341,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
 
         data_partners = [
             OaebuPartner(
-                name=OaebuPartnerName.oapen_irus_uk,
+                name=OaebuDatasetType.oapen_irus_uk,
                 dag_id_prefix="oapen_irus_uk",
                 gcp_project_id="project",
                 gcp_dataset_id="irus_uk",
@@ -1413,7 +1413,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
 
         data_partners = [
             OaebuPartner(
-                name=OaebuPartnerName.oapen_irus_uk,
+                name=OaebuDatasetType.oapen_irus_uk,
                 dag_id_prefix="google_analytics",
                 gcp_project_id="project",
                 gcp_dataset_id="google",
@@ -1487,7 +1487,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
 
         data_partners = [
             OaebuPartner(
-                name=OaebuPartnerName.jstor_country,
+                name=OaebuDatasetType.jstor_country,
                 dag_id_prefix="jstor",
                 gcp_project_id="project",
                 gcp_dataset_id="jstor",
@@ -1753,12 +1753,12 @@ class TestOnixWorkflowFunctional(ObservatoryTestCase):
         partners = []
         for (name, isbn_field_name, title_field_name, dag_id_prefix), table_id in zip(
             [
-                (OaebuPartnerName.jstor_country, "ISBN", "Book_Title", "jstor"),
-                (OaebuPartnerName.jstor_institution, "ISBN", "Book_Title", "jstor"),
-                (OaebuPartnerName.google_books_sales, "Primary_ISBN", "Title", "google_books"),
-                (OaebuPartnerName.google_books_traffic, "Primary_ISBN", "Title", "google_books"),
-                (OaebuPartnerName.oapen_irus_uk, "ISBN", "book_title", "oapen_irus_uk"),
-                (OaebuPartnerName.google_analytics, "publication_id", "title", "google_analytics"),
+                (OaebuDatasetType.jstor_country, "ISBN", "Book_Title", "jstor"),
+                (OaebuDatasetType.jstor_institution, "ISBN", "Book_Title", "jstor"),
+                (OaebuDatasetType.google_books_sales, "Primary_ISBN", "Title", "google_books"),
+                (OaebuDatasetType.google_books_traffic, "Primary_ISBN", "Title", "google_books"),
+                (OaebuDatasetType.oapen_irus_uk, "ISBN", "book_title", "oapen_irus_uk"),
+                (OaebuDatasetType.google_analytics, "publication_id", "title", "google_analytics"),
             ],
             table_ids,
         ):

--- a/oaebu_workflows/workflows/tests/test_onix_workflow.py
+++ b/oaebu_workflows/workflows/tests/test_onix_workflow.py
@@ -1635,7 +1635,7 @@ class TestOnixWorkflowFunctional(ObservatoryTestCase):
                 name="Onix Workflow Example Dataset",
                 address="project.dataset.table",
                 service="bigquery",
-                connection=Workflow(id=telescope.id),
+                workflow=Workflow(id=telescope.id),
                 dataset_type=DatasetType(id=1),
             )
             self.api.put_dataset(dataset)

--- a/oaebu_workflows/workflows/tests/test_onix_workflow.py
+++ b/oaebu_workflows/workflows/tests/test_onix_workflow.py
@@ -179,7 +179,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
         def __init__(self):
             self.organisation = Organisation(
                 name="test",
-                gcp_project_id="project_id",
+                project_id="project_id",
             )
 
     def __init__(self, *args, **kwargs):
@@ -198,14 +198,14 @@ class TestOnixWorkflow(ObservatoryTestCase):
                 dag_id="onix_workflow_test",
                 release_date=pendulum.datetime(2021, 1, 1),
                 onix_release_date=pendulum.datetime(2021, 1, 1),
-                gcp_project_id=self.telescope.organisation.gcp_project_id,
+                gcp_project_id=self.telescope.organisation.project_id,
                 gcp_bucket_name=self.bucket_name,
                 onix_dataset_id="",
                 onix_table_id="onix",
             )
             wf = OnixWorkflow(
                 org_name=self.telescope.organisation.name,
-                gcp_project_id=self.telescope.organisation.gcp_project_id,
+                gcp_project_id=self.telescope.organisation.project_id,
                 gcp_bucket_name=self.bucket_name,
             )
 
@@ -232,7 +232,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
         with CliRunner().isolated_filesystem():
             wf = OnixWorkflow(
                 org_name=self.telescope.organisation.name,
-                gcp_project_id=self.telescope.organisation.gcp_project_id,
+                gcp_project_id=self.telescope.organisation.project_id,
                 gcp_bucket_name=self.bucket_name,
                 dag_id="dagid",
             )
@@ -241,7 +241,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
                 dag_id="dagid",
                 release_date=pendulum.datetime(2021, 1, 1),
                 onix_release_date=pendulum.datetime(2021, 1, 1),
-                gcp_project_id=self.telescope.organisation.gcp_project_id,
+                gcp_project_id=self.telescope.organisation.project_id,
                 gcp_bucket_name=self.bucket_name,
                 onix_dataset_id="",
                 onix_table_id="onix",
@@ -267,7 +267,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
         with CliRunner().isolated_filesystem():
             wf = OnixWorkflow(
                 org_name=self.telescope.organisation.name,
-                gcp_project_id=self.telescope.organisation.gcp_project_id,
+                gcp_project_id=self.telescope.organisation.project_id,
                 gcp_bucket_name=self.bucket_name,
             )
 
@@ -275,7 +275,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
                 dag_id="onix_workflow_test",
                 release_date=pendulum.datetime(2021, 1, 1),
                 onix_release_date=pendulum.datetime(2021, 1, 1),
-                gcp_project_id=self.telescope.organisation.gcp_project_id,
+                gcp_project_id=self.telescope.organisation.project_id,
                 gcp_bucket_name=self.bucket_name,
                 onix_dataset_id="onix",
                 onix_table_id="onix",
@@ -350,7 +350,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
         with CliRunner().isolated_filesystem():
             wf = OnixWorkflow(
                 org_name=self.telescope.organisation.name,
-                gcp_project_id=self.telescope.organisation.gcp_project_id,
+                gcp_project_id=self.telescope.organisation.project_id,
                 gcp_bucket_name=self.bucket_name,
             )
             records = wf.get_onix_records("project_id", "ds_id", "table_id")
@@ -364,7 +364,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
         with CliRunner().isolated_filesystem():
             wf = OnixWorkflow(
                 org_name=self.telescope.organisation.name,
-                gcp_project_id=self.telescope.organisation.gcp_project_id,
+                gcp_project_id=self.telescope.organisation.project_id,
                 gcp_bucket_name=self.bucket_name,
             )
 
@@ -386,7 +386,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
         with CliRunner().isolated_filesystem():
             wf = OnixWorkflow(
                 org_name=self.telescope.organisation.name,
-                gcp_project_id=self.telescope.organisation.gcp_project_id,
+                gcp_project_id=self.telescope.organisation.project_id,
                 gcp_bucket_name=self.bucket_name,
             )
 
@@ -401,7 +401,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
         with CliRunner().isolated_filesystem():
             wf = OnixWorkflow(
                 org_name=self.telescope.organisation.name,
-                gcp_project_id=self.telescope.organisation.gcp_project_id,
+                gcp_project_id=self.telescope.organisation.project_id,
                 gcp_bucket_name=self.bucket_name,
             )
 
@@ -409,7 +409,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
                 dag_id="onix_workflow_test",
                 release_date=pendulum.datetime(2021, 1, 1),
                 onix_release_date=pendulum.datetime(2021, 1, 1),
-                gcp_project_id=self.telescope.organisation.gcp_project_id,
+                gcp_project_id=self.telescope.organisation.project_id,
                 gcp_bucket_name=self.bucket_name,
                 onix_dataset_id="onix",
                 onix_table_id="onix",
@@ -467,7 +467,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
         with CliRunner().isolated_filesystem():
             wf = OnixWorkflow(
                 org_name=self.telescope.organisation.name,
-                gcp_project_id=self.telescope.organisation.gcp_project_id,
+                gcp_project_id=self.telescope.organisation.project_id,
                 gcp_bucket_name=self.bucket_name,
                 data_partners=data_partners,
             )
@@ -615,7 +615,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
         with CliRunner().isolated_filesystem():
             wf = OnixWorkflow(
                 org_name=org_name,
-                gcp_project_id=self.telescope.organisation.gcp_project_id,
+                gcp_project_id=self.telescope.organisation.project_id,
                 gcp_bucket_name=self.bucket_name,
                 data_partners=data_partners,
             )
@@ -737,7 +737,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
             with CliRunner().isolated_filesystem():
                 wf = OnixWorkflow(
                     org_name=self.telescope.organisation.name,
-                    gcp_project_id=self.telescope.organisation.gcp_project_id,
+                    gcp_project_id=self.telescope.organisation.project_id,
                     gcp_bucket_name=self.bucket_name,
                 )
 
@@ -745,7 +745,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
                     dag_id="onix_workflow_test",
                     release_date=pendulum.datetime(2021, 1, 1),
                     onix_release_date=pendulum.datetime(2021, 1, 1),
-                    gcp_project_id=self.telescope.organisation.gcp_project_id,
+                    gcp_project_id=self.telescope.organisation.project_id,
                     gcp_bucket_name=self.bucket_name,
                     onix_dataset_id="onix",
                     onix_table_id="onix",
@@ -852,7 +852,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
             with CliRunner().isolated_filesystem():
                 wf = OnixWorkflow(
                     org_name=self.telescope.organisation.name,
-                    gcp_project_id=self.telescope.organisation.gcp_project_id,
+                    gcp_project_id=self.telescope.organisation.project_id,
                     gcp_bucket_name=self.bucket_name,
                 )
 
@@ -860,7 +860,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
                     dag_id="onix_workflow_test",
                     release_date=pendulum.datetime(2021, 1, 1),
                     onix_release_date=pendulum.datetime(2021, 1, 1),
-                    gcp_project_id=self.telescope.organisation.gcp_project_id,
+                    gcp_project_id=self.telescope.organisation.project_id,
                     gcp_bucket_name=self.bucket_name,
                     onix_dataset_id="onix",
                     onix_table_id="onix",
@@ -893,7 +893,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
         with CliRunner().isolated_filesystem():
             wf = OnixWorkflow(
                 org_name=self.telescope.organisation.name,
-                gcp_project_id=self.telescope.organisation.gcp_project_id,
+                gcp_project_id=self.telescope.organisation.project_id,
                 gcp_bucket_name=self.bucket_name,
             )
             with patch(
@@ -907,7 +907,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
                             dag_id="onix_workflow_test",
                             release_date=pendulum.datetime(2021, 1, 1),
                             onix_release_date=pendulum.datetime(2021, 1, 1),
-                            gcp_project_id=self.telescope.organisation.gcp_project_id,
+                            gcp_project_id=self.telescope.organisation.project_id,
                             gcp_bucket_name=self.bucket_name,
                             onix_dataset_id="onix",
                             onix_table_id="onix",
@@ -957,7 +957,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
         with CliRunner().isolated_filesystem():
             wf = OnixWorkflow(
                 org_name=self.telescope.organisation.name,
-                gcp_project_id=self.telescope.organisation.gcp_project_id,
+                gcp_project_id=self.telescope.organisation.project_id,
                 gcp_bucket_name=self.bucket_name,
                 dag_id="dagid",
                 data_partners=data_partners,
@@ -967,7 +967,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
                 dag_id="onix_workflow_test",
                 release_date=pendulum.datetime(2021, 1, 1),
                 onix_release_date=pendulum.datetime(2021, 1, 1),
-                gcp_project_id=self.telescope.organisation.gcp_project_id,
+                gcp_project_id=self.telescope.organisation.project_id,
                 gcp_bucket_name=self.bucket_name,
                 onix_dataset_id="onix",
                 onix_table_id="onix",
@@ -1020,7 +1020,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
         with CliRunner().isolated_filesystem():
             wf = OnixWorkflow(
                 org_name=self.telescope.organisation.name,
-                gcp_project_id=self.telescope.organisation.gcp_project_id,
+                gcp_project_id=self.telescope.organisation.project_id,
                 gcp_bucket_name=self.bucket_name,
             )
             mock_bq_table_query.return_value = True
@@ -1029,7 +1029,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
                     dag_id="onix_workflow_test",
                     release_date=pendulum.datetime(2021, 1, 1),
                     onix_release_date=pendulum.datetime(2021, 1, 1),
-                    gcp_project_id=self.telescope.organisation.gcp_project_id,
+                    gcp_project_id=self.telescope.organisation.project_id,
                     gcp_bucket_name=self.bucket_name,
                     onix_dataset_id="onix",
                     onix_table_id="onix",
@@ -1058,7 +1058,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
                     dag_id="onix_workflow_test",
                     release_date=pendulum.datetime(2021, 1, 1),
                     onix_release_date=pendulum.datetime(2021, 1, 1),
-                    gcp_project_id=self.telescope.organisation.gcp_project_id,
+                    gcp_project_id=self.telescope.organisation.project_id,
                     gcp_bucket_name=self.bucket_name,
                     onix_dataset_id="onix",
                     onix_table_id="onix",
@@ -1071,7 +1071,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
         with CliRunner().isolated_filesystem():
             wf = OnixWorkflow(
                 org_name=self.telescope.organisation.name,
-                gcp_project_id=self.telescope.organisation.gcp_project_id,
+                gcp_project_id=self.telescope.organisation.project_id,
                 gcp_bucket_name=self.bucket_name,
             )
             mock_bq_table_query.return_value = True
@@ -1080,7 +1080,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
                     dag_id="onix_workflow_test",
                     release_date=pendulum.datetime(2021, 1, 1),
                     onix_release_date=pendulum.datetime(2021, 1, 1),
-                    gcp_project_id=self.telescope.organisation.gcp_project_id,
+                    gcp_project_id=self.telescope.organisation.project_id,
                     gcp_bucket_name=self.bucket_name,
                     onix_dataset_id="onix",
                     onix_table_id="onix",
@@ -1109,7 +1109,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
                     dag_id="onix_workflow_test",
                     release_date=pendulum.datetime(2021, 1, 1),
                     onix_release_date=pendulum.datetime(2021, 1, 1),
-                    gcp_project_id=self.telescope.organisation.gcp_project_id,
+                    gcp_project_id=self.telescope.organisation.project_id,
                     gcp_bucket_name=self.bucket_name,
                     onix_dataset_id="onix",
                     onix_table_id="onix",
@@ -1137,7 +1137,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
         with CliRunner().isolated_filesystem():
             wf = OnixWorkflow(
                 org_name=self.telescope.organisation.name,
-                gcp_project_id=self.telescope.organisation.gcp_project_id,
+                gcp_project_id=self.telescope.organisation.project_id,
                 gcp_bucket_name=self.bucket_name,
                 data_partners=data_partners,
             )
@@ -1147,7 +1147,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
                     dag_id="onix_workflow_test",
                     release_date=pendulum.datetime(2021, 1, 1),
                     onix_release_date=pendulum.datetime(2021, 1, 1),
-                    gcp_project_id=self.telescope.organisation.gcp_project_id,
+                    gcp_project_id=self.telescope.organisation.project_id,
                     gcp_bucket_name=self.bucket_name,
                     onix_dataset_id="onix",
                     onix_table_id="onix",
@@ -1165,7 +1165,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
                     dag_id="onix_workflow_test",
                     release_date=pendulum.datetime(2021, 1, 1),
                     onix_release_date=pendulum.datetime(2021, 1, 1),
-                    gcp_project_id=self.telescope.organisation.gcp_project_id,
+                    gcp_project_id=self.telescope.organisation.project_id,
                     gcp_bucket_name=self.bucket_name,
                     onix_dataset_id="onix",
                     onix_table_id="onix",
@@ -1211,7 +1211,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
         with CliRunner().isolated_filesystem():
             wf = OnixWorkflow(
                 org_name=self.telescope.organisation.name,
-                gcp_project_id=self.telescope.organisation.gcp_project_id,
+                gcp_project_id=self.telescope.organisation.project_id,
                 gcp_bucket_name=self.bucket_name,
                 data_partners=data_partners,
             )
@@ -1221,7 +1221,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
                     dag_id="onix_workflow_test",
                     release_date=pendulum.datetime(2021, 1, 1),
                     onix_release_date=pendulum.datetime(2021, 1, 1),
-                    gcp_project_id=self.telescope.organisation.gcp_project_id,
+                    gcp_project_id=self.telescope.organisation.project_id,
                     gcp_bucket_name=self.bucket_name,
                     onix_dataset_id="onix",
                     onix_table_id="onix",
@@ -1239,7 +1239,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
                     dag_id="onix_workflow_test",
                     release_date=pendulum.datetime(2021, 1, 1),
                     onix_release_date=pendulum.datetime(2021, 1, 1),
-                    gcp_project_id=self.telescope.organisation.gcp_project_id,
+                    gcp_project_id=self.telescope.organisation.project_id,
                     gcp_bucket_name=self.bucket_name,
                     onix_dataset_id="onix",
                     onix_table_id="onix",
@@ -1285,7 +1285,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
         with CliRunner().isolated_filesystem():
             wf = OnixWorkflow(
                 org_name=self.telescope.organisation.name,
-                gcp_project_id=self.telescope.organisation.gcp_project_id,
+                gcp_project_id=self.telescope.organisation.project_id,
                 gcp_bucket_name=self.bucket_name,
                 data_partners=data_partners,
             )
@@ -1295,7 +1295,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
                     dag_id="onix_workflow_test",
                     release_date=pendulum.datetime(2021, 1, 1),
                     onix_release_date=pendulum.datetime(2021, 1, 1),
-                    gcp_project_id=self.telescope.organisation.gcp_project_id,
+                    gcp_project_id=self.telescope.organisation.project_id,
                     gcp_bucket_name=self.bucket_name,
                     onix_dataset_id="onix",
                     onix_table_id="onix",
@@ -1313,7 +1313,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
                     dag_id="onix_workflow_test",
                     release_date=pendulum.datetime(2021, 1, 1),
                     onix_release_date=pendulum.datetime(2021, 1, 1),
-                    gcp_project_id=self.telescope.organisation.gcp_project_id,
+                    gcp_project_id=self.telescope.organisation.project_id,
                     gcp_bucket_name=self.bucket_name,
                     onix_dataset_id="onix",
                     onix_table_id="onix",
@@ -1357,7 +1357,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
         with CliRunner().isolated_filesystem():
             wf = OnixWorkflow(
                 org_name=self.telescope.organisation.name,
-                gcp_project_id=self.telescope.organisation.gcp_project_id,
+                gcp_project_id=self.telescope.organisation.project_id,
                 gcp_bucket_name=self.bucket_name,
                 data_partners=data_partners,
             )
@@ -1367,7 +1367,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
                     dag_id="onix_workflow_test",
                     release_date=pendulum.datetime(2021, 1, 1),
                     onix_release_date=pendulum.datetime(2021, 1, 1),
-                    gcp_project_id=self.telescope.organisation.gcp_project_id,
+                    gcp_project_id=self.telescope.organisation.project_id,
                     gcp_bucket_name=self.bucket_name,
                     onix_dataset_id="onix",
                     onix_table_id="onix",
@@ -1385,7 +1385,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
                     dag_id="onix_workflow_test",
                     release_date=pendulum.datetime(2021, 1, 1),
                     onix_release_date=pendulum.datetime(2021, 1, 1),
-                    gcp_project_id=self.telescope.organisation.gcp_project_id,
+                    gcp_project_id=self.telescope.organisation.project_id,
                     gcp_bucket_name=self.bucket_name,
                     onix_dataset_id="onix",
                     onix_table_id="onix",
@@ -1429,7 +1429,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
         with CliRunner().isolated_filesystem():
             wf = OnixWorkflow(
                 org_name=self.telescope.organisation.name,
-                gcp_project_id=self.telescope.organisation.gcp_project_id,
+                gcp_project_id=self.telescope.organisation.project_id,
                 gcp_bucket_name=self.bucket_name,
                 data_partners=data_partners,
             )
@@ -1439,7 +1439,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
                     dag_id="onix_workflow_test",
                     release_date=pendulum.datetime(2021, 1, 1),
                     onix_release_date=pendulum.datetime(2021, 1, 1),
-                    gcp_project_id=self.telescope.organisation.gcp_project_id,
+                    gcp_project_id=self.telescope.organisation.project_id,
                     gcp_bucket_name=self.bucket_name,
                     onix_dataset_id="onix",
                     onix_table_id="onix",
@@ -1457,7 +1457,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
                     dag_id="onix_workflow_test",
                     release_date=pendulum.datetime(2021, 1, 1),
                     onix_release_date=pendulum.datetime(2021, 1, 1),
-                    gcp_project_id=self.telescope.organisation.gcp_project_id,
+                    gcp_project_id=self.telescope.organisation.project_id,
                     gcp_bucket_name=self.bucket_name,
                     onix_dataset_id="onix",
                     onix_table_id="onix",
@@ -1503,7 +1503,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
         with CliRunner().isolated_filesystem():
             wf = OnixWorkflow(
                 org_name=self.telescope.organisation.name,
-                gcp_project_id=self.telescope.organisation.gcp_project_id,
+                gcp_project_id=self.telescope.organisation.project_id,
                 gcp_bucket_name=self.bucket_name,
                 data_partners=data_partners,
             )
@@ -1513,7 +1513,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
                     dag_id="onix_workflow_test",
                     release_date=pendulum.datetime(2021, 1, 1),
                     onix_release_date=pendulum.datetime(2021, 1, 1),
-                    gcp_project_id=self.telescope.organisation.gcp_project_id,
+                    gcp_project_id=self.telescope.organisation.project_id,
                     gcp_bucket_name=self.bucket_name,
                     onix_dataset_id="onix",
                     onix_table_id="onix",
@@ -1546,7 +1546,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
                     dag_id="onix_workflow_test",
                     release_date=pendulum.datetime(2021, 1, 1),
                     onix_release_date=pendulum.datetime(2021, 1, 1),
-                    gcp_project_id=self.telescope.organisation.gcp_project_id,
+                    gcp_project_id=self.telescope.organisation.project_id,
                     gcp_bucket_name=self.bucket_name,
                     onix_dataset_id="onix",
                     onix_table_id="onix",
@@ -1612,9 +1612,9 @@ class TestOnixWorkflowFunctional(ObservatoryTestCase):
         for org in orgs:
             organisation = Organisation(
                 name=org,
-                gcp_project_id="project",
-                gcp_download_bucket="download_bucket",
-                gcp_transform_bucket="transform_bucket",
+                project_id="project",
+                download_bucket="download_bucket",
+                transform_bucket="transform_bucket",
             )
             organisation = self.api.put_organisation(organisation)
 

--- a/oaebu_workflows/workflows/tests/test_onix_workflow.py
+++ b/oaebu_workflows/workflows/tests/test_onix_workflow.py
@@ -42,10 +42,6 @@ from observatory.api.client.model.table_type import TableType
 from observatory.api.client.model.workflow import Workflow
 from observatory.api.client.model.workflow_type import WorkflowType
 from observatory.api.server.dataset_type import DatasetTypeId
-from observatory.api.server.orm import (
-    Dataset,
-    Organisation,
-)
 from observatory.api.testing import ObservatoryApiEnvironment
 from observatory.platform.utils.airflow_utils import AirflowConns
 from observatory.platform.utils.file_utils import load_jsonl

--- a/oaebu_workflows/workflows/tests/test_onix_workflow.py
+++ b/oaebu_workflows/workflows/tests/test_onix_workflow.py
@@ -30,7 +30,8 @@ from google.cloud.bigquery import SourceFormat
 
 from oaebu_workflows.config import schema_folder as default_schema_folder
 from oaebu_workflows.config import test_fixtures_folder
-from oaebu_workflows.workflows.oaebu_partners import OaebuPartner, OaebuDatasetType
+from oaebu_workflows.workflows.oaebu_partners import OaebuPartner
+from observatory.api.server.dataset_type import DatasetTypeId
 from oaebu_workflows.workflows.onix_workflow import OnixWorkflow, OnixWorkflowRelease
 from observatory.api.server.orm import (
     Dataset,
@@ -420,7 +421,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
     def test_dag_structure_ignore_google_analytics(self):
         data_partners = [
             OaebuPartner(
-                name=OaebuDatasetType.jstor_country,
+                name=DatasetTypeId.jstor_country,
                 dag_id_prefix="jstor",
                 gcp_project_id="project",
                 gcp_dataset_id="dataset",
@@ -430,7 +431,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
                 sharded=False,
             ),
             OaebuPartner(
-                name=OaebuDatasetType.oapen_irus_uk,
+                name=DatasetTypeId.oapen_irus_uk,
                 dag_id_prefix="oapen_irus_uk",
                 gcp_project_id="project",
                 gcp_dataset_id="dataset",
@@ -440,7 +441,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
                 sharded=False,
             ),
             OaebuPartner(
-                name=OaebuDatasetType.google_books_sales,
+                name=DatasetTypeId.google_books_sales,
                 dag_id_prefix="google_books",
                 gcp_project_id="project",
                 gcp_dataset_id="dataset",
@@ -450,7 +451,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
                 sharded=False,
             ),
             OaebuPartner(
-                name=OaebuDatasetType.google_books_traffic,
+                name=DatasetTypeId.google_books_traffic,
                 dag_id_prefix="google_books",
                 gcp_project_id="project",
                 gcp_dataset_id="dataset",
@@ -557,7 +558,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
     def test_dag_structure_with_google_analytics(self):
         data_partners = [
             OaebuPartner(
-                name=OaebuDatasetType.jstor_country,
+                name=DatasetTypeId.jstor_country,
                 dag_id_prefix="jstor",
                 gcp_project_id="project",
                 gcp_dataset_id="dataset",
@@ -567,7 +568,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
                 sharded=False,
             ),
             OaebuPartner(
-                name=OaebuDatasetType.oapen_irus_uk,
+                name=DatasetTypeId.oapen_irus_uk,
                 dag_id_prefix="oapen_irus_uk",
                 gcp_project_id="project",
                 gcp_dataset_id="dataset",
@@ -577,7 +578,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
                 sharded=False,
             ),
             OaebuPartner(
-                name=OaebuDatasetType.google_books_sales,
+                name=DatasetTypeId.google_books_sales,
                 dag_id_prefix="google_books",
                 gcp_project_id="project",
                 gcp_dataset_id="dataset",
@@ -587,7 +588,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
                 sharded=False,
             ),
             OaebuPartner(
-                name=OaebuDatasetType.google_books_traffic,
+                name=DatasetTypeId.google_books_traffic,
                 dag_id_prefix="google_books",
                 gcp_project_id="project",
                 gcp_dataset_id="dataset",
@@ -597,7 +598,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
                 sharded=False,
             ),
             OaebuPartner(
-                name=OaebuDatasetType.google_analytics,
+                name=DatasetTypeId.google_analytics,
                 dag_id_prefix="google_analytics",
                 gcp_project_id="project",
                 gcp_dataset_id="dataset",
@@ -1121,7 +1122,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
 
         data_partners = [
             OaebuPartner(
-                name=OaebuDatasetType.jstor_country,
+                name=DatasetTypeId.jstor_country,
                 dag_id_prefix="jstor",
                 gcp_project_id="project",
                 gcp_dataset_id="jstor",
@@ -1195,7 +1196,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
 
         data_partners = [
             OaebuPartner(
-                name=OaebuDatasetType.google_books_sales,
+                name=DatasetTypeId.google_books_sales,
                 dag_id_prefix="google_books",
                 gcp_project_id="project",
                 gcp_dataset_id="google_books",
@@ -1269,7 +1270,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
 
         data_partners = [
             OaebuPartner(
-                name=OaebuDatasetType.google_books_traffic,
+                name=DatasetTypeId.google_books_traffic,
                 dag_id_prefix="google_books",
                 gcp_project_id="project",
                 gcp_dataset_id="google_books",
@@ -1341,7 +1342,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
 
         data_partners = [
             OaebuPartner(
-                name=OaebuDatasetType.oapen_irus_uk,
+                name=DatasetTypeId.oapen_irus_uk,
                 dag_id_prefix="oapen_irus_uk",
                 gcp_project_id="project",
                 gcp_dataset_id="irus_uk",
@@ -1413,7 +1414,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
 
         data_partners = [
             OaebuPartner(
-                name=OaebuDatasetType.oapen_irus_uk,
+                name=DatasetTypeId.oapen_irus_uk,
                 dag_id_prefix="google_analytics",
                 gcp_project_id="project",
                 gcp_dataset_id="google",
@@ -1487,7 +1488,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
 
         data_partners = [
             OaebuPartner(
-                name=OaebuDatasetType.jstor_country,
+                name=DatasetTypeId.jstor_country,
                 dag_id_prefix="jstor",
                 gcp_project_id="project",
                 gcp_dataset_id="jstor",
@@ -1753,12 +1754,12 @@ class TestOnixWorkflowFunctional(ObservatoryTestCase):
         partners = []
         for (name, isbn_field_name, title_field_name, dag_id_prefix), table_id in zip(
             [
-                (OaebuDatasetType.jstor_country, "ISBN", "Book_Title", "jstor"),
-                (OaebuDatasetType.jstor_institution, "ISBN", "Book_Title", "jstor"),
-                (OaebuDatasetType.google_books_sales, "Primary_ISBN", "Title", "google_books"),
-                (OaebuDatasetType.google_books_traffic, "Primary_ISBN", "Title", "google_books"),
-                (OaebuDatasetType.oapen_irus_uk, "ISBN", "book_title", "oapen_irus_uk"),
-                (OaebuDatasetType.google_analytics, "publication_id", "title", "google_analytics"),
+                (DatasetTypeId.jstor_country, "ISBN", "Book_Title", "jstor"),
+                (DatasetTypeId.jstor_institution, "ISBN", "Book_Title", "jstor"),
+                (DatasetTypeId.google_books_sales, "Primary_ISBN", "Title", "google_books"),
+                (DatasetTypeId.google_books_traffic, "Primary_ISBN", "Title", "google_books"),
+                (DatasetTypeId.oapen_irus_uk, "ISBN", "book_title", "oapen_irus_uk"),
+                (DatasetTypeId.google_analytics, "publication_id", "title", "google_analytics"),
             ],
             table_ids,
         ):

--- a/oaebu_workflows/workflows/tests/test_ucl_discovery_telescope.py
+++ b/oaebu_workflows/workflows/tests/test_ucl_discovery_telescope.py
@@ -125,7 +125,7 @@ class TestUclDiscoveryTelescope(ObservatoryTestCase):
             name="Ucl Discovery Dataset",
             address="project.dataset.table",
             service="bigquery",
-            connection=Workflow(id=1),
+            workflow=Workflow(id=1),
             dataset_type=DatasetType(id=1),
         )
         self.api.put_dataset(dataset)

--- a/oaebu_workflows/workflows/tests/test_ucl_discovery_telescope.py
+++ b/oaebu_workflows/workflows/tests/test_ucl_discovery_telescope.py
@@ -24,7 +24,6 @@ from airflow.exceptions import AirflowException, AirflowSkipException
 from airflow.models.connection import Connection
 from click.testing import CliRunner
 from croniter import croniter
-from oaebu_workflows.identifiers import WorkflowTypes
 from observatory.api.client.model.organisation import Organisation
 from observatory.api.server import orm
 from oaebu_workflows.workflows.ucl_discovery_telescope import (
@@ -45,10 +44,9 @@ from observatory.api.testing import ObservatoryApiEnvironment
 from observatory.api.client import ApiClient, Configuration
 from observatory.api.client.api.observatory_api import ObservatoryApi  # noqa: E501
 from observatory.api.client.model.organisation import Organisation
-from observatory.api.client.model.telescope import Telescope
+from observatory.api.client.model.workflow import Workflow
 from observatory.api.client.model.workflow_type import WorkflowType
 from observatory.api.client.model.dataset import Dataset
-from observatory.api.client.model.dataset_release import DatasetRelease
 from observatory.api.client.model.dataset_type import DatasetType
 from observatory.api.client.model.table_type import TableType
 from observatory.platform.utils.release_utils import get_dataset_releases
@@ -101,13 +99,13 @@ class TestUclDiscoveryTelescope(ObservatoryTestCase):
         )
         self.api.put_organisation(organisation)
 
-        telescope = Telescope(
+        telescope = Workflow(
             name=name,
             workflow_type=WorkflowType(id=1),
             organisation=Organisation(id=1),
             extra={},
         )
-        self.api.put_telescope(telescope)
+        self.api.put_workflow(telescope)
 
         table_type = TableType(
             type_id="partitioned",
@@ -127,7 +125,7 @@ class TestUclDiscoveryTelescope(ObservatoryTestCase):
             name="Ucl Discovery Dataset",
             address="project.dataset.table",
             service="bigquery",
-            connection=Telescope(id=1),
+            connection=Workflow(id=1),
             dataset_type=DatasetType(id=1),
         )
         self.api.put_dataset(dataset)

--- a/oaebu_workflows/workflows/tests/test_ucl_discovery_telescope.py
+++ b/oaebu_workflows/workflows/tests/test_ucl_discovery_telescope.py
@@ -95,9 +95,9 @@ class TestUclDiscoveryTelescope(ObservatoryTestCase):
 
         organisation = Organisation(
             name=self.org_name,
-            gcp_project_id="project",
-            gcp_download_bucket="download_bucket",
-            gcp_transform_bucket="transform_bucket",
+            project_id="project",
+            download_bucket="download_bucket",
+            transform_bucket="transform_bucket",
         )
         self.api.put_organisation(organisation)
 
@@ -190,9 +190,9 @@ class TestUclDiscoveryTelescope(ObservatoryTestCase):
         execution_date = pendulum.datetime(year=2021, month=4, day=1)
         organisation = Organisation(
             name=self.organisation_name,
-            gcp_project_id=self.project_id,
-            gcp_download_bucket=env.download_bucket,
-            gcp_transform_bucket=env.transform_bucket,
+            project_id=self.project_id,
+            download_bucket=env.download_bucket,
+            transform_bucket=env.transform_bucket,
         )
         telescope = UclDiscoveryTelescope(organisation=organisation, dataset_id=dataset_id, workflow_id=1)
         dag = telescope.make_dag()
@@ -280,9 +280,9 @@ class TestUclDiscoveryTelescope(ObservatoryTestCase):
         """
         organisation = Organisation(
             name=self.organisation_name,
-            gcp_project_id=self.project_id,
-            gcp_download_bucket="download_bucket",
-            gcp_transform_bucket="transform_bucket",
+            project_id=self.project_id,
+            download_bucket="download_bucket",
+            transform_bucket="transform_bucket",
         )
         telescope = UclDiscoveryTelescope(organisation=organisation, dataset_id="dataset_id")
         release = UclDiscoveryRelease(

--- a/oaebu_workflows/workflows/tests/test_ucl_discovery_telescope.py
+++ b/oaebu_workflows/workflows/tests/test_ucl_discovery_telescope.py
@@ -24,7 +24,7 @@ from airflow.exceptions import AirflowException, AirflowSkipException
 from airflow.models.connection import Connection
 from click.testing import CliRunner
 from croniter import croniter
-from oaebu_workflows.identifiers import TelescopeTypes
+from oaebu_workflows.identifiers import WorkflowTypes
 from observatory.api.client.model.organisation import Organisation
 from observatory.api.server import orm
 from oaebu_workflows.workflows.ucl_discovery_telescope import (
@@ -46,7 +46,7 @@ from observatory.api.client import ApiClient, Configuration
 from observatory.api.client.api.observatory_api import ObservatoryApi  # noqa: E501
 from observatory.api.client.model.organisation import Organisation
 from observatory.api.client.model.telescope import Telescope
-from observatory.api.client.model.telescope_type import TelescopeType
+from observatory.api.client.model.workflow_type import WorkflowType
 from observatory.api.client.model.dataset import Dataset
 from observatory.api.client.model.dataset_release import DatasetRelease
 from observatory.api.client.model.dataset_type import DatasetType
@@ -90,8 +90,8 @@ class TestUclDiscoveryTelescope(ObservatoryTestCase):
         dt = pendulum.now("UTC")
 
         name = "Ucl Discovery Telescope"
-        telescope_type = TelescopeType(name=name, type_id=UclDiscoveryTelescope.DAG_ID_PREFIX)
-        self.api.put_telescope_type(telescope_type)
+        workflow_type = WorkflowType(name=name, type_id=UclDiscoveryTelescope.DAG_ID_PREFIX)
+        self.api.put_workflow_type(workflow_type)
 
         organisation = Organisation(
             name=self.org_name,
@@ -103,7 +103,7 @@ class TestUclDiscoveryTelescope(ObservatoryTestCase):
 
         telescope = Telescope(
             name=name,
-            telescope_type=TelescopeType(id=1),
+            workflow_type=WorkflowType(id=1),
             organisation=Organisation(id=1),
             extra={},
         )

--- a/oaebu_workflows/workflows/ucl_discovery_telescope.py
+++ b/oaebu_workflows/workflows/ucl_discovery_telescope.py
@@ -215,9 +215,10 @@ class UclDiscoveryTelescope(OrganisationTelescope):
         schedule_interval: str = "@monthly",
         dataset_id: str = "ucl",
         schema_folder: str = default_schema_folder(),
-        catchup:bool = True,
+        catchup: bool = True,
         airflow_vars: list = None,
         max_active_runs: int = 10,
+        workflow_id: int = None,
     ):
         """Construct a UclDiscoveryTelescope instance.
         :param organisation: the Organisation of which data is processed.
@@ -228,6 +229,7 @@ class UclDiscoveryTelescope(OrganisationTelescope):
         :param schema_folder: the SQL schema path.
         :param airflow_vars: list of airflow variable keys, for each variable it is checked if it exists in airflow.
         :param max_active_runs: the maximum number of DAG runs to execute in parallel.
+        :param workflow_id: api workflow id.
         """
 
         if airflow_vars is None:
@@ -251,6 +253,7 @@ class UclDiscoveryTelescope(OrganisationTelescope):
             catchup=catchup,
             airflow_vars=airflow_vars,
             max_active_runs=max_active_runs,
+            workflow_id=workflow_id,
         )
         self.add_setup_task(self.check_dependencies)
         self.add_task_chain(
@@ -261,6 +264,7 @@ class UclDiscoveryTelescope(OrganisationTelescope):
                 self.upload_transformed,
                 self.bq_load_partition,
                 self.cleanup,
+                self.add_new_dataset_releases,
             ]
         )
 
@@ -298,6 +302,7 @@ class UclDiscoveryTelescope(OrganisationTelescope):
         """
         # Transform each release
         releases[0].transform()
+
 
 def get_downloads_per_country(countries_url: str) -> Tuple[List[dict], int]:
     """Requests info on downloads per country for a specific eprint id

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 beautifulsoup4>=4.9.3,<5
 faker>=8.12.1,<9
 Markdown==3.3.4 # prevent error: INSTALLED_EXTENSIONS = metadata.entry_points(group='markdown.extensions') TypeError: entry_points() got an unexpected keyword argument 'group'
+responses==0.20.*


### PR DESCRIPTION
Depends on [INF-325/dataset_release_utils](https://github.com/The-Academic-Observatory/observatory-platform/tree/INF-325/dataset_release_utils).

Adds basic dataset release record creation in the api for stream, snapshot, and organisation telescopes.