### PR TITLE
Fix/api update

### DIFF
--- a/oaebu_workflows/dags/doab_telescope.py
+++ b/oaebu_workflows/dags/doab_telescope.py
@@ -24,6 +24,7 @@ from observatory.platform.utils.api import make_observatory_api
 # Fetch all telescopes
 api = make_observatory_api()
 workflow_type = api.get_workflow_type(type_id=WorkflowTypes.doab)
-workflows = api.get_workflows(workflow_type_id=workflow_type.id, limit=1000)
-workflow = DoabTelescope(workflow_id=workflows[0].id)
-globals()[workflow.dag_id] = workflow.make_dag()
+workflows = api.get_workflows(workflow_type_id=workflow_type.id, limit=1)
+if len(workflows):
+    workflow = DoabTelescope(workflow_id=workflows[0].id)
+    globals()[workflow.dag_id] = workflow.make_dag()

--- a/oaebu_workflows/dags/oapen_metadata_telescope.py
+++ b/oaebu_workflows/dags/oapen_metadata_telescope.py
@@ -24,6 +24,7 @@ from oaebu_workflows.identifiers import WorkflowTypes
 # Fetch all workflows
 api = make_observatory_api()
 workflow_type = api.get_workflow_type(type_id=WorkflowTypes.oapen_metadata)
-workflows = api.get_workflows(workflow_type_id=workflow_type.id, limit=1000)
-workflow = OapenMetadataTelescope(workflow_id=workflows[0].id)
-globals()[workflow.dag_id] = workflow.make_dag()
+workflows = api.get_workflows(workflow_type_id=workflow_type.id, limit=1)
+if len(workflows):
+    workflow = OapenMetadataTelescope(workflow_id=workflows[0].id)
+    globals()[workflow.dag_id] = workflow.make_dag()

--- a/oaebu_workflows/dags/oapen_workflow.py
+++ b/oaebu_workflows/dags/oapen_workflow.py
@@ -24,7 +24,7 @@ from oaebu_workflows.identifiers import WorkflowTypes
 # Fetch all workflows
 api = make_observatory_api()
 workflow_type = api.get_workflow_type(type_id=WorkflowTypes.oapen_workflow)
-workflows = api.get_workflows(workflow_type_id=workflow_type.id, limit=1000)
-
-workflow = OapenWorkflow(workflow_id=workflows[0].id)
-globals()[workflow.dag_id] = workflow.make_dag()
+workflows = api.get_workflows(workflow_type_id=workflow_type.id, limit=1)
+if len(workflows):
+    workflow = OapenWorkflow(workflow_id=workflows[0].id)
+    globals()[workflow.dag_id] = workflow.make_dag()

--- a/oaebu_workflows/dags/onix_telescope.py
+++ b/oaebu_workflows/dags/onix_telescope.py
@@ -30,9 +30,9 @@ workflows = api.get_workflows(workflow_type_id=workflow_type.id, limit=1000)
 for workflow in workflows:
     organisation = workflow.organisation
     organisation_name = organisation.name
-    project_id = organisation.gcp_project_id
-    download_bucket = organisation.gcp_download_bucket
-    transform_bucket = organisation.gcp_transform_bucket
+    project_id = organisation.project_id
+    download_bucket = organisation.download_bucket
+    transform_bucket = organisation.transform_bucket
     dataset_location = "us"
     date_regex = workflow.extra.get("date_regex")
     date_format = workflow.extra.get("date_format")

--- a/oaebu_workflows/dags/onix_workflow.py
+++ b/oaebu_workflows/dags/onix_workflow.py
@@ -50,8 +50,8 @@ def get_gcp_address(dataset: Dataset) -> Tuple[str, str, str]:
     :return: project id, dataset id, table id.
     """
 
-    if dataset.service != "bigquery":
-        raise AirflowException("Unsupported DatasetStorage type")
+    if dataset.service != "google":
+        raise AirflowException("Unsupported Service type")
 
     return dataset.address.split(".")
 
@@ -136,7 +136,7 @@ def get_oaebu_partner_data(organisation_id: int) -> List[OaebuPartner]:
 
 # Fetch all ONIX telescopes
 api = make_observatory_api()
-workflow_type = api.get_workflow_type(type_id=WorkflowTypes.onix)
+workflow_type = api.get_workflow_type(type_id=WorkflowTypes.onix_workflow)
 workflows = api.get_workflows(workflow_type_id=workflow_type.id, limit=1000)
 
 # Create workflows for each organisation

--- a/oaebu_workflows/dags/onix_workflow.py
+++ b/oaebu_workflows/dags/onix_workflow.py
@@ -142,8 +142,8 @@ workflows = api.get_workflows(workflow_type_id=workflow_type.id, limit=1000)
 # Create workflows for each organisation
 for workflow in workflows:
     org_name = workflow.organisation.name
-    gcp_project_id = workflow.organisation.gcp_project_id
-    gcp_bucket_name = workflow.organisation.gcp_transform_bucket
+    gcp_project_id = workflow.organisation.project_id
+    gcp_bucket_name = workflow.organisation.transform_bucket
     data_partners = get_oaebu_partner_data(workflow.organisation.id)
 
     workflow = OnixWorkflow(

--- a/oaebu_workflows/dags/onix_workflow.py
+++ b/oaebu_workflows/dags/onix_workflow.py
@@ -64,7 +64,7 @@ def get_isbn_field_name(dataset: Dataset) -> str:
     """
 
     if dataset.dataset_type.extra is None:
-        return False
+        raise AirflowException("dataset_type.extra missing")
 
     isbn_field_name = dataset.dataset_type.extra.get("isbn_field_name", None)
     if isbn_field_name is None:
@@ -81,7 +81,7 @@ def get_title_field_name(dataset: Dataset) -> str:
     """
 
     if dataset.dataset_type.extra is None:
-        return False
+        raise AirflowException("dataset_type.extra missing")
 
     title_field_name = dataset.dataset_type.extra.get("title_field_name", None)
     if title_field_name is None:

--- a/oaebu_workflows/workflows/doab_telescope.py
+++ b/oaebu_workflows/workflows/doab_telescope.py
@@ -22,6 +22,8 @@ from typing import Tuple
 import pendulum
 from airflow.exceptions import AirflowException
 from pendulum.parsing.exceptions import ParserError
+
+from oaebu_workflows.config import schema_folder as default_schema_folder
 from observatory.platform.utils.airflow_utils import AirflowVars
 from observatory.platform.utils.file_utils import list_to_jsonl_gz
 from observatory.platform.utils.url_utils import get_user_agent, retry_session
@@ -30,7 +32,6 @@ from observatory.platform.workflows.stream_telescope import (
     StreamRelease,
     StreamTelescope,
 )
-from oaebu_workflows.config import schema_folder as default_schema_folder
 
 
 class DoabRelease(StreamRelease):

--- a/oaebu_workflows/workflows/google_analytics_telescope.py
+++ b/oaebu_workflows/workflows/google_analytics_telescope.py
@@ -28,8 +28,8 @@ from google.cloud import bigquery
 from googleapiclient.discovery import Resource, build
 from oauth2client.service_account import ServiceAccountCredentials
 
-from observatory.api.client.model.organisation import Organisation
 from oaebu_workflows.config import schema_folder as default_schema_folder
+from observatory.api.client.model.organisation import Organisation
 from observatory.platform.utils.airflow_utils import AirflowConns, AirflowVars
 from observatory.platform.utils.file_utils import list_to_jsonl_gz
 from observatory.platform.utils.workflow_utils import add_partition_date, make_dag_id

--- a/oaebu_workflows/workflows/google_books_telescope.py
+++ b/oaebu_workflows/workflows/google_books_telescope.py
@@ -26,8 +26,8 @@ from airflow.exceptions import AirflowException
 from airflow.models.taskinstance import TaskInstance
 from google.cloud import bigquery
 
-from observatory.api.client.model.organisation import Organisation
 from oaebu_workflows.config import schema_folder as default_schema_folder
+from observatory.api.client.model.organisation import Organisation
 from observatory.platform.utils.airflow_utils import AirflowConns, AirflowVars
 from observatory.platform.utils.file_utils import list_to_jsonl_gz
 from observatory.platform.utils.workflow_utils import (

--- a/oaebu_workflows/workflows/jstor_telescope.py
+++ b/oaebu_workflows/workflows/jstor_telescope.py
@@ -37,13 +37,13 @@ from google.oauth2.credentials import Credentials
 from googleapiclient.discovery import Resource, build
 from tenacity import retry, stop_after_attempt, wait_exponential, wait_fixed
 
-from observatory.api.client.model.organisation import Organisation
 from oaebu_workflows.config import schema_folder as default_schema_folder
+from observatory.api.client.model.organisation import Organisation
 from observatory.platform.utils.airflow_utils import AirflowConns, AirflowVars
 from observatory.platform.utils.file_utils import list_to_jsonl_gz
-from observatory.platform.utils.workflow_utils import add_partition_date, convert, make_dag_id
-from observatory.platform.utils.workflow_utils import SubFolder, workflow_path
 from observatory.platform.utils.url_utils import get_user_agent
+from observatory.platform.utils.workflow_utils import SubFolder, workflow_path
+from observatory.platform.utils.workflow_utils import add_partition_date, convert, make_dag_id
 from observatory.platform.workflows.organisation_telescope import OrganisationRelease, OrganisationTelescope
 
 

--- a/oaebu_workflows/workflows/oapen_irus_uk_telescope.py
+++ b/oaebu_workflows/workflows/oapen_irus_uk_telescope.py
@@ -32,6 +32,8 @@ from google.oauth2.service_account import IDTokenCredentials
 from googleapiclient.discovery import Resource, build
 from googleapiclient.errors import HttpError
 from oauth2client.service_account import ServiceAccountCredentials
+
+from oaebu_workflows.config import schema_folder as default_schema_folder
 from observatory.api.client.model.organisation import Organisation
 from observatory.platform.utils.airflow_utils import AirflowConns, AirflowVars
 from observatory.platform.utils.file_utils import get_file_hash, list_to_jsonl_gz
@@ -53,8 +55,6 @@ from observatory.platform.workflows.organisation_telescope import (
     OrganisationRelease,
     OrganisationTelescope,
 )
-
-from oaebu_workflows.config import schema_folder as default_schema_folder
 
 
 class OapenIrusUkRelease(OrganisationRelease):

--- a/oaebu_workflows/workflows/oapen_metadata_telescope.py
+++ b/oaebu_workflows/workflows/oapen_metadata_telescope.py
@@ -23,6 +23,7 @@ from typing import List, Tuple
 
 import pendulum
 from airflow.exceptions import AirflowException
+
 from oaebu_workflows.config import schema_folder as default_schema_folder
 from observatory.platform.utils.airflow_utils import AirflowVars
 from observatory.platform.utils.file_utils import list_to_jsonl_gz

--- a/oaebu_workflows/workflows/onix_telescope.py
+++ b/oaebu_workflows/workflows/onix_telescope.py
@@ -25,6 +25,7 @@ import pendulum
 from airflow.exceptions import AirflowException
 from airflow.models.taskinstance import TaskInstance
 from google.cloud.bigquery import SourceFormat
+
 from oaebu_workflows.config import schema_folder as default_schema_folder
 from observatory.platform.utils.airflow_utils import AirflowConns, AirflowVars
 from observatory.platform.utils.config_utils import observatory_home

--- a/oaebu_workflows/workflows/onix_workflow.py
+++ b/oaebu_workflows/workflows/onix_workflow.py
@@ -25,15 +25,16 @@ from typing import List, Optional
 import pendulum
 from airflow.exceptions import AirflowException
 from google.cloud.bigquery import SourceFormat
+
 from oaebu_workflows.config import schema_folder as default_schema_folder
 from oaebu_workflows.config import sql_folder
 from oaebu_workflows.workflows.oaebu_partners import OaebuPartner
-from observatory.api.server.dataset_type import DatasetTypeId
 from oaebu_workflows.workflows.onix_telescope import OnixTelescope
 from oaebu_workflows.workflows.onix_work_aggregation import (
     BookWorkAggregator,
     BookWorkFamilyAggregator,
 )
+from observatory.api.server.dataset_type import DatasetTypeId
 from observatory.platform.utils.dag_run_sensor import DagRunSensor
 from observatory.platform.utils.file_utils import list_to_jsonl_gz
 from observatory.platform.utils.gc_utils import (

--- a/oaebu_workflows/workflows/ucl_discovery_telescope.py
+++ b/oaebu_workflows/workflows/ucl_discovery_telescope.py
@@ -25,13 +25,13 @@ import pendulum
 from airflow.exceptions import AirflowException, AirflowSkipException
 from google.cloud import bigquery
 
-from observatory.api.client.model.organisation import Organisation
 from oaebu_workflows.config import schema_folder as default_schema_folder
+from observatory.api.client.model.organisation import Organisation
 from observatory.platform.utils.airflow_utils import AirflowVars
 from observatory.platform.utils.file_utils import list_to_jsonl_gz
-from observatory.platform.workflows.organisation_telescope import OrganisationRelease, OrganisationTelescope
 from observatory.platform.utils.url_utils import retry_session
 from observatory.platform.utils.workflow_utils import add_partition_date, make_dag_id
+from observatory.platform.workflows.organisation_telescope import OrganisationRelease, OrganisationTelescope
 
 
 class UclDiscoveryRelease(OrganisationRelease):


### PR DESCRIPTION
Fixes to enable the workflows to function with the API changes:
* Prevent IndexError by only creating DOAB, OAPEN Metadata and OAPEN Workflow when a workflow exists. There should only be zero or one of each of these workflows.
* In ONIX Telescope, remove `gcp_` prefixes.
* In ONIX Workflow:
  * Change dataset.service check to google rather than  BigQuery.
  * In get_isbn_field_name and get_title_field_name raise exception when dataset_type.extra is None rather than returning False, which will end up setting isbn_field_name and title_field_name to False in the SQL if the extra is not specified by mistake.
* Removed unused imports and re-sorted them. 