### PR TITLE
INF-540: Updated JSTOR telescope to ignore new fields in the schema

### DIFF
--- a/oaebu_workflows/workflows/jstor_telescope.py
+++ b/oaebu_workflows/workflows/jstor_telescope.py
@@ -216,6 +216,7 @@ class JstorTelescope(OrganisationTelescope):
             max_active_runs=max_active_runs,
             workflow_id=workflow_id,
             tags=[Tag.oaebu],
+            load_bigquery_table_kwargs={"ignore_unknown_values": True},
         )
         self.publisher_id = publisher_id
 


### PR DESCRIPTION
The JSTOR telescope has run into issues with new data. The data cannot be loaded into the table as there are now new fields. We would prefer new fields to be ignored by default so that this doesn't happen.