### PR TITLE
Bad 241 - UCL Discovery data collection - Added ISBN10s

### DIFF
--- a/oaebu_workflows/database/schema/ucl_discovery_2008-01-01.json
+++ b/oaebu_workflows/database/schema/ucl_discovery_2008-01-01.json
@@ -96,6 +96,12 @@
     "type": "STRING"
   },
   {
+    "description": "ISBN10",
+    "mode": "NULLABLE",
+    "name": "isbn10",
+    "type": "STRING"
+  },
+  {
     "description": "Language elements",
     "mode": "NULLABLE",
     "name": "language_elements",

--- a/oaebu_workflows/workflows/tests/test_ucl_discovery_telescope.py
+++ b/oaebu_workflows/workflows/tests/test_ucl_discovery_telescope.py
@@ -74,7 +74,7 @@ class TestUclDiscoveryTelescope(ObservatoryTestCase):
         self.metadata_cassette = test_fixtures_folder("ucl_discovery", "metadata.yaml")
         self.country_cassette = test_fixtures_folder("ucl_discovery", "country.yaml")
         self.download_hash = "8ae68aa5a455a1835fd906665746ee8c"
-        self.transform_hash = "5a552603"
+        self.transform_hash = "ef8ba725"
 
         # API environment
         self.host = "localhost"

--- a/oaebu_workflows/workflows/ucl_discovery_telescope.py
+++ b/oaebu_workflows/workflows/ucl_discovery_telescope.py
@@ -164,6 +164,7 @@ class UclDiscoveryRelease(OrganisationRelease):
                         "language": row["language"],
                         "doi": row["doi"],
                         "isbn": row["isbn_13"],
+                        "isbn10": row["isbn"],
                         "language_elements": row["language_elements"],
                         "series": row["series"],
                         "pagerange": row["pagerange"],


### PR DESCRIPTION
Added column of "isbn" to the data pull because they are supposed to contain ISBN10s but sometimes also contain ISBN13s and vice versa. By adding this change, we can make a list of effected eprint IDs with dirty ISBNs that we can send to the publisher and request them to fix the errors. 