### PR TITLE
Update Google Books schedule interval

### DIFF
--- a/docs/oaebu_workflows/telescopes/google_books.md
+++ b/docs/oaebu_workflows/telescopes/google_books.md
@@ -23,7 +23,7 @@ The corresponding tables created in BigQuery are `google.google_books_salesYYYYM
 +------------------------------+---------+
 | Harvest Type                 |  SFTP   |
 +------------------------------+---------+
-| Harvest Frequency            | Monthly |
+| Harvest Frequency            | Weekly  |
 +------------------------------+---------+
 | Runs on remote worker        | False   |
 +------------------------------+---------+

--- a/oaebu_workflows/workflows/google_books_telescope.py
+++ b/oaebu_workflows/workflows/google_books_telescope.py
@@ -164,7 +164,7 @@ class GoogleBooksTelescope(OrganisationTelescope):
         accounts: Optional[List[str]],
         dag_id: Optional[str] = None,
         start_date: pendulum.DateTime = pendulum.datetime(2018, 1, 1),
-        schedule_interval: str = "@monthly",
+        schedule_interval: str = "@weekly",
         dataset_id: str = "google",
         schema_folder: str = default_schema_folder(),
         catchup: bool = False,


### PR DESCRIPTION
Update schedule from monthly to weekly. 
The google books reports need to be updated manually to the SFTP server, because of this manual process they might be updated at any point during the month.
It will be better to run the telescope every week to check if there are new reports available, so the kibana dashboards can be updated during the weekend with the latest google books data.