### PR TITLE
INF-550: Updated JSTOR transform for new report format

### DIFF
--- a/oaebu_workflows/fixtures/jstor/country_20210401.tsv
+++ b/oaebu_workflows/fixtures/jstor/country_20210401.tsv
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6b7c98be28f1cbf2ca6dbcca51714b779cb39889110814a3f13fdd08626da5d7
-size 1802

--- a/oaebu_workflows/fixtures/jstor/country_20220801.tsv
+++ b/oaebu_workflows/fixtures/jstor/country_20220801.tsv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:df2e52ecdae0a25bd1a496e6f354d8486e543189a6fff210c86913322421eaaf
+size 1762

--- a/oaebu_workflows/fixtures/jstor/institution_20210401.tsv
+++ b/oaebu_workflows/fixtures/jstor/institution_20210401.tsv
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:dc0c19f67da75c4cfe6c26c7c279fe1707ff7fcb4e1b0299c6b52914b6f8706f
-size 567

--- a/oaebu_workflows/fixtures/jstor/institution_20220801.tsv
+++ b/oaebu_workflows/fixtures/jstor/institution_20220801.tsv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:59e93d1b713ddbd9b78d013145f2df285c7e92f3bb92c72947d16dbac53a5d05
+size 567

--- a/oaebu_workflows/workflows/tests/test_jstor_telescope.py
+++ b/oaebu_workflows/workflows/tests/test_jstor_telescope.py
@@ -70,32 +70,32 @@ class TestJstorTelescope(ObservatoryTestCase):
         self.host = "localhost"
         self.api_port = find_free_port()
 
-        self.release_date = pendulum.parse("20210301").end_of("month")
+        self.release_date = pendulum.parse("20220701").end_of("month")
         publisher_id = self.extra.get("publisher_id")
         self.country_report = {
-            "path": test_fixtures_folder("jstor", "country_20210401.tsv"),
+            "path": test_fixtures_folder("jstor", "country_20220801.tsv"),
             "url": "https://www.jstor.org/admin/reports/download/249192019",
             "headers": {
                 "Content-Disposition": f"attachment; filename=PUB_{publisher_id}_PUBBCU_"
                 f'{self.release_date.strftime("%Y%m%d")}.tsv'
             },
-            "download_hash": "1bad528f89b2d8df0846c47a58d7fb2e",
-            "transform_hash": "9b197a54",
+            "download_hash": "9330cc71f8228838ac84abb33cedb3b8",
+            "transform_hash": "5a72fe64",
             "table_rows": 10,
         }
         self.institution_report = {
-            "path": test_fixtures_folder("jstor", "institution_20210401.tsv"),
+            "path": test_fixtures_folder("jstor", "institution_20220801.tsv"),
             "url": "https://www.jstor.org/admin/reports/download/129518301",
             "headers": {
                 "Content-Disposition": f"attachment; filename=PUB_{publisher_id}_PUBBIU_"
                 f'{self.release_date.strftime("%Y%m%d")}.tsv'
             },
-            "download_hash": "793ee70d9102d8dca3cace65cb00ecc3",
-            "transform_hash": "4a664f4d",
+            "download_hash": "1c78c316766a3f7306d6c19440250484",
+            "transform_hash": "f339ea81",
             "table_rows": 3,
         }
         self.wrong_publisher_report = {
-            "path": test_fixtures_folder("jstor", "institution_20210401.tsv"),  # has to be valid path, but is not used
+            "path": test_fixtures_folder("jstor", "institution_20220801.tsv"),  # has to be valid path, but is not used
             "url": "https://www.jstor.org/admin/reports/download/12345",
             "headers": {
                 "Content-Disposition": f"attachment; filename=PUB_publisher_PUBBIU_"


### PR DESCRIPTION
JSTOR report format has changed in the following ways:

- Removal of the Usage Month column
- Renaming of Total Item Requests to Reporting Period Total
- Addition of a date column for each month that the report spans

These changes break our workflow, so I have adjusted the telescope's transform function such that the original headings are retained