### PR TITLE
Fix error in create_oaebu_book_product_table task. 

### DIFF
--- a/oaebu_workflows/database/sql/create_book_products.sql.jinja2
+++ b/oaebu_workflows/database/sql/create_book_products.sql.jinja2
@@ -175,7 +175,7 @@ WITH empty_oapen as (
         CAST(null as INT64) as unique_item_investigations,
         CAST(null as INT64) as unique_item_requests,
         [STRUCT(
-            CAST(null as STRING) as name, null as code, CAST(null as INT64) as title_requests, CAST(null as INT64) as total_item_investigations,
+            CAST(null as STRING) as name, CAST(null as STRING) as code, CAST(null as INT64) as title_requests, CAST(null as INT64) as total_item_investigations,
             CAST(null as INT64) as total_item_requests, CAST(null as INT64) as unique_item_investigations, CAST(null as INT64) as unique_item_requests
         )] as country,
         [STRUCT(


### PR DESCRIPTION
The current query has an incorrect signature for the helper function 'group_items_irus_country'. The 'code' field in the used array isn't typecast to string.

Original error message:

> No matching signature for function group_items_irus_country for argument types: ARRAY<STRUCT<name STRING, code INT64, title_requests INT64, ...>>. Supported signature: group_items_irus_country(ARRAY<STRUCT<name STRING, code STRING, title_requests INT64, ...>>) at [392:64]

EDIT:
This issue only pops up when the rendered template from `create_book_products.sql.jinja2` uses the `empty_oapen` table, instead of the oapen table from the oaebu_intermediate dataset.

The oapen table from the oaebu_intermediate dataset has the correct type for the 'code' field.

In principle the `empty_oapen` table is used when there isn't any oapen data available for a given partner/publisher .
I believe that for all of our current partners there is oapen data available, and the issue with the query only popped up because the template was rendered incorrectly due to an unrelated issue with our API.

I think it would still be good to fix this query with the added CAST, so the query is correct if we do need to use the empty oapen table at one point.