### PR TITLE
Remove old buckets and datasets with same prefix

### DIFF
--- a/oaebu_workflows/workflows/tests/test_doab_telescope.py
+++ b/oaebu_workflows/workflows/tests/test_doab_telescope.py
@@ -38,6 +38,7 @@ from observatory.platform.utils.test_utils import (
     ObservatoryTestCase,
     module_file_path,
     find_free_port,
+    make_prefix,
 )
 from observatory.platform.utils.workflow_utils import (
     blob_name,
@@ -86,6 +87,9 @@ class TestDoabTelescope(ObservatoryTestCase):
         self.api = ObservatoryApi(api_client=api_client)  # noqa: E501
         self.env = ObservatoryApiEnvironment(host=self.host, port=self.port)
         self.org_name = "UCL Press"
+
+        # Create prefix depending on test name and organisation
+        self.prefix = make_prefix(self.__class__.__name__, self.org_name)
 
     def setup_api(self):
         dt = pendulum.now("UTC")
@@ -165,7 +169,7 @@ class TestDoabTelescope(ObservatoryTestCase):
         :return: None
         """
 
-        env = ObservatoryEnvironment(self.project_id, self.data_location, api_host=self.host, api_port=self.port)
+        env = ObservatoryEnvironment(self.project_id, self.data_location, prefix=self.prefix, api_host=self.host, api_port=self.port)
 
         with env.create():
             self.setup_connections(env)
@@ -178,7 +182,12 @@ class TestDoabTelescope(ObservatoryTestCase):
         :return: None.
         """
         # Setup Observatory environment
-        env = ObservatoryEnvironment(self.project_id, self.data_location, api_host=self.host, api_port=self.port)
+        env = ObservatoryEnvironment(self.project_id, self.data_location, prefix=self.prefix, api_host=self.host, api_port=self.port)
+
+        # Remove buckets and datasets 7 days or older.
+        env.delete_old_test_buckets(age_to_delete=7)
+        env.delete_old_test_datasets(age_to_delete=7)
+
         dataset_id = env.add_dataset()
 
         # Setup Telescope

--- a/oaebu_workflows/workflows/tests/test_elastic_workflow.py
+++ b/oaebu_workflows/workflows/tests/test_elastic_workflow.py
@@ -23,7 +23,7 @@ from oaebu_workflows.config import elastic_mappings_folder
 from oaebu_workflows.dags.elastic_import_workflow import load_elastic_mappings_oaebu
 from observatory.platform.utils.config_utils import module_file_path
 from observatory.platform.utils.jinja2_utils import render_template
-from observatory.platform.utils.test_utils import ObservatoryEnvironment, ObservatoryTestCase
+from observatory.platform.utils.test_utils import ObservatoryEnvironment, ObservatoryTestCase, make_prefix
 from observatory.platform.utils.workflow_utils import make_dag_id
 
 
@@ -34,6 +34,9 @@ class TestElasticImportWorkflow(ObservatoryTestCase):
         super().__init__(*args, **kwargs)
         self.project_id = os.getenv("TEST_GCP_PROJECT_ID")
         self.data_location = os.getenv("TEST_GCP_DATA_LOCATION")
+
+        # Create prefix depending on test name and organisation
+        self.prefix = make_prefix(self.__class__.__name__, "")
 
     def test_load_elastic_mappings_oaebu(self):
         """Test load_elastic_mappings_oaebu"""
@@ -157,7 +160,7 @@ class TestElasticImportWorkflow(ObservatoryTestCase):
         :return: None
         """
 
-        env = ObservatoryEnvironment(self.project_id, self.data_location, enable_api=False)
+        env = ObservatoryEnvironment(self.project_id, self.data_location, prefix=self.prefix, enable_api=False)
         with env.create():
             expected_dag_ids = [
                 make_dag_id("elastic_import", suffix)

--- a/oaebu_workflows/workflows/tests/test_google_analytics_telescope.py
+++ b/oaebu_workflows/workflows/tests/test_google_analytics_telescope.py
@@ -36,7 +36,8 @@ from observatory.platform.utils.test_utils import (
     ObservatoryEnvironment,
     ObservatoryTestCase,
     module_file_path,
-    find_free_port
+    find_free_port,
+    make_prefix,
 )
 from observatory.api.testing import ObservatoryApiEnvironment
 from observatory.api.client import ApiClient, Configuration
@@ -73,6 +74,9 @@ class TestGoogleAnalyticsTelescope(ObservatoryTestCase):
         self.api = ObservatoryApi(api_client=api_client)  # noqa: E501
         self.env = ObservatoryApiEnvironment(host=self.host, port=self.port)
         self.org_name = "UCL Press"
+
+        # Create prefix depending on test name and organisation
+        self.prefix = make_prefix(self.__class__.__name__, "")
 
     def setup_api(self, org_name=None):
         dt = pendulum.now("UTC")
@@ -150,7 +154,7 @@ class TestGoogleAnalyticsTelescope(ObservatoryTestCase):
         :return: None
         """
 
-        env = ObservatoryEnvironment(self.project_id, self.data_location, api_host=self.host, api_port=self.port)
+        env = ObservatoryEnvironment(self.project_id, self.data_location, prefix=self.prefix, api_host=self.host, api_port=self.port)
         with env.create():
             self.setup_connections(env)
             self.setup_api()
@@ -175,8 +179,16 @@ class TestGoogleAnalyticsTelescope(ObservatoryTestCase):
         http = HttpMockSequence(create_http_mock_sequence(self.organisation_name))
         mock_build.return_value = build("analyticsreporting", "v4", http=http)
 
+        # Create prefix depending on test name and organisation
+        self.prefix = make_prefix(self.__class__.__name__, self.organisation_name)
+
         # Setup Observatory environment
-        env = ObservatoryEnvironment(self.project_id, self.data_location, api_host=self.host, api_port=self.port)
+        env = ObservatoryEnvironment(self.project_id, self.data_location, prefix=self.prefix, api_host=self.host, api_port=self.port)
+
+        # Remove buckets and datasets 7 days or older.
+        env.delete_old_test_buckets(age_to_delete=7)
+        env.delete_old_test_datasets(age_to_delete=7)
+        
         dataset_id = env.add_dataset()
 
         # Setup Telescope
@@ -343,8 +355,16 @@ class TestGoogleAnalyticsTelescope(ObservatoryTestCase):
         http = HttpMockSequence(create_http_mock_sequence(self.organisation_name))
         mock_build.return_value = build("analyticsreporting", "v4", http=http)
 
+        # Create prefix depending on test name and organisation
+        self.prefix = make_prefix(self.__class__.__name__, self.organisation_name)
+
         # Setup Observatory environment
-        env = ObservatoryEnvironment(self.project_id, self.data_location, api_host=self.host, api_port=self.port)
+        env = ObservatoryEnvironment(self.project_id, self.data_location, prefix=self.prefix, api_host=self.host, api_port=self.port)
+
+        # Remove buckets and datasets 7 days or older.
+        env.delete_old_test_buckets(age_to_delete=7)
+        env.delete_old_test_datasets(age_to_delete=7)
+
         dataset_id = env.add_dataset()
 
         # Setup Telescope

--- a/oaebu_workflows/workflows/tests/test_oapen_irus_uk_telescope.py
+++ b/oaebu_workflows/workflows/tests/test_oapen_irus_uk_telescope.py
@@ -46,6 +46,7 @@ from observatory.platform.utils.test_utils import (
     module_file_path,
     random_id,
     find_free_port,
+    make_prefix,
 )
 from observatory.platform.utils.workflow_utils import blob_name, table_ids_from_path
 from requests import Response
@@ -103,6 +104,9 @@ class TestOapenIrusUkTelescope(ObservatoryTestCase):
         self.api = ObservatoryApi(api_client=api_client)  # noqa: E501
         self.env = ObservatoryApiEnvironment(host=self.host, port=self.port)
         self.org_name = "UCL Press"
+
+        # Create prefix depending on test name and organisation
+        self.prefix = make_prefix(self.__class__.__name__, self.org_name)
 
     def setup_api(self, env=None):
         dt = pendulum.now("UTC")
@@ -186,7 +190,7 @@ class TestOapenIrusUkTelescope(ObservatoryTestCase):
         :return: None
         """
 
-        env = ObservatoryEnvironment(self.project_id, self.data_location, api_host=self.host, api_port=self.port)
+        env = ObservatoryEnvironment(self.project_id, self.data_location, prefix=self.prefix, api_host=self.host, api_port=self.port)
 
         with env.create():
             self.setup_connections(env)
@@ -202,7 +206,12 @@ class TestOapenIrusUkTelescope(ObservatoryTestCase):
         :return: None.
         """
         # Setup Observatory environment
-        env = ObservatoryEnvironment(self.project_id, self.data_location, api_host=self.host, api_port=self.port)
+        env = ObservatoryEnvironment(self.project_id, self.data_location, prefix=self.prefix, api_host=self.host, api_port=self.port)
+
+        # Remove buckets and datasets 7 days or older.
+        env.delete_old_test_buckets(age_to_delete=7)
+        env.delete_old_test_datasets(age_to_delete=7)
+
         dataset_id = env.add_dataset()
 
         # Setup Telescope

--- a/oaebu_workflows/workflows/tests/test_oapen_metadata_telescope.py
+++ b/oaebu_workflows/workflows/tests/test_oapen_metadata_telescope.py
@@ -37,6 +37,7 @@ from observatory.platform.utils.test_utils import (
     ObservatoryTestCase,
     module_file_path,
     find_free_port,
+    make_prefix,
 )
 from observatory.platform.utils.workflow_utils import (
     blob_name,
@@ -87,9 +88,17 @@ class TestOapenMetadataTelescope(ObservatoryTestCase):
         self.env = ObservatoryApiEnvironment(host=self.host, port=self.port)
         self.org_name = "Curtin Press"
 
+        # Create prefix depending on test name and organisation
+        self.prefix = make_prefix(self.__class__.__name__, self.org_name)
+
     def setup_environment(self) -> ObservatoryEnvironment:
         """Setup observatory environment"""
-        env = ObservatoryEnvironment(self.project_id, self.data_location, api_host=self.host, api_port=self.port)
+        env = ObservatoryEnvironment(self.project_id, self.data_location, prefix=self.prefix, api_host=self.host, api_port=self.port)
+
+        # Remove buckets and datasets 7 days or older.
+        env.delete_old_test_buckets(age_to_delete=7)
+        env.delete_old_test_datasets(age_to_delete=7)
+
         self.dataset_id = env.add_dataset()
         return env
 
@@ -171,7 +180,7 @@ class TestOapenMetadataTelescope(ObservatoryTestCase):
 
         :return: None
         """
-        env = ObservatoryEnvironment(self.project_id, self.data_location, api_host=self.host, api_port=self.port)
+        env = ObservatoryEnvironment(self.project_id, self.data_location, prefix=self.prefix, api_host=self.host, api_port=self.port)
 
         with env.create():
             self.setup_connections(env)

--- a/oaebu_workflows/workflows/tests/test_oapen_workflow.py
+++ b/oaebu_workflows/workflows/tests/test_oapen_workflow.py
@@ -36,6 +36,7 @@ from observatory.platform.utils.test_utils import (
     bq_load_tables,
     make_dummy_dag,
     find_free_port,
+    make_prefix,
 )
 from observatory.platform.utils.workflow_utils import (
     make_dag_id,
@@ -141,6 +142,9 @@ class TestOapenWorkflowFunctional(ObservatoryTestCase):
         self.gcp_dataset_id = "oaebu"
         self.irus_uk_dag_id_prefix = "oapen_irus_uk"
         self.irus_uk_table_id = "oapen_irus_uk"
+
+        # Create prefix depending on test name and organisation
+        self.prefix = make_prefix(self.__class__.__name__, self.org_name)
 
         # API environment
         self.host = "localhost"
@@ -266,8 +270,12 @@ class TestOapenWorkflowFunctional(ObservatoryTestCase):
         """Functional test of the OAPEN workflow"""
 
         # Setup Observatory environment
-        env = ObservatoryEnvironment(self.gcp_project_id, self.data_location, api_port=self.port, api_host=self.host)
+        env = ObservatoryEnvironment(self.gcp_project_id, self.data_location, prefix=self.prefix, api_port=self.port, api_host=self.host)
         org_name = self.org_name
+
+        # Remove buckets and datasets 7 days or older.
+        env.delete_old_test_buckets(age_to_delete=7)
+        env.delete_old_test_datasets(age_to_delete=7)
 
         # Create datasets
         oaebu_intermediate_dataset_id = env.add_dataset(prefix="oaebu_intermediate")

--- a/oaebu_workflows/workflows/tests/test_ucl_discovery_telescope.py
+++ b/oaebu_workflows/workflows/tests/test_ucl_discovery_telescope.py
@@ -38,6 +38,7 @@ from observatory.platform.utils.test_utils import (
     ObservatoryTestCase,
     module_file_path,
     find_free_port,
+    make_prefix,
 )
 from requests.exceptions import RetryError
 from oaebu_workflows.config import test_fixtures_folder
@@ -84,6 +85,9 @@ class TestUclDiscoveryTelescope(ObservatoryTestCase):
         self.api = ObservatoryApi(api_client=api_client)  # noqa: E501
         self.env = ObservatoryApiEnvironment(host=self.host, port=self.port)
         self.org_name = "UCL Press"
+
+        # Create prefix depending on test name and organisation
+        self.prefix = make_prefix(self.__class__.__name__, self.org_name)
 
     def setup_api(self):
         dt = pendulum.now("UTC")
@@ -161,7 +165,7 @@ class TestUclDiscoveryTelescope(ObservatoryTestCase):
         :return: None
         """
 
-        env = ObservatoryEnvironment(self.project_id, self.data_location, api_host=self.host, api_port=self.port)
+        env = ObservatoryEnvironment(self.project_id, self.data_location, prefix=self.prefix, api_host=self.host, api_port=self.port)
 
         with env.create():
             self.setup_connections(env)
@@ -182,7 +186,14 @@ class TestUclDiscoveryTelescope(ObservatoryTestCase):
         ], 25
 
         # Setup Observatory environment
-        env = ObservatoryEnvironment(self.project_id, self.data_location, api_host=self.host, api_port=self.port)
+        env = ObservatoryEnvironment(
+            self.project_id, self.data_location, prefix=self.prefix, api_host=self.host, api_port=self.port
+        )
+
+        # Remove buckets and datasets 7 days or older.
+        env.delete_old_test_buckets(age_to_delete=7)
+        env.delete_old_test_datasets(age_to_delete=7)
+
         dataset_id = env.add_dataset()
 
         # Setup Telescope


### PR DESCRIPTION
Added functions from [PR](https://github.com/The-Academic-Observatory/observatory-platform/pull/578) to make a common prefix for the buckets and datasets and will delete them if they are older than 7 days. The prefix is unique to each test and will not delete buckets or datasets created or being used by other tests. 

Unit tests will fail until [PR](https://github.com/The-Academic-Observatory/observatory-platform/pull/578) is merged. 