### PR TITLE
Create .zenodo.json

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -2,11 +2,6 @@
   "license": {
     "id": "Apache-2.0"
   },
-  "communities": [
-    {
-      "id": "coki"
-    }
-  ],
   "creators": [
     {
       "orcid": "0000-0001-8288-5241",

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -44,6 +44,11 @@
       "name": "Kathryn Napier"
     },
     {
+      "orcid": "0000-0001-9542-1577",
+      "affiliation": "Centre for Culture and Technology, Curtin University",
+      "name": "Niamh Quigley"
+    },
+    {
       "orcid": "0000-0002-0068-716X",
       "affiliation": "Centre for Culture and Technology, Curtin University",
       "name": "Cameron Neylon"
@@ -52,11 +57,6 @@
       "orcid": "0000-0001-6551-8140",
       "affiliation": "Centre for Culture and Technology, Curtin University",
       "name": "Lucy Montgomery"
-    },
-    {
-      "orcid": "0000-0001-9542-1577",
-      "affiliation": "Centre for Culture and Technology, Curtin University",
-      "name": "Niamh Quigley"
     }
   ]
 }

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -55,8 +55,8 @@
     },
     {
       "orcid": "0000-0001-9542-1577",
-      "affiliation": "Niamh Quigley",
-      "name": "Centre for Culture and Technology, Curtin University"
+      "affiliation": "Centre for Culture and Technology, Curtin University",
+      "name": "Niamh Quigley"
     }
   ]
 }

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,4 +1,19 @@
 {
+  "title": "OAeBU Workflows",
+  "description": "<p>OAeBU Workflows provides Apache Airflow workflows for fetching, processing and analysing data about Open Access Books.&nbsp;The workflows include: Directory of Open Access Books (DOAB), Google Analytics, Google Books, JSTOR, Oapen IRUS UK, Oapen Metadata, Onix, UCL Discovery and an Onix Workflow for combining all of this data.</p>\n\n<p><strong>Contributors</strong><br>\nConceptualization: Richard Hosking, Aniek Roelofs, Cameron Neylon, and Lucy Montgomery.<br>\nData curation: Richard Hosking, Aniek Roelofs, James P. Diprose, Rebecca N. Handcock, Alkim Ozaygen, and Rebecca Lange.<br>\nFormal analysis: Richard Hosking, Aniek Roelofs, and Rebecca N. Handcock.<br>\nFunding acquisition: Cameron Neylon and Lucy Montgomery.<br>\nInvestigation: Richard Hosking, Aniek Roelofs, Tuan-Yow Chien, James P. Diprose, Rebecca N. Handcock, Alkim Ozaygen, and Kathryn R. Napier.<br>\nMethodology: Richard Hosking, Aniek Roelofs, Tuan-Yow Chien, and James P. Diprose.<br>\nProject administration: Richard Hosking, Kathryn R. Napier, Cameron Neylon, and Lucy Montgomery.<br>\nResources: Richard Hosking, Aniek Roelofs, and James P. Diprose. Software: Richard Hosking, Aniek Roelofs, Tuan-Yow Chien, and James P. Diprose.<br>\nSupervision: Richard Hosking, James P. Diprose, Kathryn R. Napier, Cameron Neylon, and Lucy Montgomery.<br>\nValidation: Richard Hosking, Aniek Roelofs, Tuan-Yow Chien, Rebecca N. Handcock, and Kathryn R. Napier.<br>\nVisualization: Richard Hosking, Rebecca N. Handcock, and Kathryn R. Napier.<br>\nWriting - original draft: Richard Hosking, Aniek Roelofs, Tuan-Yow Chien, James P. Diprose, and Niamh Quigley.<br>\nWriting - review &amp; editing: Richard Hosking, Aniek Roelofs, Rebecca N. Handcock, Kathryn R. Napier, and Niamh Quigley.</p>",
+  "notes": "The Curtin Open Knowledge Initiative (COKI) is a strategic initiative of the Research Office at Curtin, the Faculty of Humanities, School of Media, Creative Arts and Social Inquiry and the Curtin Institute for Computation, with additional support from the Andrew W. Mellon Foundation and the Arcadia Fund, a charitable fund of Lisbet Rausing and Peter Baldwin.",
+  "communities": [
+    {
+      "identifier": "coki"
+    }
+  ],
+  "keywords": [
+    "books",
+    "open access books",
+    "apache airflow",
+    "workflow",
+    "coki"
+  ],
   "license": {
     "id": "Apache-2.0"
   },

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,67 @@
+{
+  "license": {
+    "id": "Apache-2.0"
+  },
+  "communities": [
+    {
+      "id": "coki"
+    }
+  ],
+  "creators": [
+    {
+      "orcid": "0000-0001-8288-5241",
+      "affiliation": "Centre for Culture and Technology, Curtin University",
+      "name": "Richard Hosking"
+    },
+    {
+      "orcid": "0000-0003-0485-3388",
+      "affiliation": "Curtin Institute for Computation, Curtin University",
+      "name": "Aniek Roelofs"
+    },
+    {
+      "orcid": "0000-0002-6237-7423",
+      "affiliation": "Chien",
+      "name": "Tuan-Yow"
+    },
+    {
+      "orcid": "0000-0002-5094-3571",
+      "affiliation": "Centre for Culture and Technology, Curtin University",
+      "name": "James P. Diprose"
+    },
+    {
+      "orcid": "0000-0001-5903-6620",
+      "affiliation": "Curtin Institute for Computation, Curtin University",
+      "name": "Rebecca N. Handcock"
+    },
+    {
+      "orcid": "0000-0001-6813-8362",
+      "affiliation": "Centre for Culture and Technology, Curtin University",
+      "name": "Alkim Ozaygen"
+    },
+    {
+      "orcid": "0000-0002-9449-4384",
+      "affiliation": "Curtin Institute for Computation, Curtin University",
+      "name": "Rebecca Lange"
+    },
+    {
+      "orcid": "0000-0003-1202-7238",
+      "affiliation": "Curtin Institute for Computation, Curtin University",
+      "name": "Kathryn Napier"
+    },
+    {
+      "orcid": "0000-0002-0068-716X",
+      "affiliation": "Centre for Culture and Technology, Curtin University",
+      "name": "Cameron Neylon"
+    },
+    {
+      "orcid": "0000-0001-6551-8140",
+      "affiliation": "Centre for Culture and Technology, Curtin University",
+      "name": "Lucy Montgomery"
+    },
+    {
+      "orcid": "0000-0001-9542-1577",
+      "affiliation": "Quigley",
+      "name": "Niamh"
+    }
+  ]
+}

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -15,8 +15,8 @@
     },
     {
       "orcid": "0000-0002-6237-7423",
-      "affiliation": "Chien",
-      "name": "Tuan-Yow"
+      "affiliation": "Centre for Culture and Technology, Curtin University",
+      "name": "Tuan-Yow Chien"
     },
     {
       "orcid": "0000-0002-5094-3571",
@@ -55,8 +55,8 @@
     },
     {
       "orcid": "0000-0001-9542-1577",
-      "affiliation": "Quigley",
-      "name": "Niamh"
+      "affiliation": "Niamh Quigley",
+      "name": "Centre for Culture and Technology, Curtin University"
     }
   ]
 }


### PR DESCRIPTION
Added .zenodo.json to prevent the CFF file from overriding automatic release information and to ensure that authors are updated in Zenodo each release.