### PR TITLE
Bad 214 oapen onix unittest table updates

### DIFF
--- a/oaebu_workflows/database/sql/export_book_subject_bic_metrics.sql.jinja2
+++ b/oaebu_workflows/database/sql/export_book_subject_bic_metrics.sql.jinja2
@@ -75,4 +75,4 @@ FROM(
     WHERE month.oapen_irus_uk IS NOT NULL OR month.google_books_traffic IS NOT NULL OR month.google_books_sales IS NOT NULL
     GROUP BY subject, month
     ORDER BY subject ASC, month DESC) as metrics
-LEFT JOIN `oaebu-public-data.oaebu_reference.bic_lookup` as bic on bic.code = subject
+LEFT JOIN `{{ subject_project_id }}.{{ subject_dataset_id}}.bic_lookup` as bic on bic.code = subject

--- a/oaebu_workflows/fixtures/oapen_workflow/bic_lookup.jsonl
+++ b/oaebu_workflows/fixtures/oapen_workflow/bic_lookup.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2d8eaf07df94db15e4d2fe04ea49789fc0665f3bf4ca21cb269a3dbf9dfa7dcb
+size 1248

--- a/oaebu_workflows/fixtures/oapen_workflow/book.jsonl
+++ b/oaebu_workflows/fixtures/oapen_workflow/book.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7d07ce320c51002df807c78fd3d6a65259636a803b7ad4eac5922f54f323bfee
+size 437

--- a/oaebu_workflows/fixtures/oapen_workflow/expected_book_product.jsonl
+++ b/oaebu_workflows/fixtures/oapen_workflow/expected_book_product.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a390de70477ba2ce9fbbdf7adace9af68b8e1720eba8801844025b4b5f621bb0
+size 4269

--- a/oaebu_workflows/fixtures/oapen_workflow/expected_onix.jsonl
+++ b/oaebu_workflows/fixtures/oapen_workflow/expected_onix.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9f43a9c621317ea10ca1e7825a7f22c1244a6316cea651369e657d47ddf2d45d
+size 1425

--- a/oaebu_workflows/fixtures/oapen_workflow/oapen_irus_uk.jsonl
+++ b/oaebu_workflows/fixtures/oapen_workflow/oapen_irus_uk.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6f3be525b93c2037d6e3787d3140f293d7f336988d67abd16c48145c99eeedfb
+size 1066

--- a/oaebu_workflows/fixtures/oapen_workflow/oapen_irus_uk.jsonl
+++ b/oaebu_workflows/fixtures/oapen_workflow/oapen_irus_uk.jsonl
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6f3be525b93c2037d6e3787d3140f293d7f336988d67abd16c48145c99eeedfb
-size 1066
+oid sha256:8383a9edbd862163ce630ef6d330708336ccbd372b497dc0a7ee12bc3fc03023
+size 1459

--- a/oaebu_workflows/fixtures/oapen_workflow/oapen_metadata.jsonl
+++ b/oaebu_workflows/fixtures/oapen_workflow/oapen_metadata.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:84c2b2dd82703333e01bc2f4919d484945e1141da6f2b88df6b6c6af74cccddf
+size 2800

--- a/oaebu_workflows/fixtures/oapen_workflow/onix_work_isbn.jsonl
+++ b/oaebu_workflows/fixtures/oapen_workflow/onix_work_isbn.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d2d83d0d1bc74621cec9d4e5688bf09e634915c15e29a49c91539ec2c4148676
+size 71

--- a/oaebu_workflows/fixtures/oapen_workflow/schema/bic_lookup_1900-01-01.json
+++ b/oaebu_workflows/fixtures/oapen_workflow/schema/bic_lookup_1900-01-01.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:035adf20fdbbd95e4178c5316afa94baa50008d66bd6c15b18f9c658b5d44863
+size 182

--- a/oaebu_workflows/fixtures/oapen_workflow/schema/book_2021-11-25.json
+++ b/oaebu_workflows/fixtures/oapen_workflow/schema/book_2021-11-25.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b1530a3453f52874ca0941210ad7ed7f04efb572f1e212fd2d1db0a23844d82f
+size 3948

--- a/oaebu_workflows/fixtures/oapen_workflow/schema/oapen_irus_uk_1900-01-01.json
+++ b/oaebu_workflows/fixtures/oapen_workflow/schema/oapen_irus_uk_1900-01-01.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:db3d00de3fedd076acefd2265dd033ab416c635d85b4eebb8f872707a20c18f6
+size 6446

--- a/oaebu_workflows/fixtures/oapen_workflow/schema/oapen_metadata_2018-05-14.json
+++ b/oaebu_workflows/fixtures/oapen_workflow/schema/oapen_metadata_2018-05-14.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:30b33d446ad6383d0423d948365fe9343b67b11878721300f66d639711c1bd7f
+size 17319

--- a/oaebu_workflows/fixtures/onix_workflow/bic_lookup.jsonl
+++ b/oaebu_workflows/fixtures/onix_workflow/bic_lookup.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2d8eaf07df94db15e4d2fe04ea49789fc0665f3bf4ca21cb269a3dbf9dfa7dcb
+size 1248

--- a/oaebu_workflows/fixtures/onix_workflow/bisac_lookup.jsonl
+++ b/oaebu_workflows/fixtures/onix_workflow/bisac_lookup.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3048fcc8ecf525e3b80ab688d4dd806f9a981724cec668dde7eeb46b3792cb5b
+size 2107

--- a/oaebu_workflows/fixtures/onix_workflow/schema/bic_lookup_1900-01-01.json
+++ b/oaebu_workflows/fixtures/onix_workflow/schema/bic_lookup_1900-01-01.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:035adf20fdbbd95e4178c5316afa94baa50008d66bd6c15b18f9c658b5d44863
+size 182

--- a/oaebu_workflows/fixtures/onix_workflow/schema/bisac_lookup_1900-01-01.json
+++ b/oaebu_workflows/fixtures/onix_workflow/schema/bisac_lookup_1900-01-01.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:035adf20fdbbd95e4178c5316afa94baa50008d66bd6c15b18f9c658b5d44863
+size 182

--- a/oaebu_workflows/fixtures/onix_workflow/schema/onix_1900-01-01.json
+++ b/oaebu_workflows/fixtures/onix_workflow/schema/onix_1900-01-01.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cc5f0b324f29ede9a0cf465e0055080232975eb9d4cf2250e305e48f1444c493
+size 47704

--- a/oaebu_workflows/fixtures/onix_workflow/schema/thema_lookup_1900-01-01.json
+++ b/oaebu_workflows/fixtures/onix_workflow/schema/thema_lookup_1900-01-01.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:035adf20fdbbd95e4178c5316afa94baa50008d66bd6c15b18f9c658b5d44863
+size 182

--- a/oaebu_workflows/fixtures/onix_workflow/thema_lookup.jsonl
+++ b/oaebu_workflows/fixtures/onix_workflow/thema_lookup.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e0e8190f3cc5a8a20fb183f92f4a5836e6591f1325f222f5ffd312afd4167baf
+size 1362

--- a/oaebu_workflows/workflows/oapen_workflow.py
+++ b/oaebu_workflows/workflows/oapen_workflow.py
@@ -91,6 +91,8 @@ class OapenWorkflow(Workflow):
         oaebu_elastic_dataset: str = "data_export",
         country_project_id: str = "academic-observatory",
         country_dataset_id: str = "settings",
+        subject_project_id: str = "oaebu-public-data",
+        subject_dataset_id: str = "oaebu_reference",
         dataset_location: str = "us",
         dataset_description: str = "Oapen workflow tables",
         dag_id: Optional[str] = None,
@@ -102,16 +104,26 @@ class OapenWorkflow(Workflow):
     ):
         """Initialises the workflow object.
         :param ao_gcp_project_id: GCP project ID for the Academic Observatory.
+        :param oapen_gcp_project_id: GCP project ID for oapen data.
         :param oapen_metadata_dataset_id: GCP dataset ID for the oapen data.
         :param oapen_metadata_table_id: GCP table ID for the oapen data.
+        :param public_book_metadata_dataset_id: GCP dataset ID for metadata.
+        :param public_book_metadata_table_id: GCP table ID for book metadata.
         :param public_book_dataset_id: GCP dataset ID for the public book data.
         :param public_book_table_id: GCP table ID for the public book data.
         :param irus_uk_dag_id_prefix: OAEBU IRUS_UK dag id prefix.
         :param irus_uk_dataset_id: OAEBU IRUS_UK dataset id.
         :param irus_uk_table_id: OAEBU IRUS_UK table id.
         :param oaebu_dataset: OAEBU dataset.
+        :param oaebu_onix_dataset: GCP oapen onix dataset name.
         :param oaebu_intermediate_dataset: OAEBU intermediate dataset.
         :param oaebu_elastic_dataset: OAEBU elastic dataset.
+        :param country_project_id: GCP project ID containing the country lookup table.
+        :param country_dataset_id: GCP dataset ID for the country lookup table.
+        :param subject_project_id: GCP project ID containing the book subject lookup table (bic).
+        :param subject_dataset_id: GCP dataset ID for the book subject lookup table (bic).
+        :param dataset_location: GCP region.
+        :param dataset_description: Description of dataset.
         :param dag_id: DAG ID.
         :param start_date: Start date of the DAG.
         :param schedule_interval: Scheduled interval for running the DAG.
@@ -160,6 +172,9 @@ class OapenWorkflow(Workflow):
 
         self.country_project_id = country_project_id
         self.country_dataset_id = country_dataset_id
+
+        self.subject_project_id = subject_project_id
+        self.subject_dataset_id = subject_dataset_id
 
         # Initialise Telesecope base class
         super().__init__(
@@ -384,6 +399,8 @@ class OapenWorkflow(Workflow):
             release=release_date,
             country_project_id=self.country_project_id,
             country_dataset_id=self.country_dataset_id,
+            subject_project_id=self.subject_project_id,
+            subject_dataset_id=self.subject_dataset_id,
         )
 
         status = create_bigquery_table_from_query(
@@ -415,16 +432,6 @@ class OapenWorkflow(Workflow):
                 "file_type": "json",
             },
             {
-                "output_table": "book_product_metrics_institution",
-                "query_template": "export_book_metrics_institution.sql.jinja2",
-                "file_type": "json",
-            },
-            {
-                "output_table": "institution_list",
-                "query_template": "export_institution_list.sql.jinja2",
-                "file_type": "json",
-            },
-            {
                 "output_table": "book_product_metrics_city",
                 "query_template": "export_book_metrics_city.sql.jinja2",
                 "file_type": "json",
@@ -442,16 +449,6 @@ class OapenWorkflow(Workflow):
             {
                 "output_table": "book_product_subject_bic_metrics",
                 "query_template": "export_book_subject_bic_metrics.sql.jinja2",
-                "file_type": "json",
-            },
-            {
-                "output_table": "book_product_subject_bisac_metrics",
-                "query_template": "export_book_subject_bisac_metrics.sql.jinja2",
-                "file_type": "json",
-            },
-            {
-                "output_table": "book_product_subject_thema_metrics",
-                "query_template": "export_book_subject_thema_metrics.sql.jinja2",
                 "file_type": "json",
             },
             {

--- a/oaebu_workflows/workflows/onix_workflow.py
+++ b/oaebu_workflows/workflows/onix_workflow.py
@@ -232,6 +232,8 @@ class OnixWorkflow(Workflow):
         country_dataset_id: str = "settings",
         onix_dataset_id: str = "onix",
         onix_table_id: str = "onix",
+        subject_project_id: str = "oaebu-public-data",
+        subject_dataset_id: str = "oaebu_reference",
         schema_folder: str = default_schema_folder(),
         dag_id: Optional[str] = None,
         start_date: Optional[pendulum.DateTime] = pendulum.datetime(2021, 3, 28),
@@ -267,6 +269,8 @@ class OnixWorkflow(Workflow):
         self.gcp_bucket_name = gcp_bucket_name
         self.onix_dataset_id = onix_dataset_id
         self.onix_table_id = onix_table_id
+        self.subject_project_id = subject_project_id
+        self.subject_dataset_id = subject_dataset_id
         self.schema_folder = schema_folder
 
         api = make_observatory_api()
@@ -773,6 +777,8 @@ class OnixWorkflow(Workflow):
             release=release_date,
             country_project_id=self.country_project_id,
             country_dataset_id=self.country_dataset_id,
+            subject_project_id=self.subject_project_id,
+            subject_dataset_id=self.subject_dataset_id,
         )
 
         status = create_bigquery_table_from_query(

--- a/oaebu_workflows/workflows/tests/test_oapen_workflow.py
+++ b/oaebu_workflows/workflows/tests/test_oapen_workflow.py
@@ -201,7 +201,7 @@ class TestOapenWorkflowFunctional(ObservatoryTestCase):
         conn = Connection(conn_id=AirflowConns.OBSERVATORY_API, uri=f"http://:password@{self.host}:{self.port}")
         env.add_connection(conn)
 
-    def setup_fake_data(self, settings_dataset_id: str, fixtures_dataset_id:str, release_date: pendulum.DateTime):
+    def setup_fake_data(self, settings_dataset_id: str, fixtures_dataset_id: str, release_date: pendulum.DateTime):
         # Settings dataset
         country = load_jsonl(test_fixtures_folder("onix_workflow", "country.jsonl"))
         settings_schema_path = test_fixtures_folder("onix_workflow", "schema")
@@ -222,7 +222,7 @@ class TestOapenWorkflowFunctional(ObservatoryTestCase):
             ),
             Table(
                 "book",
-                True, # book table must be sharded
+                True,  # book table must be sharded
                 fixtures_dataset_id,
                 book,
                 "book",
@@ -300,7 +300,7 @@ class TestOapenWorkflowFunctional(ObservatoryTestCase):
                 start_date=start_date,
                 country_project_id=self.gcp_project_id,
                 country_dataset_id=oaebu_settings_dataset_id,
-                subject_project_id=self.gcp_project_id, 
+                subject_project_id=self.gcp_project_id,
                 subject_dataset_id=oaebu_fixtures_dataset_id,
                 workflow_id=1,
             )
@@ -437,5 +437,9 @@ class TestOapenWorkflowFunctional(ObservatoryTestCase):
             book_product_table_id = f"{self.gcp_project_id}.{oaebu_output_dataset_id}.book_product{release_suffix}"
             self.assert_table_integrity(onix_table_id)
             self.assert_table_integrity(book_product_table_id)
-            self.assert_table_content(onix_table_id, load_jsonl(test_fixtures_folder("oapen_workflow", "expected_onix.jsonl")))
-            self.assert_table_content(book_product_table_id, load_jsonl(test_fixtures_folder("oapen_workflow", "expected_book_product.jsonl")))
+            self.assert_table_content(
+                onix_table_id, load_jsonl(test_fixtures_folder("oapen_workflow", "expected_onix.jsonl"))
+            )
+            self.assert_table_content(
+                book_product_table_id, load_jsonl(test_fixtures_folder("oapen_workflow", "expected_book_product.jsonl"))
+            )


### PR DESCRIPTION
Removed dependency on the observatory-unit-testing project for the oapen workflow unit test and created mock data to replace the previously used real data. The test also no longer queries data from the academic-observatory dataset.