### PR TITLE
Fix oapen metadata 'invalid date' issue

### DIFF
--- a/oaebu_workflows/workflows/oapen_metadata_telescope.py
+++ b/oaebu_workflows/workflows/oapen_metadata_telescope.py
@@ -181,7 +181,7 @@ class OapenMetadataTelescope(StreamTelescope):
             schema_folder,
             schema_prefix=schema_prefix,
             airflow_vars=airflow_vars,
-            load_bigquery_table_kwargs={"ignore_unknown_values": True}
+            load_bigquery_table_kwargs={"ignore_unknown_values": True},
         )
 
         self.add_setup_task(self.check_dependencies)
@@ -260,7 +260,8 @@ def transform_value_to_list(k: str, v: str) -> Tuple[list, list]:
         v = v.replace(",", "||")
     v = list(dict.fromkeys([x.strip() for x in v.split("||")]))
     if k == "dc.date.issued":
-        v = [pendulum.parse(date).to_date_string() for date in v]
+        # Use rjust to create 4 digit year number < 1000 on linux, e.g. 215 -> 0215
+        v = [pendulum.parse(date).to_date_string().rjust(10, "0") for date in v]
     if k == "dc.subject.classification":
         for c in v:
             if c.startswith("bic Book Industry Communication::"):


### PR DESCRIPTION
One of the entries in the latest oapen metadata release has a `dc.date.issued` value of "0215".

This is likely a typo and should be "2015". Regardless of the cause, this value is currently formatted into a date format using `pendulum.parse(date).to_date_string()`.
The result of this is "215-01-01" on linux and "0215-01-01" on mac (see https://bugs.python.org/issue13305 explaining difference).

The date format accepted by BigQuery is `'YYYY-[M]M-[D]D'`, so "215-01-01" leads to the error that we see in Airflow:
```
Invalid date: '215-01-01' Field: issued; Value: 215-01-01
```

To fix this I have updated
`pendulum.parse(date).to_date_string()`
to
`pendulum.parse(date).to_date_string().rjust(10, '0')` so the date string will always include a 4 digit year by appending zeros to the start of the string.