### PR TITLE
BAD-276: Fulcrum Telescope Development

### DIFF
--- a/docs/oaebu_workflows/telescopes/fulcrum.md
+++ b/docs/oaebu_workflows/telescopes/fulcrum.md
@@ -1,0 +1,84 @@
+# Fulcrum
+
+The Fulcrum telescope collects usage statistics for titles accessed via the [Fulcrum Platform](https://www.fulcrum.org/). Usage data is accessible through [IRUS](https://irus.jisc.ac.uk/r5/) in much the same way as the [OAPEN_IRUS_UK](./oapen_irus_uk.md) telescope. Unlike OAPEN IRUS UK, Fulcrum does not record sensitive IP address information. This makes dealing with the data much simpler.
+
+The earliest avaialable data for the Fulcrum platform is April 2022. It follows that all data is of [COUNTER](https://www.projectcounter.org/) 5 standard.
+
+```eval_rst
++------------------------------+--------------+
+| Summary                      |              |
++==============================+==============+
+| Average runtime              | 5-10 mins    |
++------------------------------+--------------+
+| Average download size        | 1-10 MB      |
++------------------------------+--------------+
+| Harvest Type                 | API          |
++------------------------------+--------------+
+| Harvest Frequency            | Monthly      |
++------------------------------+--------------+
+| Runs on remote worker        | False        |
++------------------------------+--------------+
+| Catchup missed runs          | True         |
++------------------------------+--------------+
+| Credentials Required         | Yes          |
++------------------------------+--------------+
+| Uses Telescope Template      | None         |
++------------------------------+--------------+
+| Each shard includes all data | No           |
++------------------------------+--------------+
+```
+
+## Airflow connections
+
+Note that all values need to be urlencoded.
+In the config.yaml file, the following airflow connections are required:
+
+### oapen_irus_uk_api
+
+To get the requestor_id/api_key for IRUS
+
+## Data Download
+
+The download is done via an API call to IRUS:
+
+```
+https://irus.jisc.ac.uk/api/v3/irus/reports/irus_ir/?platform=235&requestor_id={requestor_id}&begin_date={start_date}&end_date={end_date}
+```
+
+Where the requestor ID is the API key for the IRUS API. The telescope will use the same begin and end dates (YYYY-MM) in order to retrieve data on a per-month basis.
+
+A second call to the API is made with the following appended to the above URL:
+
+```
+&attributes_to_show=Country
+```
+
+Which splits the data by country, leaving us with two datasets. These datasets will be referred to as the _total_ and _country_ datasets.
+
+Before making any changes to the data, these datasets are uploaded to a Google storage bucket
+
+## Data Transform
+
+The transform step has a few things to achieve:
+
+-   Collate the _total_ and _country_ datasets into a single object
+-   Remove columns that are not of interest to us
+-   Add the release month to each row as a partitioning column
+-   Remove rows from the data that do not relate to the publisher of interest
+
+The result of points 1 -> 3 are evident in the [schema](#latest-schema). The final point requires some communication with the publisher. This is because a single publisher may have published titles under more than one name. For example, University of Michigan has 10 associated publishing names. These names are listed as part of a dictionary in the telescope.
+
+The resulting transformed file is uploaded to a Google Cloud bucket
+
+## BigQuery Load
+
+The transformed data is loaded from the Google Cloud bucket into a partitioned BigQuery table. The table is in the respective publisher's Project and a _fulcrum_ dataset will be created if it does not exist. Since the data is partitioned on the release month, there will only be a single table.
+
+## Latest schema
+
+```eval_rst
+.. csv-table::
+   :file: ../../schemas/fulcrum.csv
+   :width: 100%
+   :header-rows: 1
+```

--- a/docs/oaebu_workflows/telescopes/index.rst
+++ b/docs/oaebu_workflows/telescopes/index.rst
@@ -10,6 +10,7 @@ output data to other places. Workflows are built on top of Apache Airflow's DAGs
     jstor
     oapen_metadata
     oapen_irus_uk
+    fulcrum
     onix
     thoth
     ucl_discovery

--- a/oaebu_workflows/api_type_ids.py
+++ b/oaebu_workflows/api_type_ids.py
@@ -38,6 +38,7 @@ class DatasetTypeId:
     jstor_institution = "jstor_institution"
     oapen_irus_uk = "oapen_irus_uk"
     ucl_discovery = "ucl_discovery"
+    fulcrum = "fulcrum"
 
     # Workflow dataset types, i.e., dataset types for datasets created by various non Telescope workflows.
     onix_workflow = "onix_workflow"
@@ -56,6 +57,7 @@ class WorkflowTypeId:
     jstor = "jstor"
     oapen_irus_uk = "oapen_irus_uk"
     ucl_discovery = "ucl_discovery"
+    fulcrum = "fulcrum"
 
     # Workflow dataset types, i.e., dataset types for datasets created by various non Telescope workflows.
     onix_workflow = "onix_workflow"

--- a/oaebu_workflows/dags/fulcrum_telescope.py
+++ b/oaebu_workflows/dags/fulcrum_telescope.py
@@ -1,0 +1,50 @@
+# Copyright 2020 Curtin University
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Author: Keegan Smith
+
+# The keywords airflow and DAG are required to load the DAGs from this file, see bullet 2 in the Apache Airflow FAQ:
+# https://airflow.apache.org/docs/stable/faq.html
+
+from oaebu_workflows.identifiers import WorkflowTypes
+from oaebu_workflows.workflows.fulcrum_telescope import FulcrumTelescope
+from observatory.platform.utils.api import make_observatory_api
+from observatory.platform.utils.workflow_utils import make_dag_id
+
+# Fetch all workflows
+api = make_observatory_api()
+workflow_type = api.get_workflow_type(type_id=WorkflowTypes.fulcrum)
+workflows = api.get_workflows(workflow_type_id=workflow_type.id, limit=1000)
+
+# Make all workflows
+for workflow in workflows:
+    organisation = workflow.organisation
+    organisation_name = organisation.name
+    project_id = organisation.project_id
+    download_bucket = organisation.download_bucket
+    transform_bucket = organisation.transform_bucket
+    data_location = "us"
+    dag_id = make_dag_id(FulcrumTelescope.DAG_ID_PREFIX, organisation_name)
+
+    workflow = FulcrumTelescope(
+        workflow_id=workflow.id,
+        organisation_name=organisation_name,
+        project_id=project_id,
+        download_bucket=download_bucket,
+        transform_bucket=transform_bucket,
+        data_location=data_location,
+        dag_id=dag_id,
+        catchup=True,
+    )
+    globals()[workflow.dag_id] = workflow.make_dag()

--- a/oaebu_workflows/database/schema/fulcrum.json
+++ b/oaebu_workflows/database/schema/fulcrum.json
@@ -1,0 +1,112 @@
+[
+  {
+    "description": "Proprietary identifier of the book.",
+    "mode": "NULLABLE",
+    "name": "proprietary_id",
+    "type": "STRING"
+  },
+  {
+    "description": "ISBN of the book.",
+    "mode": "NULLABLE",
+    "name": "ISBN",
+    "type": "STRING"
+  },
+  {
+    "description": "Title of the book",
+    "mode": "NULLABLE",
+    "name": "book_title",
+    "type": "STRING"
+  },
+  {
+    "description": "The publisher",
+    "mode": "NULLABLE",
+    "name": "publisher",
+    "type": "STRING"
+  },
+  {
+    "description": "The names of the authors",
+    "mode": "NULLABLE",
+    "name": "authors",
+    "type": "STRING"
+  },
+  {
+    "description": "The investigated month.",
+    "mode": "NULLABLE",
+    "name": "month",
+    "type": "DATE"
+  },
+  {
+    "description": "The total number of item investigations.",
+    "mode": "NULLABLE",
+    "name": "total_item_investigations",
+    "type": "INTEGER"
+  },
+  {
+    "description": "The total number of item requests.",
+    "mode": "NULLABLE",
+    "name": "total_item_requests",
+    "type": "INTEGER"
+  },
+  {
+    "description": "The number of unique item investigations.",
+    "mode": "NULLABLE",
+    "name": "unique_item_investigations",
+    "type": "INTEGER"
+  },
+  {
+    "description": "The number of unique item requests.",
+    "mode": "NULLABLE",
+    "name": "unique_item_requests",
+    "type": "INTEGER"
+  },
+  {
+    "description": "Record to store statistics on the country level.",
+    "mode": "REPEATED",
+    "name": "country",
+    "type": "RECORD",
+    "fields": [
+      {
+        "description": "The country name of the client registered by oapen irus uk.",
+        "mode": "NULLABLE",
+        "name": "name",
+        "type": "STRING"
+      },
+      {
+        "description": "The country code of the client registered by oapen irus uk.",
+        "mode": "NULLABLE",
+        "name": "code",
+        "type": "STRING"
+      },
+      {
+        "description": "The total number of item investigations.",
+        "mode": "NULLABLE",
+        "name": "total_item_investigations",
+        "type": "INTEGER"
+      },
+      {
+        "description": "The total number of item requests.",
+        "mode": "NULLABLE",
+        "name": "total_item_requests",
+        "type": "INTEGER"
+      },
+      {
+        "description": "The number of unique item investigations.",
+        "mode": "NULLABLE",
+        "name": "unique_item_investigations",
+        "type": "INTEGER"
+      },
+      {
+        "description": "The number of unique item requests.",
+        "mode": "NULLABLE",
+        "name": "unique_item_requests",
+        "type": "INTEGER"
+      }
+    ]
+  },
+  {
+    "mode": "REQUIRED",
+    "name": "release_date",
+    "type": "DATE",
+    "description": "Last day of the release month. Table is partitioned on this column."
+  }
+]

--- a/oaebu_workflows/fixtures/fulcrum/fulcrum_download_cassette.yaml
+++ b/oaebu_workflows/fixtures/fulcrum/fulcrum_download_cassette.yaml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:541bbbb721d36d9917ba4a32e5273ccf28554c39505e4ee1330631be8a247c41
+size 7272

--- a/oaebu_workflows/fixtures/fulcrum/test_country_download.jsonl
+++ b/oaebu_workflows/fixtures/fulcrum/test_country_download.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d2fc512913bbc7682c638768500069d1526273a1e89dcd88f4e683ddb210c377
+size 2543

--- a/oaebu_workflows/fixtures/fulcrum/test_final_table.jsonl
+++ b/oaebu_workflows/fixtures/fulcrum/test_final_table.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3740176fe45577e9885526f24470ff12383896aa9b54b0f1953fc5309cd6cbcd
+size 1917

--- a/oaebu_workflows/fixtures/fulcrum/test_totals_download.jsonl
+++ b/oaebu_workflows/fixtures/fulcrum/test_totals_download.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:249e3867fdba5855d6c3e4270c944133b5c19aa12fde3f4d44a64aac79261b57
+size 1756

--- a/oaebu_workflows/fixtures/fulcrum/test_transform.jsonl
+++ b/oaebu_workflows/fixtures/fulcrum/test_transform.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:241ec3eb98ce4e943dedab39936821c86b92127593027fc50836e315ee3977c8
+size 1951

--- a/oaebu_workflows/identifiers.py
+++ b/oaebu_workflows/identifiers.py
@@ -27,3 +27,4 @@ class WorkflowTypes:
     onix_workflow = "onix_workflow"
     ucl_discovery = "ucl_discovery"
     doab = "doab"
+    fulcrum = "fulcrum"

--- a/oaebu_workflows/seed/dataset_info.py
+++ b/oaebu_workflows/seed/dataset_info.py
@@ -284,6 +284,14 @@ def get_dataset_info(api: ObservatoryApi):
         workflow=workflows["Wits Press OAPEN IRUS-UK Telescope"],
         dataset_type=get_dataset_type(api=api, type_id=DatasetTypeId.oapen_irus_uk),
     )
+    name = "UoMP Fulcrum Dataset"
+    dataset_info[name] = Dataset(
+        name=name,
+        service="google",
+        address="oaebu-umich-press.oapen.fulcrum",
+        workflow=workflows["UoMP Fulcrum Telescope"],
+        dataset_type=get_dataset_type(api=api, type_id=DatasetTypeId.fulcrum),
+    )
     name = "OBP OAPEN IRUS UK Dataset"
     dataset_info[name] = Dataset(
         name=name,

--- a/oaebu_workflows/seed/dataset_type_info.py
+++ b/oaebu_workflows/seed/dataset_type_info.py
@@ -85,6 +85,12 @@ def get_dataset_type_info(api: ObservatoryApi):
         name="ONIX Workflow",
         table_type=TableType(id=ttids[TableTypeId.partitioned]),
     )
+    dataset_type_info[DatasetTypeId.fulcrum] = DatasetType(
+        type_id=DatasetTypeId.fulcrum,
+        name="Fuclrum Telescope",
+        extra={"isbn_field_name": "ISBN", "title_field_name": "book_title"},
+        table_type=TableType(id=ttids[TableTypeId.partitioned]),
+    )
     return dataset_type_info
 
 

--- a/oaebu_workflows/seed/workflow_info.py
+++ b/oaebu_workflows/seed/workflow_info.py
@@ -251,6 +251,14 @@ def get_workflow_info(api: ObservatoryApi):
         },
         tags='["oaebu"]',
     )
+    name = "UoMP Fulcrum Telescope"
+    workflow_info[name] = Workflow(
+        name=name,
+        organisation=Organisation(id=orgids["University of Michigan Press"]),
+        workflow_type=WorkflowType(id=wftids[WorkflowTypeId.fulcrum]),
+        extra={},
+        tags='["oaebu"]',
+    )
     name = "UCL Press UCL Discovery Telescope"
     workflow_info[name] = Workflow(
         name=name,

--- a/oaebu_workflows/seed/workflow_type_info.py
+++ b/oaebu_workflows/seed/workflow_type_info.py
@@ -45,6 +45,10 @@ def get_workflow_type_info():
         type_id=WorkflowTypeId.oapen_irus_uk,
         name="OAPEN IRUS-UK Telescope",
     )
+    workflow_type_info[WorkflowTypeId.fulcrum] = WorkflowType(
+        type_id=WorkflowTypeId.fulcrum,
+        name="Fulcrum Telescope",
+    )
     workflow_type_info[WorkflowTypeId.oapen_metadata] = WorkflowType(
         type_id=WorkflowTypeId.oapen_metadata,
         name="OAPEN Metadata",

--- a/oaebu_workflows/workflows/fulcrum_telescope.py
+++ b/oaebu_workflows/workflows/fulcrum_telescope.py
@@ -1,0 +1,409 @@
+# Copyright 2023 Curtin University
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Author: Keegan Smith
+
+import logging
+import os
+from typing import Dict, List, Optional, Tuple
+
+import pendulum
+from airflow.exceptions import AirflowException
+from airflow.hooks.base import BaseHook
+from google.cloud.bigquery import SourceFormat
+from google.cloud.bigquery.table import TimePartitioningType
+
+from oaebu_workflows.config import schema_folder as default_schema_folder
+from oaebu_workflows.dag_tag import Tag
+from observatory.platform.utils.airflow_utils import AirflowConns, make_workflow_folder
+from observatory.platform.utils.file_utils import list_to_jsonl_gz, list_files, load_jsonl, blob_name_from_path
+from observatory.platform.utils.url_utils import retry_get_url
+from observatory.platform.utils.config_utils import find_schema
+from observatory.platform.utils.gc_utils import upload_files_to_cloud_storage
+from observatory.platform.utils.workflow_utils import (
+    bq_load_partition,
+    table_ids_from_path,
+    make_release_date,
+    cleanup,
+)
+from observatory.platform.workflows.workflow import Release, Workflow
+
+IRUS_FULCRUM_ENDPOINT_TEMPLATE = (
+    "https://irus.jisc.ac.uk/api/v3/irus/reports/irus_ir/?platform=235"
+    "&requestor_id={requestor_id}&begin_date={start_date}&end_date={end_date}"
+)
+
+ORG_PUBLISHER_MAPPINGS = {
+    # https://www.press.umich.edu/browse/distributed_clients
+    "University of Michigan Press": [
+        "American Academy in Rome",
+        "American Society of Papyrologists",
+        "University of Michigan Bentley Library",
+        "University of Michigan Center for Chinese Studies",
+        "University of Michigan Center for Japanese Studies",
+        "University of Michigan Center for South Asia Studies",
+        "University of Michigan Center for South East Asian Studies",
+        "University of Michigan Department of Near Eastern Studies",
+        "University of Michigan Museum of Anthropological Archaeology",
+        "University of Michigan Press",
+    ]
+}
+
+
+class FulcrumRelease(Release):
+    def __init__(self, dag_id: str, release_date: pendulum.DateTime):
+        """Create a FulcrumRelease instance.
+
+        :param dag_id: the DAG id.
+        :param release_date: the date of the release.
+        """
+        self.dag_id = dag_id
+        self.release_date = release_date
+
+
+class FulcrumTelescope(Workflow):
+    DAG_ID_PREFIX = "fulcrum"
+
+    def __init__(
+        self,
+        workflow_id: int,
+        organisation_name: str,
+        project_id: str,
+        download_bucket: str,
+        transform_bucket: str,
+        data_location: str,
+        dag_id: str,
+        start_date: pendulum.DateTime = pendulum.datetime(2022, 4, 1),  # Earliest available data
+        schedule_interval: str = "0 0 14 * *",  # Run on the 14th of every month
+        dataset_id: str = "fulcrum",
+        merge_partition_field: str = "release_date",
+        schema_folder: str = default_schema_folder(),
+        source_format: str = SourceFormat.NEWLINE_DELIMITED_JSON,
+        airflow_conns: List = None,
+        catchup: bool = True,
+        download_file_name="fulcrum.jsonl.gz",
+        transform_file_name="fulcrum.jsonl.gz",
+        dataset_description: str = "IRUS Fulcrum Data Feed",
+        load_bigquery_table_kwargs=None,
+    ):
+        """The Fulcrum Telescope
+        :param workflow_id: api workflow id.
+        :param organisation_name: the Organisation the DAG will process.
+        :param project_id: the google cloud project id
+        :param download_bucket: the name of the google cloud download bucket
+        :param transform_bucket: the name of the google cloud transform bucket
+        :param data_location: the project location/region in google cloud platform
+        :param dag_id: the id of the DAG.
+        :param start_date: the start date of the DAG.
+        :param schedule_interval: the schedule interval of the DAG.
+        :param merge_partition_field: the field to partition the table on
+        :param dataset_id: the BigQuery dataset id.
+        :param schema_folder: the SQL schema path.
+        :param source_format: the format of the data to load into BigQuery.
+        :param dataset_description: description for the BigQuery dataset.
+        :param table_descriptions: a dictionary with table ids and corresponding table descriptions.
+        :param catchup: whether to catchup the DAG or not.
+        :param airflow_conns: list of airflow connection keys, for each connection it is checked if it exists in airflow
+        :param download_file_name: The local name of the downloaded file(s)
+        :param tranform_file_name: The local name of the transformed file
+        :param load_bigquery_table_kwargs: any kwargs to send to the bigquery table loader
+        """
+
+        if airflow_conns is None:
+            airflow_conns = [AirflowConns.OAPEN_IRUS_UK_API]
+
+        if load_bigquery_table_kwargs is None:
+            load_bigquery_table_kwargs = {"ignore_unknown_values": True}
+
+        if not ORG_PUBLISHER_MAPPINGS.get(organisation_name):
+            raise AirflowException(f"Organisation {organisation_name} is not one of the expected name mappings")
+
+        # Cloud workspace settings
+        self.project_id = project_id
+        self.download_bucket = download_bucket
+        self.transform_bucket = transform_bucket
+
+        # Database settings
+        self.dataset_description = dataset_description
+        self.dataset_id = dataset_id
+        self.schema_folder = schema_folder
+        self.source_format = source_format
+        self.data_location = data_location
+
+        # Fulcrum settings
+        self.organisation_name = organisation_name
+        self.merge_partition_field = merge_partition_field
+        self.load_bigquery_table_kwargs = load_bigquery_table_kwargs
+
+        # Workflow files/folders
+        self.download_file_name = download_file_name
+        self.transform_file_name = transform_file_name
+        self.workflow_folder = None
+        self.download_totals_folder = None
+        self.download_country_folder = None
+        self.transform_folder = None
+
+        super().__init__(
+            dag_id,
+            start_date,
+            schedule_interval,
+            workflow_id=workflow_id,
+            airflow_conns=airflow_conns,
+            catchup=catchup,
+            tags=[Tag.oaebu],
+        )
+
+        self.add_setup_task(self.check_dependencies)
+        self.add_task(self.download)
+        self.add_task(self.upload_downloaded)
+        self.add_task(self.transform)
+        self.add_task(self.upload_transformed)
+        self.add_task(self.bq_load)
+        self.add_task(self.cleanup)
+        self.add_task(self.add_new_dataset_releases)
+
+    def make_release(self, **kwargs) -> FulcrumRelease:
+        """Create a FulcrumRelease instance"""
+        # Release date should be the month before the execution date
+        release_date = make_release_date(**kwargs).subtract(months=1)
+        release = FulcrumRelease(self.dag_id, release_date)
+
+        # Make the download and transform folders
+        self.workflow_folder = make_workflow_folder(self.dag_id, release_date)
+        self.download_totals_folder = make_workflow_folder(self.dag_id, release_date, "download", "totals")
+        self.download_country_folder = make_workflow_folder(self.dag_id, release_date, "download", "country")
+        self.transform_folder = make_workflow_folder(self.dag_id, release_date, "transform")
+        return release
+
+    def download(self, release: FulcrumRelease, **kwargs):
+        """Task to download the Fulcrum data for a release
+
+        :param releases: the FulcrumRelease instance.
+        """
+        requestor_id = BaseHook.get_connection(AirflowConns.OAPEN_IRUS_UK_API).login
+        download_month = release.release_date.format("YYYY-MM")
+        totals_data, country_data = download_fulcrum_month_data(download_month, requestor_id)
+        totals_path = os.path.join(self.download_totals_folder, self.download_file_name)
+        country_path = os.path.join(self.download_country_folder, self.download_file_name)
+
+        if not totals_data or not country_data:
+            raise AirflowException(f"Data not available for supplied release date: {self.download_month}")
+
+        list_to_jsonl_gz(totals_path, totals_data)
+        list_to_jsonl_gz(country_path, country_data)
+
+    def upload_downloaded(self, release: FulcrumRelease, **kwargs):
+        """Upload the downloaded fulcrum data to the google cloud download bucket
+
+        :param release: the FulcrumRelease instance
+        :raises AirflowException: Raised if there is not exactly 1 file in the totals download folder
+        :raises AirflowException: Raised if there is not exactly 1 file in the country download folder
+        :raises AirflowException: Raised if totals blob upload fails for any reason
+        :raises AirflowException: Raised if country blob upload fails for any reason
+        """
+        download_totals_files = list_files(self.download_totals_folder, self.download_file_name)
+        if len(download_totals_files) != 1:
+            raise AirflowException(
+                f"Unexpected number of files in totals download folder. Expected 1, found {len(download_totals_files)}"
+            )
+
+        download_country_files = list_files(self.download_country_folder, self.download_file_name)
+        if len(download_country_files) != 1:
+            raise AirflowException(
+                f"Unexpected number of files in country download folder. Expected 1, found {len(download_country_files)}"
+            )
+
+        totals_blob = blob_name_from_path(download_totals_files[0])
+        success_totals = upload_files_to_cloud_storage(self.download_bucket, [totals_blob], download_totals_files)
+        country_blob = blob_name_from_path(download_country_files[0])
+        success_country = upload_files_to_cloud_storage(self.download_bucket, [country_blob], download_country_files)
+
+        if not success_country and success_totals:
+            raise AirflowException("Download blobs could not be uploaded to cloud storage")
+
+    def transform(self, release: FulcrumRelease, **kwargs):
+        """Task to transform the fulcrum data
+
+        :param release: the FulcrumRelease instance.
+        """
+        totals_data = load_jsonl(os.path.join(self.download_totals_folder, self.download_file_name))
+        country_data = load_jsonl(os.path.join(self.download_country_folder, self.download_file_name))
+        transformed_data = transform_fulcrum_data(
+            totals_data=totals_data,
+            country_data=country_data,
+            release_date=release.release_date,
+            organisation_name=self.organisation_name,
+            organisation_mappings=ORG_PUBLISHER_MAPPINGS,
+        )
+        list_to_jsonl_gz(os.path.join(self.transform_folder, self.transform_file_name), transformed_data)
+
+    def upload_transformed(self, release: FulcrumRelease, **kwargs):
+        """Upload the transformed fulcrum data to the google cloud download bucket
+
+        :param release: the FulcrumRelease instance.
+        :raises AirflowException: Raised if there is not exactly 1 file in the transform folder matching the expected name
+        :raises AirflowException: Raised if transform blob upload fails for any reason
+        """
+        transform_files = list_files(self.transform_folder, self.transform_file_name)
+        if len(transform_files) != 1:
+            raise AirflowException(
+                f"Unexpected number of files in transform folder. Expected 1, found {len(transform_files)}"
+            )
+
+        blob = blob_name_from_path(transform_files[0])
+        success = upload_files_to_cloud_storage(self.transform_bucket, [blob], transform_files)
+        if not success:
+            raise AirflowException("Blob could not be uploaded to cloud storage")
+
+    def bq_load(self, release: FulcrumRelease, **kwargs) -> None:
+        """Load the transfromed data into bigquery
+
+        :param release: the FulcrumRelease instance.
+        """
+        transform_files = list_files(self.transform_folder, self.transform_file_name)
+        if len(transform_files) != 1:
+            raise AirflowException(
+                f"Unexpected number of files in transform folder. Expected 1, found {len(transform_files)}"
+            )
+        # Load each transformed release
+        transform_blob = blob_name_from_path(transform_files[0])
+        table_id, _ = table_ids_from_path(transform_files[0])
+        schema_file_path = find_schema(path=self.schema_folder, table_name="fulcrum")
+        bq_load_partition(
+            schema_file_path=schema_file_path,
+            project_id=self.project_id,
+            transform_bucket=self.transform_bucket,
+            transform_blob=transform_blob,
+            dataset_id=self.dataset_id,
+            data_location=self.data_location,
+            table_id=table_id,
+            release_date=release.release_date,
+            source_format=self.source_format,
+            partition_type=TimePartitioningType.MONTH,
+            dataset_description=self.dataset_description,
+            partition_field=self.merge_partition_field,
+            **self.load_bigquery_table_kwargs,
+        )
+
+    def cleanup(self, release: FulcrumRelease, **kwargs) -> None:
+        """Delete all files and folders associated with this release.
+
+        :param release: the FulcrumRelease instance.
+        """
+        cleanup(self.dag_id, execution_date=kwargs["execution_date"], workflow_folder=self.workflow_folder)
+
+
+def download_fulcrum_month_data(
+    download_month: str,
+    requestor_id: str,
+    num_retries: str = 3,
+) -> Tuple[List[dict], List[dict]]:
+    """Download Fulcrum data for the release month
+
+    :param download_month: The month to download usage data from
+    :param requestor_id: The requestor ID - used to access irus platform
+    :param num_retries: Number of attempts to make for the URL
+    """
+    base_url = IRUS_FULCRUM_ENDPOINT_TEMPLATE.format(
+        requestor_id=requestor_id,
+        start_date=download_month,
+        end_date=download_month,
+    )
+    country_url = base_url + "&attributes_to_show=Country"
+    logging.info(f"Downloading Fulcrum metrics for month: {download_month}")
+    totals_data = retry_get_url(base_url, num_retries=num_retries).json()
+    country_data = retry_get_url(country_url, num_retries=num_retries).json()
+    totals_data = totals_data.get("Report_Items")
+    country_data = country_data.get("Report_Items")
+
+    return totals_data, country_data
+
+
+def transform_fulcrum_data(
+    totals_data: List[dict],
+    country_data: List[dict],
+    release_date: pendulum.DateTime,
+    organisation_name: str = None,
+    organisation_mappings: dict = ORG_PUBLISHER_MAPPINGS,
+) -> List[dict]:
+    """
+    Transforms Fulcrum downloaded "totals" and "country" data.
+    If organisation name is supplied, will extract only the data related to this organisation
+
+    :param totals_data: Fulcrum usage data aggregated over all countries
+    :param country_data: Fulcrum usage data split by country
+    :param release_data: The release date of this data. Will insert the end of month into the data as a reference
+    :param organisation_name: The name of the organisation/publisher to extract
+    :param organisation_mappings: The organisation mappings dictionary
+    """
+    # Extract only the publishers related to this organisation name
+    if organisation_name:
+        totals_data = [i for i in totals_data if i["Publisher"] in organisation_mappings[organisation_name]]
+        country_data = [i for i in country_data if i["Publisher"] in organisation_mappings[organisation_name]]
+
+    # Total and Country-granulated results should all have the same item entries and be ordered the same, but we should check anyway
+    c_ids = [i["IRUS_Item_ID"] for i in country_data]
+    t_ids = [i["IRUS_Item_ID"] for i in totals_data]
+    if len(c_ids) != len(t_ids):
+        raise AirflowException("Country entry data is not the same length as total entry data")
+
+    # Mapping the IDs to list elements
+    c_id_mapping = {entry["IRUS_Item_ID"]: i for (i, entry) in enumerate(country_data)}
+    t_id_mapping = {entry["IRUS_Item_ID"]: i for (i, entry) in enumerate(totals_data)}
+
+    transformed_data = []
+    for t_id, c_id in zip(t_ids, c_ids):
+        transformed_row = {}
+        t_entry = totals_data[t_id_mapping[t_id]]
+        c_entry = country_data[c_id_mapping[c_id]]
+
+        # Metrics with country granulation
+        country_metrics = []
+        for c_metric in c_entry["Performance_Instances"]:  # For each country
+            country_metrics.append(
+                {
+                    "name": c_metric["Country"]["Country"],
+                    "code": c_metric["Country"]["Country_Code"],
+                    "Total_Item_Investigations": c_metric["Metric_Type_Counts"].get("Total_Item_Investigations"),
+                    "Total_Item_Requests": c_metric["Metric_Type_Counts"].get("Total_Item_Requests"),
+                    "Unique_Item_Investigations": c_metric["Metric_Type_Counts"].get("Unique_Item_Investigations"),
+                    "Unique_Item_Requests": c_metric["Metric_Type_Counts"].get("Unique_Item_Requests"),
+                }
+            )
+
+        # Total Metrics
+        t_metric = t_entry["Performance_Instances"][0]
+        total_item_investigations = t_metric["Metric_Type_Counts"].get("Total_Item_Investigations")
+        total_item_requests = t_metric["Metric_Type_Counts"].get("Total_Item_Requests")
+        unique_item_investigations = t_metric["Metric_Type_Counts"].get("Unique_Item_Investigations")
+        unique_item_requests = t_metric["Metric_Type_Counts"].get("Unique_Item_Requests")
+
+        # Row structure
+        transformed_row = {
+            "proprietary_id": t_id,  # t_id == c_id
+            "ISBN": t_entry.get("ISBN"),
+            "book_title": t_entry.get("Item"),
+            "publisher": t_entry.get("Publisher"),
+            "authors": t_entry.get("Authors"),
+            "event_month": pendulum.parse(t_entry["Performance_Instances"][0]["Event_Month"]).format("YYYY-MM"),
+            "total_item_investigations": total_item_investigations,
+            "total_item_requests": total_item_requests,
+            "unique_item_investigations": unique_item_investigations,
+            "unique_item_requests": unique_item_requests,
+            "country": country_metrics,
+            "release_date": release_date.end_of("month").format("YYYY-MM-DD"),
+        }
+        transformed_data.append(transformed_row)
+
+    return transformed_data

--- a/oaebu_workflows/workflows/tests/test_fulcrum_telescope.py
+++ b/oaebu_workflows/workflows/tests/test_fulcrum_telescope.py
@@ -1,0 +1,324 @@
+# Copyright 2021 Curtin University
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Author: Keegan Smith
+
+import os
+from unittest.mock import patch
+
+import pendulum
+from airflow.exceptions import AirflowException
+from airflow.models.connection import Connection
+from airflow.utils.state import State
+import vcr
+
+from oaebu_workflows.config import test_fixtures_folder
+from oaebu_workflows.workflows.fulcrum_telescope import (
+    FulcrumTelescope,
+    blob_name_from_path,
+    download_fulcrum_month_data,
+    transform_fulcrum_data,
+)
+from observatory.platform.utils.file_utils import load_jsonl
+from observatory.platform.utils.test_utils import (
+    ObservatoryEnvironment,
+    ObservatoryTestCase,
+    module_file_path,
+    find_free_port,
+)
+from observatory.api.testing import ObservatoryApiEnvironment
+from observatory.api.client import ApiClient, Configuration
+from observatory.api.client.api.observatory_api import ObservatoryApi
+from observatory.api.client.model.organisation import Organisation
+from observatory.api.client.model.workflow import Workflow
+from observatory.api.client.model.workflow_type import WorkflowType
+from observatory.api.client.model.dataset import Dataset
+from observatory.api.client.model.dataset_type import DatasetType
+from observatory.api.client.model.table_type import TableType
+from observatory.platform.utils.release_utils import get_dataset_releases
+from observatory.platform.utils.airflow_utils import AirflowConns
+from observatory.platform.utils.workflow_utils import table_ids_from_path
+from airflow.models import Connection
+from airflow.utils.state import State
+
+FAKE_ORG_PUBLISHER_MAPPINGS = {"Fake Press": ["Fake Publisher 1", "Fake Publisher 2", "Fake Publisher 3"]}
+
+
+class TestFulcrumTelescope(ObservatoryTestCase):
+    """Tests for the Fulcrum telescope"""
+
+    def __init__(self, *args, **kwargs):
+        """Constructor which sets up variables used by tests.
+
+        :param args: arguments.
+        :param kwargs: keyword arguments.
+        """
+        super(TestFulcrumTelescope, self).__init__(*args, **kwargs)
+        self.project_id = os.getenv("TEST_GCP_PROJECT_ID")
+        self.data_location = os.getenv("TEST_GCP_DATA_LOCATION")
+        self.data_location = "us"
+
+        # API environment
+        self.host = "localhost"
+        self.port = find_free_port()
+        configuration = Configuration(host=f"http://{self.host}:{self.port}")
+        api_client = ApiClient(configuration)
+        self.api = ObservatoryApi(api_client=api_client)
+        self.env = ObservatoryApiEnvironment(host=self.host, port=self.port)
+
+        # Fixtures
+        self.download_cassette = os.path.join(test_fixtures_folder("fulcrum"), "fulcrum_download_cassette.yaml")
+        self.test_table = os.path.join(test_fixtures_folder("fulcrum"), "test_final_table.jsonl")
+        self.test_totals_download = os.path.join(test_fixtures_folder("fulcrum"), "test_totals_download.jsonl")
+        self.test_country_download = os.path.join(test_fixtures_folder("fulcrum"), "test_country_download.jsonl")
+        self.test_transform = os.path.join(test_fixtures_folder("fulcrum"), "test_transform.jsonl")
+
+    def setup_api(self):
+
+        name = "Fulcrum Telescope"
+        workflow_type = WorkflowType(name=name, type_id=FulcrumTelescope.DAG_ID_PREFIX)
+        self.api.put_workflow_type(workflow_type)
+
+        organisation = Organisation(
+            name="University of Michigan Press",
+            project_id="project",
+            download_bucket="download_bucket",
+            transform_bucket="transform_bucket",
+        )
+        self.api.put_organisation(organisation)
+
+        telescope = Workflow(
+            name=name,
+            workflow_type=WorkflowType(id=1),
+            organisation=Organisation(id=1),
+            extra={},
+        )
+        self.api.put_workflow(telescope)
+
+        table_type = TableType(
+            type_id="partitioned",
+            name="partitioned bq table",
+        )
+        self.api.put_table_type(table_type)
+
+        dataset_type = DatasetType(
+            type_id="fulcrum",
+            name="ds type",
+            extra={},
+            table_type=TableType(id=1),
+        )
+        self.api.put_dataset_type(dataset_type)
+
+        dataset = Dataset(
+            name="Fulcrum",
+            address="project.dataset.table",
+            service="bigquery",
+            workflow=Workflow(id=1),
+            dataset_type=DatasetType(id=1),
+        )
+        self.api.put_dataset(dataset)
+
+    def setup_connections(self, env):
+        # Add Observatory API connection
+        env.add_connection(
+            Connection(conn_id=AirflowConns.OBSERVATORY_API, uri=f"http://:password@{self.host}:{self.port}")
+        )
+        env.add_connection(Connection(conn_id=AirflowConns.OAPEN_IRUS_UK_API, uri=f"http://fake_api_login:@"))
+
+    @patch("oaebu_workflows.workflows.fulcrum_telescope.ORG_PUBLISHER_MAPPINGS", FAKE_ORG_PUBLISHER_MAPPINGS)
+    def test_dag_structure(self):
+        """Test that the ONIX DAG has the correct structure and raises errors when necessary"""
+
+        # Giving an org name not in the mappings should raise an error
+        with self.assertRaises(AirflowException):
+            FulcrumTelescope(
+                workflow_id=1,
+                organisation_name="Nonexistent Organisation",
+                dag_id=f"{FulcrumTelescope.DAG_ID_PREFIX}_test",
+                project_id="my-project",
+                download_bucket="download_bucket",
+                transform_bucket="transform_bucket",
+                data_location=self.data_location,
+            )
+
+        dag = FulcrumTelescope(
+            workflow_id=1,
+            organisation_name="Fake Press",
+            dag_id=f"{FulcrumTelescope.DAG_ID_PREFIX}_test",
+            project_id="my-project",
+            download_bucket="download_bucket",
+            transform_bucket="transform_bucket",
+            data_location=self.data_location,
+        ).make_dag()
+
+        self.assert_dag_structure(
+            {
+                "check_dependencies": ["download"],
+                "download": ["upload_downloaded"],
+                "upload_downloaded": ["transform"],
+                "transform": ["upload_transformed"],
+                "upload_transformed": ["bq_load"],
+                "bq_load": ["cleanup"],
+                "cleanup": ["add_new_dataset_releases"],
+                "add_new_dataset_releases": [],
+            },
+            dag,
+        )
+
+    def test_dag_load(self):
+        """Test that the DAG can be loaded from a DAG bag."""
+        env = ObservatoryEnvironment(self.project_id, self.data_location, api_host=self.host, api_port=self.port)
+        with env.create():
+            self.setup_connections(env)
+            self.setup_api()
+            dag_file = os.path.join(module_file_path("oaebu_workflows.dags"), "fulcrum_telescope.py")
+            self.assert_dag_load(f"fulcrum_university_of_michigan_press", dag_file)
+
+    @patch("oaebu_workflows.workflows.fulcrum_telescope.ORG_PUBLISHER_MAPPINGS", FAKE_ORG_PUBLISHER_MAPPINGS)
+    def test_telescope(self):
+        """Test the Fulcrum telescope end to end."""
+        # Setup Observatory environment
+        env = ObservatoryEnvironment(self.project_id, self.data_location, api_host=self.host, api_port=self.port)
+        dataset_id = env.add_dataset()
+
+        # Create the Observatory environment and run tests
+        with env.create():
+            self.setup_connections(env)
+            self.setup_api()
+
+            # Setup Telescope
+            execution_date = pendulum.datetime(year=2022, month=4, day=14)
+            telescope = FulcrumTelescope(
+                workflow_id=1,
+                organisation_name="Fake Press",
+                dag_id=f"{FulcrumTelescope.DAG_ID_PREFIX}_test",
+                project_id=self.project_id,
+                download_bucket=env.download_bucket,
+                transform_bucket=env.transform_bucket,
+                data_location=self.data_location,
+                dataset_id=dataset_id,
+            )
+            dag = telescope.make_dag()
+
+            # Add the fake requestor ID as a connection
+            with env.create_dag_run(dag, execution_date):
+                # Test that all dependencies are specified: no error should be thrown
+                ti = env.run_task(telescope.check_dependencies.__name__)
+                self.assertEqual(ti.state, State.SUCCESS)
+
+                # Test download
+                fulcrum_vcr = vcr.VCR(record_mode="none")
+                # with patch(
+                #     "oaebu_workflows.workflows.fulcrum_telescope.download.BaseHook.get_connection", "fake_requestor_id"
+                # ):
+                with fulcrum_vcr.use_cassette(self.download_cassette):
+                    ti = env.run_task(telescope.download.__name__)
+                self.assertEqual(ti.state, State.SUCCESS)
+
+                # Test upload downloaded
+                ti = env.run_task(telescope.upload_downloaded.__name__)
+                self.assertEqual(ti.state, State.SUCCESS)
+
+                # Test transform
+                ti = env.run_task(telescope.transform.__name__)
+                self.assertEqual(ti.state, State.SUCCESS)
+
+                # Test upload to cloud storage
+                ti = env.run_task(telescope.upload_transformed.__name__)
+                self.assertEqual(ti.state, State.SUCCESS)
+
+                # Test load into BigQuery
+                ti = env.run_task(telescope.bq_load.__name__)
+                self.assertEqual(ti.state, State.SUCCESS)
+
+                # Make assertions
+                download_totals_file_path = os.path.join(telescope.download_totals_folder, telescope.download_file_name)
+                download_country_file_path = os.path.join(
+                    telescope.download_country_folder, telescope.download_file_name
+                )
+                transform_file_path = os.path.join(telescope.transform_folder, telescope.transform_file_name)
+                download_totals_blob = blob_name_from_path(download_totals_file_path)
+                download_country_blob = blob_name_from_path(download_country_file_path)
+                transform_blob = blob_name_from_path(transform_file_path)
+                test_table_id = f"{self.project_id}.{dataset_id}.{table_ids_from_path(transform_file_path)[0]}"
+
+                # Downloaded files
+                self.assert_file_integrity(download_totals_file_path, "95b7dceb", "gzip_crc")
+                self.assert_file_integrity(download_country_file_path, "0a713d03", "gzip_crc")
+
+                # Uploaded download blob
+                self.assert_blob_integrity(env.download_bucket, download_totals_blob, download_totals_file_path)
+                self.assert_blob_integrity(env.download_bucket, download_country_blob, download_country_file_path)
+
+                # Transformed file
+                self.assert_file_integrity(transform_file_path, "40a25e4e", "gzip_crc")
+
+                # Uploaded transform blob
+                self.assert_blob_integrity(env.transform_bucket, transform_blob, transform_file_path)
+
+                # Uploaded table
+                self.assert_table_integrity(test_table_id, expected_rows=3)
+                self.assert_table_content(test_table_id, load_jsonl(self.test_table))
+
+                # Test cleanup
+                ti = env.run_task(telescope.cleanup.__name__)
+                self.assertEqual(ti.state, State.SUCCESS)
+                self.assertFalse(os.path.exists(telescope.workflow_folder))
+                self.assertFalse(os.path.exists(telescope.download_totals_folder))
+                self.assertFalse(os.path.exists(telescope.download_country_folder))
+                self.assertFalse(os.path.exists(telescope.transform_folder))
+
+                # add_dataset_release_task
+                dataset_releases = get_dataset_releases(dataset_id=1)
+                self.assertEqual(len(dataset_releases), 0)
+                ti = env.run_task("add_new_dataset_releases")
+                self.assertEqual(ti.state, State.SUCCESS)
+                dataset_releases = get_dataset_releases(dataset_id=1)
+                self.assertEqual(len(dataset_releases), 1)
+
+    def test_download_fulcrum_month_data(self):
+        """Tests the download_fuclrum_month_data function"""
+        vcr_ = vcr.VCR(record_mode="none")
+        with vcr_.use_cassette(self.download_cassette):
+            actual_totals, actual_country = download_fulcrum_month_data(
+                download_month="2022-04", requestor_id="fake_api_login", num_retries=0
+            )
+        expected_totals = load_jsonl(self.test_totals_download)
+        expected_country = load_jsonl(self.test_country_download)
+
+        # Make list order deterministic before testing
+        actual_totals = [dict(sorted(d.items())) for d in actual_totals]
+        actual_country = [dict(sorted(d.items())) for d in actual_country]
+        expected_totals = [dict(sorted(d.items())) for d in expected_totals]
+        expected_country = [dict(sorted(d.items())) for d in expected_country]
+        self.assertListEqual(actual_totals, expected_totals)
+        self.assertListEqual(actual_country, expected_country)
+
+    def test_transform_fulcrum_data(self):
+        """Tests the transform_fulcrum_data function"""
+        totals = load_jsonl(self.test_totals_download)
+        country = load_jsonl(self.test_country_download)
+        actual_transform = transform_fulcrum_data(
+            totals_data=totals,
+            country_data=country,
+            release_date=pendulum.datetime(year=2022, month=4, day=1),
+            organisation_name="Fake Press",
+            organisation_mappings=FAKE_ORG_PUBLISHER_MAPPINGS,
+        )
+        expected_transform = load_jsonl(self.test_transform)
+
+        # Make list order deterministic before testing
+        actual_transform = [dict(sorted(d.items())) for d in actual_transform]
+        expected_transform = [dict(sorted(d.items())) for d in expected_transform]
+        self.assertListEqual(actual_transform, expected_transform)


### PR DESCRIPTION
## Fulcrum Telescope

Similar to the Thoth Telescope (#119), Fulcrum forgoes the use of the telescope templates in favor of a more modular approach. 

The telescope can be compared to the oapen_irus_uk telescope as it hits the same API (using a different platform number - 235). However, because no sensitive IP information is used, it is much simpler to operate.

The telescope workflow runs once a month for every publisher that makes use of the Fulcrum platform. Each run will download its respective month's data, transform it and add it to a partitioned table in BigQuery.

Currently, only University of Michigan is using Fulcrum