### PR TITLE
Use country.google_analytics_name for matching with Google Analytics

### DIFF
--- a/oaebu_workflows/database/sql/export_book_metrics_country.sql.jinja2
+++ b/oaebu_workflows/database/sql/export_book_metrics_country.sql.jinja2
@@ -101,7 +101,7 @@ google_analytics_month_country as (
         name as country_name,
         value
     FROM months, UNNEST(google_analytics)) as google
-    LEFT JOIN `{{ country_project_id }}.{{ country_dataset_id }}.country` as country on country.iso_name = google.country_name
+    LEFT JOIN `{{ country_project_id }}.{{ country_dataset_id }}.country` as country on country.google_analytics_name = google.country_name
 ),
 
 ucl_discovery_month_country as (

--- a/oaebu_workflows/fixtures/onix_workflow/country.jsonl
+++ b/oaebu_workflows/fixtures/onix_workflow/country.jsonl
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cf558ed888eaa7ec9af98387a6ddafbbfa70468837d877acf98692f887261c07
-size 52463
+oid sha256:0e7ff8c3dbcabd4ce8eb0e52ad8bccaad10772567caf3ed5b8fd4acd71354af9
+size 65926

--- a/oaebu_workflows/fixtures/onix_workflow/schema/country_2019-01-01.json
+++ b/oaebu_workflows/fixtures/onix_workflow/schema/country_2019-01-01.json
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8c835b57ac775fc7d26c5240025112e452fe4bdab284126ec0c4010f2e88f95a
-size 1098
+oid sha256:8069bc644c7d4cb26aaf43c7e5c090fe9fb17704205e0afbd6908c8c2378071d
+size 1331


### PR DESCRIPTION
Google Analytics uses their own variation of country names, which are used as a part of a join in oaebu_workflows/database/sql/export_book_metrics_country.sql.jinja2, so a new field has been added to the country table that contains the names used in Google Analytics (rather than being in a separate table).