### PR TITLE
BAD-372: Thoth Telescope

### DIFF
--- a/docs/oaebu_workflows/telescopes/thoth.md
+++ b/docs/oaebu_workflows/telescopes/thoth.md
@@ -1,0 +1,52 @@
+# Thoth
+
+The Thoth Telescope downloads, transforms and loads publisher ONIX feeds from [Thoth](https://thoth.pub/) into BigQuery. [ONIX](https://www.editeur.org/83/Overview/) is a standard format that book publishers use to share information about the books that they have published.
+
+Thoth is a free, open metadata service that publishers can choose to utilise as a solution for metadata storage. Thoth can provide metadata upon request in a number of formats. The Thoth Telescope used the [Thoth Export API](https://export.thoth.pub/#get-/formats/-format_id-) to download metadata in an ONIX format. This API provides a snapshot of a specified publisher's metadata at the time of request. It requires the publisher's ID as part of the URL, which can be found using the [GraphiQL API](https://api.thoth.pub/graphiql).
+
+The Thoth telescope downloads the ONIX metadata files and then transforms the data into a format suitable for loading into BigQuery with the [ONIX parser](https://github.com/The-Academic-Observatory/onix-parser) Java command line tool. This is a near-identical process to how the [ONIX telescope's](onix.md) data-transformation step is executed. The transformed data is loaded into BigQuery, where it can be picked up and used by the [ONIX Workflow](../workflows/onix_workflow_intro.md).
+
+```eval_rst
++------------------------------+--------------+
+| Summary                      |              |
++==============================+==============+
+| Average runtime              | 5-10 mins    |
++------------------------------+--------------+
+| Average download size        | 1-10 MB      |
++------------------------------+--------------+
+| Harvest Type                 | URL          |
++------------------------------+--------------+
+| Harvest Frequency            | Weekly       |
++------------------------------+--------------+
+| Runs on remote worker        | False        |
++------------------------------+--------------+
+| Catchup missed runs          | False        |
++------------------------------+--------------+
+| Credentials Required         | No           |
++------------------------------+--------------+
+| Uses Telescope Template      | None         |
++------------------------------+--------------+
+| Each shard includes all data | Yes          |
++------------------------------+--------------+
+```
+
+## Configuration
+
+The following settings need to be configured for the Thoth telescope.
+
+### Telescope API Instance
+
+A Thoth Telescope API instance needs to be created. Unlike the ONIX telescope, it does not require any 'extra' fields.
+
+### Airflow Connections
+
+The Thoth telescope does not require any airflow connections to run, as the Thoth API is freely usable.
+
+## Latest schema
+
+```eval_rst
+.. csv-table::
+   :file: ../../schemas/onix_latest.csv
+   :width: 100%
+   :header-rows: 1
+```

--- a/oaebu_workflows/api_type_ids.py
+++ b/oaebu_workflows/api_type_ids.py
@@ -50,6 +50,7 @@ class WorkflowTypeId:
     doab = "doab"
     oapen_metadata = "oapen_metadata"
     onix = "onix"
+    thoth_onix = "thoth_onix"
     google_analytics = "google_analytics"
     google_books = "google_books"
     jstor = "jstor"

--- a/oaebu_workflows/fixtures/thoth/test_table.jsonl
+++ b/oaebu_workflows/fixtures/thoth/test_table.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0f2f200ae3cbda764ee82eeef681f0a38dfb93008f2694a5de990082d167635f
+size 9138

--- a/oaebu_workflows/fixtures/thoth/thoth_download_cassette.yaml
+++ b/oaebu_workflows/fixtures/thoth/thoth_download_cassette.yaml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:114f2a0b906000493df981c5712666a0359095c3878ab39b3cee04af23b6e4e8
+size 13628

--- a/oaebu_workflows/seed/dataset_info.py
+++ b/oaebu_workflows/seed/dataset_info.py
@@ -84,6 +84,14 @@ def get_dataset_info(api: ObservatoryApi):
         workflow=workflows["UoMP ONIX Telescope"],
         dataset_type=get_dataset_type(api=api, type_id=DatasetTypeId.onix),
     )
+    name = "OBP Thoth Onix Dataset"
+    dataset_info[name] = Dataset(
+        name=name,
+        service="google",
+        address="oaebu-obp.onix.onix",
+        workflow=workflows["OBP Thoth Onix Telescope"],
+        dataset_type=get_dataset_type(api=api, type_id=DatasetTypeId.onix),
+    )
     name = "ANU Press Google Analytics Dataset"
     dataset_info[name] = Dataset(
         name=name,

--- a/oaebu_workflows/seed/organisation_info.py
+++ b/oaebu_workflows/seed/organisation_info.py
@@ -58,6 +58,13 @@ def get_organisation_info():
         download_bucket="oaebu-oapen-download",
         transform_bucket="oaebu-oapen-transform",
     )
+    name = "Open Book Publishers"
+    organisation_info[name] = Organisation(
+        name=name,
+        project_id="oaebu-obp",
+        download_bucket="oaebu-obp-download",
+        transform_bucket="oaebu-obp-transform",
+    )
     name = "Curtin University"
     organisation_info[name] = Organisation(
         name=name,

--- a/oaebu_workflows/seed/workflow_info.py
+++ b/oaebu_workflows/seed/workflow_info.py
@@ -51,7 +51,7 @@ def get_workflow_info(api: ObservatoryApi):
         name=name,
         organisation=Organisation(id=orgids["OAPEN Press"]),
         workflow_type=WorkflowType(id=wftids[WorkflowTypeId.onix]),
-        extra={"date_format": "%Y%m%d", "date_regex": "\\d{8}", "sensor_dag_ids": ["oapen_metadata"]},
+        extra={"date_regex": "\\d{8}", "sensor_dag_ids": ["oapen_metadata"]},
         tags=None,
     )
     name = "ANU Press ONIX Telescope"
@@ -59,7 +59,7 @@ def get_workflow_info(api: ObservatoryApi):
         name=name,
         organisation=Organisation(id=orgids["ANU Press"]),
         workflow_type=WorkflowType(id=wftids[WorkflowTypeId.onix]),
-        extra={"date_format": "%Y%m%d", "date_regex": "\\d{8}"},
+        extra={"date_regex": "\\d{8}"},
         tags=None,
     )
     name = "UCL Press ONIX Telescope"
@@ -67,7 +67,7 @@ def get_workflow_info(api: ObservatoryApi):
         name=name,
         organisation=Organisation(id=orgids["UCL Press"]),
         workflow_type=WorkflowType(id=wftids[WorkflowTypeId.onix]),
-        extra={"date_format": "%Y%m%d", "date_regex": "\\d{8}"},
+        extra={"date_regex": "\\d{8}"},
         tags=None,
     )
     name = "Wits Press ONIX Telescope"
@@ -75,7 +75,7 @@ def get_workflow_info(api: ObservatoryApi):
         name=name,
         organisation=Organisation(id=orgids["Wits University Press"]),
         workflow_type=WorkflowType(id=wftids[WorkflowTypeId.onix]),
-        extra={"date_format": "%Y%m%d", "date_regex": "\\d{8}"},
+        extra={"date_regex": "\\d{8}"},
         tags=None,
     )
     name = "UoMP ONIX Telescope"
@@ -83,7 +83,15 @@ def get_workflow_info(api: ObservatoryApi):
         name=name,
         organisation=Organisation(id=orgids["University of Michigan Press"]),
         workflow_type=WorkflowType(id=wftids[WorkflowTypeId.onix]),
-        extra={"date_format": "%Y%m%d", "date_regex": "\\d{8}"},
+        extra={"date_regex": "\\d{8}"},
+        tags=None,
+    )
+    name = "OBP Thoth Onix Telescope"
+    workflow_info[name] = Workflow(
+        name=name,
+        organisation=Organisation(id=orgids["Open Book Publishers"]),
+        workflow_type=WorkflowType(id=wftids[WorkflowTypeId.thoth_onix]),
+        extra={"publisher_id": "85fd969a-a16c-480b-b641-cb9adf979c3b"},
         tags=None,
     )
     name = "ANU Press Google Analytics Telescope"
@@ -198,13 +206,25 @@ def get_workflow_info(api: ObservatoryApi):
     workflow_info[name] = Workflow(
         name=name,
         organisation=Organisation(id=orgids["Wits University Press"]),
-        workflow_type=WorkflowType(id=wftids["oapen_irus_uk"]),
+        workflow_type=WorkflowType(id=wftids[WorkflowTypeId.oapen_irus_uk]),
         extra={
             "publisher_name_v4": "Wits%20University%20Press",
             "publisher_uuid_v5": "c522c2dd-daf5-4926-bf1a-ee1557d24a4b",
         },
         tags='["oaebu"]',
     )
+    name = "OBP OAPEN IRUS-UK Telescope"
+    workflow_info[name] = Workflow(
+        name=name,
+        organisation=Organisation(id=orgids["Open Book Publishers"]),
+        workflow_type=WorkflowType(id=wftids[WorkflowTypeId.oapen_irus_uk]),
+        extra={
+            "publisher_name_v4": "Open%20Book%20Publishers",
+            "publisher_uuid_v5": "23117811-c361-47b4-8b76-2c9b160c9a8b",
+        },
+        tags='["oaebu"]',
+    )
+
     name = "UCL Press UCL Discovery Telescope"
     workflow_info[name] = Workflow(
         name=name,

--- a/oaebu_workflows/seed/workflow_type_info.py
+++ b/oaebu_workflows/seed/workflow_type_info.py
@@ -49,6 +49,10 @@ def get_workflow_type_info():
         type_id=WorkflowTypeId.oapen_metadata,
         name="OAPEN Metadata Telescope",
     )
+    workflow_type_info[WorkflowTypeId.thoth_onix] = WorkflowType(
+        type_id=WorkflowTypeId.thoth_onix,
+        name="Thoth ONIX Telescope",
+    )
     workflow_type_info[WorkflowTypeId.onix] = WorkflowType(
         type_id=WorkflowTypeId.onix,
         name="ONIX Telescope",

--- a/oaebu_workflows/workflows/onix_telescope.py
+++ b/oaebu_workflows/workflows/onix_telescope.py
@@ -19,19 +19,19 @@ import os
 import re
 import shutil
 import subprocess
+from datetime import timedelta
 from typing import Dict, List, Optional
 
 import pendulum
-from datetime import timedelta
 from airflow.exceptions import AirflowException
 from airflow.models.taskinstance import TaskInstance
-from observatory.platform.utils.dag_run_sensor import DagRunSensor
-
 from google.cloud.bigquery import SourceFormat
 
 from oaebu_workflows.config import schema_folder as default_schema_folder
+from oaebu_workflows.dag_tag import Tag
 from observatory.platform.utils.airflow_utils import AirflowConns, AirflowVars
 from observatory.platform.utils.config_utils import observatory_home, find_schema
+from observatory.platform.utils.dag_run_sensor import DagRunSensor
 from observatory.platform.utils.http_download import download_file
 from observatory.platform.utils.proc_utils import wait_for_process
 from observatory.platform.utils.workflow_utils import (
@@ -39,7 +39,6 @@ from observatory.platform.utils.workflow_utils import (
     blob_name,
     bq_load_shard,
     make_dag_id,
-    make_org_id,
     make_sftp_connection,
     table_ids_from_path,
 )
@@ -47,7 +46,6 @@ from observatory.platform.workflows.snapshot_telescope import (
     SnapshotRelease,
     SnapshotTelescope,
 )
-from oaebu_workflows.dag_tag import Tag
 
 ONIX_PARSER_NAME = "coki-onix-parser.jar"
 ONIX_PARSER_URL = "https://github.com/The-Academic-Observatory/onix-parser/releases/download/v1.3.0/coki-onix-parser-1.2-SNAPSHOT-shaded.jar"

--- a/oaebu_workflows/workflows/tests/test_onix_telescope.py
+++ b/oaebu_workflows/workflows/tests/test_onix_telescope.py
@@ -19,12 +19,23 @@ import shutil
 from tempfile import TemporaryDirectory
 
 import pendulum
-from airflow.models.connection import Connection
+from airflow.models import Connection
 from airflow.utils.state import State
+
 from oaebu_workflows.config import test_fixtures_folder
 from oaebu_workflows.workflows.onix_telescope import OnixTelescope, parse_onix
+from observatory.api.client import ApiClient, Configuration
+from observatory.api.client.api.observatory_api import ObservatoryApi  # noqa: E501
+from observatory.api.client.model.dataset import Dataset
+from observatory.api.client.model.dataset_type import DatasetType
+from observatory.api.client.model.organisation import Organisation
+from observatory.api.client.model.table_type import TableType
+from observatory.api.client.model.workflow import Workflow
+from observatory.api.client.model.workflow_type import WorkflowType
+from observatory.api.testing import ObservatoryApiEnvironment
 from observatory.platform.utils.airflow_utils import AirflowConns
 from observatory.platform.utils.gc_utils import bigquery_sharded_table_id
+from observatory.platform.utils.release_utils import get_dataset_releases
 from observatory.platform.utils.test_utils import (
     ObservatoryEnvironment,
     ObservatoryTestCase,
@@ -38,19 +49,6 @@ from observatory.platform.utils.workflow_utils import (
     blob_name,
     workflow_path,
 )
-from observatory.api.testing import ObservatoryApiEnvironment
-from observatory.api.client import ApiClient, Configuration
-from observatory.api.client.api.observatory_api import ObservatoryApi  # noqa: E501
-from observatory.api.client.model.organisation import Organisation
-from observatory.api.client.model.workflow import Workflow
-from observatory.api.client.model.workflow_type import WorkflowType
-from observatory.api.client.model.dataset import Dataset
-from observatory.api.client.model.dataset_type import DatasetType
-from observatory.api.client.model.table_type import TableType
-from observatory.platform.utils.release_utils import get_dataset_releases
-from observatory.platform.utils.airflow_utils import AirflowConns
-from airflow.models import Connection
-from airflow.utils.state import State
 
 
 class TestOnixTelescope(ObservatoryTestCase):

--- a/oaebu_workflows/workflows/tests/test_thoth_telescope.py
+++ b/oaebu_workflows/workflows/tests/test_thoth_telescope.py
@@ -1,0 +1,376 @@
+# Copyright 2021 Curtin University
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Author: Keegan Smith
+
+import os
+from tempfile import TemporaryDirectory
+from unittest.mock import patch
+
+import pendulum
+from airflow.models.connection import Connection
+from airflow.operators.python_operator import PythonOperator
+from airflow.exceptions import AirflowException
+from airflow.utils.state import State
+from airflow import DAG
+import vcr
+
+from oaebu_workflows.config import test_fixtures_folder
+from oaebu_workflows.workflows.thoth_telescope import (
+    ThothTelescope,
+    thoth_download_onix,
+    make_workflow_folder,
+    blob_name_from_path,
+    get_data_path,
+    cleanup,
+    DEFAULT_FORMAT_SPECIFICATION,
+    DEFAULT_HOST_NAME,
+)
+from observatory.platform.utils.file_utils import load_jsonl
+from observatory.platform.utils.gc_utils import bigquery_sharded_table_id
+from observatory.platform.utils.test_utils import (
+    ObservatoryEnvironment,
+    ObservatoryTestCase,
+    module_file_path,
+    find_free_port,
+)
+from observatory.api.testing import ObservatoryApiEnvironment
+from observatory.api.client import ApiClient, Configuration
+from observatory.api.client.api.observatory_api import ObservatoryApi
+from observatory.api.client.model.organisation import Organisation
+from observatory.api.client.model.workflow import Workflow
+from observatory.api.client.model.workflow_type import WorkflowType
+from observatory.api.client.model.dataset import Dataset
+from observatory.api.client.model.dataset_type import DatasetType
+from observatory.api.client.model.table_type import TableType
+from observatory.platform.utils.release_utils import get_dataset_releases
+from observatory.platform.utils.airflow_utils import AirflowConns
+from observatory.platform.utils.url_utils import retry_session
+from airflow.models import Connection
+from airflow.utils.state import State
+
+FAKE_ORG_NAME = "fake_org_name"
+FAKE_PUBLISHER_ID = "fake_publisher_id"
+
+
+class TestThothTelescope(ObservatoryTestCase):
+    """Tests for the Thoth telescope"""
+
+    def __init__(self, *args, **kwargs):
+        """Constructor which sets up variables used by tests.
+
+        :param args: arguments.
+        :param kwargs: keyword arguments.
+        """
+        super(TestThothTelescope, self).__init__(*args, **kwargs)
+        self.host = "localhost"
+        self.api_port = find_free_port()
+        self.project_id = os.getenv("TEST_GCP_PROJECT_ID")
+        self.data_location = os.getenv("TEST_GCP_DATA_LOCATION")
+        self.data_location = "us"
+
+        # API environment
+        self.host = "localhost"
+        self.port = find_free_port()
+        configuration = Configuration(host=f"http://{self.host}:{self.port}")
+        api_client = ApiClient(configuration)
+        self.api = ObservatoryApi(api_client=api_client)
+        self.env = ObservatoryApiEnvironment(host=self.host, port=self.port)
+
+        # Fixtures
+        self.download_cassette = os.path.join(test_fixtures_folder("thoth"), "thoth_download_cassette.yaml")
+        self.test_table = os.path.join(test_fixtures_folder("thoth"), "test_table.jsonl")
+
+    def setup_api(self):
+
+        name = "Thoth Telescope"
+        workflow_type = WorkflowType(name=name, type_id=ThothTelescope.DAG_ID_PREFIX)
+        self.api.put_workflow_type(workflow_type)
+
+        organisation = Organisation(
+            name="Open Book Publishers",
+            project_id="project",
+            download_bucket="download_bucket",
+            transform_bucket="transform_bucket",
+        )
+        self.api.put_organisation(organisation)
+
+        telescope = Workflow(
+            name=name,
+            workflow_type=WorkflowType(id=1),
+            organisation=Organisation(id=1),
+            extra={},
+        )
+        self.api.put_workflow(telescope)
+
+        table_type = TableType(
+            type_id="partitioned",
+            name="partitioned bq table",
+        )
+        self.api.put_table_type(table_type)
+
+        dataset_type = DatasetType(
+            type_id="onix",
+            name="ds type",
+            extra={},
+            table_type=TableType(id=1),
+        )
+        self.api.put_dataset_type(dataset_type)
+
+        dataset = Dataset(
+            name="ONIX",
+            address="project.dataset.table",
+            service="bigquery",
+            workflow=Workflow(id=1),
+            dataset_type=DatasetType(id=1),
+        )
+        self.api.put_dataset(dataset)
+
+    def setup_connections(self, env):
+        # Add Observatory API connection
+        conn = Connection(conn_id=AirflowConns.OBSERVATORY_API, uri=f"http://:password@{self.host}:{self.port}")
+        env.add_connection(conn)
+
+    def test_dag_structure(self):
+        """Test that the ONIX DAG has the correct structure."""
+
+        dag = ThothTelescope(
+            dag_id=f"{ThothTelescope.DAG_ID_PREFIX}_test",
+            publisher_id=FAKE_PUBLISHER_ID,
+            project_id="my-project",
+            download_bucket="download_bucket",
+            transform_bucket="transform_bucket",
+            data_location=self.data_location,
+        ).make_dag()
+
+        self.assert_dag_structure(
+            {
+                "check_dependencies": ["download"],
+                "download": ["upload_downloaded"],
+                "upload_downloaded": ["transform"],
+                "transform": ["upload_transformed"],
+                "upload_transformed": ["bq_load"],
+                "bq_load": ["cleanup"],
+                "cleanup": ["add_new_dataset_releases"],
+                "add_new_dataset_releases": [],
+            },
+            dag,
+        )
+
+    def test_dag_load(self):
+        """Test that the DAG can be loaded from a DAG bag."""
+        env = ObservatoryEnvironment(self.project_id, self.data_location, api_host=self.host, api_port=self.port)
+        with env.create():
+            self.setup_connections(env)
+            self.setup_api()
+            dag_file = os.path.join(module_file_path("oaebu_workflows.dags"), "thoth_telescope.py")
+            self.assert_dag_load(f"thoth_onix_open_book_publishers", dag_file)
+
+    def test_telescope(self):
+        """Test the Thoth telescope end to end."""
+        # Setup Observatory environment
+        env = ObservatoryEnvironment(self.project_id, self.data_location, api_host=self.host, api_port=self.port)
+        dataset_id = env.add_dataset()
+
+        # Create the Observatory environment and run tests
+        with env.create():
+            self.setup_connections(env)
+            self.setup_api()
+
+            # Setup Telescope
+            execution_date = pendulum.datetime(year=2022, month=12, day=1)
+            release_date = pendulum.datetime(year=2022, month=12, day=3)
+            telescope = ThothTelescope(
+                dag_id=f"{ThothTelescope.DAG_ID_PREFIX}_test",
+                publisher_id="fake_publisher_id",
+                project_id=self.project_id,
+                download_bucket=env.download_bucket,
+                transform_bucket=env.transform_bucket,
+                data_location=self.data_location,
+                dataset_id=dataset_id,
+                workflow_id=1,
+            )
+            dag = telescope.make_dag()
+
+            with env.create_dag_run(dag, execution_date):
+                # Test that all dependencies are specified: no error should be thrown
+                ti = env.run_task(telescope.check_dependencies.__name__)
+                self.assertEqual(ti.state, State.SUCCESS)
+
+                # Test download
+                thoth_vcr = vcr.VCR(record_mode="none")
+                with thoth_vcr.use_cassette(self.download_cassette):
+                    ti = env.run_task(telescope.download.__name__)
+                self.assertEqual(ti.state, State.SUCCESS)
+
+                # Test upload downloaded
+                ti = env.run_task(telescope.upload_downloaded.__name__)
+                self.assertEqual(ti.state, State.SUCCESS)
+
+                # Test transform
+                ti = env.run_task(telescope.transform.__name__)
+                self.assertEqual(ti.state, State.SUCCESS)
+
+                # Test upload to cloud storage
+                ti = env.run_task(telescope.upload_transformed.__name__)
+                self.assertEqual(ti.state, State.SUCCESS)
+
+                # Test load into BigQuery
+                ti = env.run_task(telescope.bq_load.__name__)
+                self.assertEqual(ti.state, State.SUCCESS)
+
+                # Make assertions
+                download_file_path = os.path.join(telescope.download_folder, telescope.download_file_name)
+                transform_file_path = os.path.join(telescope.transform_folder, telescope.transform_file_name)
+                download_blob = blob_name_from_path(download_file_path)
+                transform_blob = blob_name_from_path(transform_file_path)
+                test_table_id = (
+                    f"{self.project_id}.{dataset_id}.{bigquery_sharded_table_id(telescope.DAG_ID_PREFIX, release_date)}"
+                )
+
+                # Downloaded file
+                self.assert_file_integrity(download_file_path, "d02bcbb97e887acbbbaa55a1b77f51ef", "md5")
+
+                # Uploaded download blob
+                self.assert_blob_integrity(env.download_bucket, download_blob, download_file_path)
+
+                # Transformed file
+                self.assert_file_integrity(transform_file_path, "782d3888162dac8f1afdaf20e42b278f", "md5")
+
+                # Uploaded transform blob
+                self.assert_blob_integrity(env.transform_bucket, transform_blob, transform_file_path)
+
+                # Uploaded table
+                self.assert_table_integrity(test_table_id, expected_rows=1)
+                self.assert_table_content(test_table_id, load_jsonl(self.test_table))
+
+                # Test cleanup
+                ti = env.run_task(telescope.cleanup.__name__)
+                self.assertEqual(ti.state, State.SUCCESS)
+                self.assertFalse(os.path.exists(telescope.workflow_folder))
+                self.assertFalse(os.path.exists(telescope.download_folder))
+                self.assertFalse(os.path.exists(telescope.transform_folder))
+
+                # add_dataset_release_task
+                dataset_releases = get_dataset_releases(dataset_id=1)
+                self.assertEqual(len(dataset_releases), 0)
+                ti = env.run_task("add_new_dataset_releases")
+                self.assertEqual(ti.state, State.SUCCESS)
+                dataset_releases = get_dataset_releases(dataset_id=1)
+                self.assertEqual(len(dataset_releases), 1)
+
+    # Function tests
+    @patch("oaebu_workflows.workflows.thoth_telescope.EnvironmentVariablesBackend.get_variable")
+    @patch("oaebu_workflows.workflows.thoth_telescope.Variable.get")
+    def test_get_data_path(self, mock_variable_get, mock_env_variable_get):
+        """Tests the function that retrieves the data_path airflow variable"""
+        # 1 - no variable available
+        mock_env_variable_get.return_value = None
+        mock_variable_get.return_value = None
+        self.assertRaises(AirflowException, get_data_path)
+        # 2 - available in environment backend
+        mock_env_variable_get.return_value = "env_return"
+        self.assertEqual("env_return", get_data_path())
+        # 3 - available in google secrets
+        mock_env_variable_get.return_value = None
+        mock_variable_get.return_value = "google_return"
+        self.assertEqual("google_return", get_data_path())
+        # 4 - available in environment and google secrets. We prefer the environment backend usage
+        mock_env_variable_get.return_value = "env_return"
+        self.assertEqual("env_return", get_data_path())
+
+    @patch("oaebu_workflows.workflows.thoth_telescope.EnvironmentVariablesBackend.get_variable")
+    def test_make_workflow_folder(self, mock_get_variable):
+        """Tests the make_workflow_folder function"""
+        with TemporaryDirectory() as tempdir:
+            mock_get_variable.return_value = tempdir
+            path = make_workflow_folder(
+                "test_dag", pendulum.datetime(year=1000, month=6, day=14), "sub_folder", "subsub_folder"
+            )
+            self.assertEqual(path, os.path.join(tempdir, f"test_dag/test_dag_1000_06_14/sub_folder/subsub_folder"))
+
+    @patch("oaebu_workflows.workflows.thoth_telescope.EnvironmentVariablesBackend.get_variable")
+    def test_blob_name_from_path(self, mock_get_variable):
+        """Tests the blob_name from_path function"""
+        with TemporaryDirectory() as tempdir:
+            mock_get_variable.return_value = tempdir
+            invalid_path = os.path.join("some", "fake", "invalid", "path", "file.txt")
+            valid_path_1 = os.path.join(tempdir, "some", "fake", "valid", "path", "file.txt")
+            valid_path_2 = os.path.join(valid_path_1, "")  # Trailing slash
+            self.assertRaises(AirflowException, blob_name_from_path, invalid_path)
+            self.assertEqual(blob_name_from_path(valid_path_1), "some/fake/valid/path/file.txt")
+            self.assertEqual(blob_name_from_path(valid_path_2), "some/fake/valid/path/file.txt")
+
+    def test_download_onix(self):
+        """
+        Tests the download_onix function.
+        Will test that the function works as expected using proxy HTTP requests
+        """
+        with TemporaryDirectory() as tempdir:
+            thoth_vcr = vcr.VCR(record_mode="none")
+            with thoth_vcr.use_cassette(self.download_cassette):
+                thoth_download_onix(FAKE_PUBLISHER_ID, tempdir, download_filename="fake_download.xml", num_retries=0)
+            self.assert_file_integrity(
+                os.path.join(tempdir, "fake_download.xml"), "d02bcbb97e887acbbbaa55a1b77f51ef", "md5"
+            )
+
+    def test_thoth_api(self):
+        """Tests that HTTP requests to the thoth API are successful"""
+        base_response = retry_session(num_retries=2).get(DEFAULT_HOST_NAME)
+        format_response = retry_session(num_retries=2).get(
+            f"{DEFAULT_HOST_NAME}/specifications/{DEFAULT_FORMAT_SPECIFICATION}"
+        )
+        self.assertEqual(base_response.status_code, 200)
+        self.assertEqual(format_response.status_code, 200)
+
+    def test_cleanup(self):
+        """
+        Tests the cleanup function.
+        Creates a task and pushes and Xcom. Also creates a fake workflow directory.
+        Both the Xcom and the directory should be deleted by the cleanup() function
+        """
+
+        def create_xcom(**kwargs):
+            ti = kwargs["ti"]
+            execution_date = kwargs["execution_date"]
+            ti.xcom_push("topic", {"release_date": execution_date.format("YYYYMMDD"), "something": "info"})
+
+        env = ObservatoryEnvironment(enable_api=False, enable_elastic=False)
+        with env.create():
+            execution_date = pendulum.datetime(2023, 1, 1)
+            with DAG(
+                dag_id="test_dag",
+                schedule_interval="@daily",
+                default_args={"owner": "airflow", "start_date": execution_date},
+                catchup=True,
+            ) as dag:
+                kwargs = {"task_id": "create_xcom"}
+                op = PythonOperator(python_callable=create_xcom, **kwargs)
+
+            with TemporaryDirectory() as workflow_dir:
+                # Create some files in the workflow folder
+                subdir = os.path.join(workflow_dir, "test_directory")
+                os.mkdir(subdir)
+
+                # DAG Run
+                with env.create_dag_run(dag=dag, execution_date=execution_date):
+                    ti = env.run_task("create_xcom")
+                    self.assertEqual("success", ti.state)
+                    msgs = ti.xcom_pull(key="topic", task_ids="create_xcom", include_prior_dates=True)
+                    self.assertIsInstance(msgs, dict)
+                    cleanup("test_dag", execution_date, workflow_folder=workflow_dir, retention_days=0)
+                    msgs = ti.xcom_pull(key="topic", task_ids="create_xcom", include_prior_dates=True)
+                    self.assertEqual(msgs, None)
+                    self.assertEqual(os.path.isdir(subdir), False)
+                    self.assertEqual(os.path.isdir(workflow_dir), False)

--- a/oaebu_workflows/workflows/tests/test_thoth_telescope.py
+++ b/oaebu_workflows/workflows/tests/test_thoth_telescope.py
@@ -19,12 +19,12 @@ from tempfile import TemporaryDirectory
 from unittest.mock import patch
 
 import pendulum
-from airflow.models.connection import Connection
-from airflow.operators.python_operator import PythonOperator
-from airflow.exceptions import AirflowException
-from airflow.utils.state import State
-from airflow import DAG
 import vcr
+from airflow import DAG
+from airflow.exceptions import AirflowException
+from airflow.models import Connection
+from airflow.operators.python import PythonOperator
+from airflow.utils.state import State
 
 from oaebu_workflows.config import test_fixtures_folder
 from oaebu_workflows.workflows.thoth_telescope import (
@@ -37,28 +37,26 @@ from oaebu_workflows.workflows.thoth_telescope import (
     DEFAULT_FORMAT_SPECIFICATION,
     DEFAULT_HOST_NAME,
 )
+from observatory.api.client import ApiClient, Configuration
+from observatory.api.client.api.observatory_api import ObservatoryApi
+from observatory.api.client.model.dataset import Dataset
+from observatory.api.client.model.dataset_type import DatasetType
+from observatory.api.client.model.organisation import Organisation
+from observatory.api.client.model.table_type import TableType
+from observatory.api.client.model.workflow import Workflow
+from observatory.api.client.model.workflow_type import WorkflowType
+from observatory.api.testing import ObservatoryApiEnvironment
+from observatory.platform.utils.airflow_utils import AirflowConns
 from observatory.platform.utils.file_utils import load_jsonl
 from observatory.platform.utils.gc_utils import bigquery_sharded_table_id
+from observatory.platform.utils.release_utils import get_dataset_releases
 from observatory.platform.utils.test_utils import (
     ObservatoryEnvironment,
     ObservatoryTestCase,
     module_file_path,
     find_free_port,
 )
-from observatory.api.testing import ObservatoryApiEnvironment
-from observatory.api.client import ApiClient, Configuration
-from observatory.api.client.api.observatory_api import ObservatoryApi
-from observatory.api.client.model.organisation import Organisation
-from observatory.api.client.model.workflow import Workflow
-from observatory.api.client.model.workflow_type import WorkflowType
-from observatory.api.client.model.dataset import Dataset
-from observatory.api.client.model.dataset_type import DatasetType
-from observatory.api.client.model.table_type import TableType
-from observatory.platform.utils.release_utils import get_dataset_releases
-from observatory.platform.utils.airflow_utils import AirflowConns
 from observatory.platform.utils.url_utils import retry_session
-from airflow.models import Connection
-from airflow.utils.state import State
 
 FAKE_ORG_NAME = "fake_org_name"
 FAKE_PUBLISHER_ID = "fake_publisher_id"

--- a/oaebu_workflows/workflows/thoth_telescope.py
+++ b/oaebu_workflows/workflows/thoth_telescope.py
@@ -1,0 +1,359 @@
+# Copyright 2023 Curtin University
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Author: Keegan Smith
+
+import os
+import shutil
+from typing import List
+import logging
+
+import pendulum
+from airflow.exceptions import AirflowException
+from airflow.models import Variable
+from google.cloud.bigquery import SourceFormat
+from airflow.secrets.environment_variables import EnvironmentVariablesBackend
+
+from observatory.platform.utils.airflow_utils import AirflowVars
+from oaebu_workflows.config import schema_folder as default_schema_folder
+from oaebu_workflows.workflows.onix_telescope import parse_onix
+from observatory.platform.utils.config_utils import find_schema
+from observatory.platform.utils.url_utils import retry_session
+from observatory.platform.utils.file_utils import list_files
+from observatory.platform.utils.gc_utils import upload_files_to_cloud_storage
+from observatory.platform.utils.workflow_utils import (
+    SubFolder,
+    bq_load_shard,
+    table_ids_from_path,
+    make_release_date,
+    delete_old_xcoms,
+)
+from observatory.platform.workflows.workflow import Workflow, Release
+
+THOTH_URL = "{host_name}/specifications/{format_specification}/publisher/{publisher_id}"
+DEFAULT_FORMAT_SPECIFICATION = "onix_3.0::oapen"
+DEFAULT_HOST_NAME = "https://export.thoth.pub"
+
+
+class ThothRelease(Release):
+    def __init__(
+        self,
+        *,
+        dag_id: str,
+        release_date: pendulum.DateTime,
+    ):
+        """Construct a ThothRelease.
+
+        :param dag_id: the DAG id.
+        :param release_date: the release date.
+        """
+        self.release_date = release_date
+        release_id = f'{dag_id}_{self.release_date.format("YYYY_MM_DD")}'
+        super().__init__(dag_id, release_id)
+
+
+class ThothTelescope(Workflow):
+    DAG_ID_PREFIX = "thoth_onix"
+
+    def __init__(
+        self,
+        *,
+        dag_id: str,
+        project_id: str,
+        download_bucket: str,
+        transform_bucket: str,
+        data_location: str,
+        publisher_id: str,
+        airflow_vars: List[str] = None,
+        start_date: pendulum.DateTime = pendulum.datetime(2022, 12, 1),
+        schedule_interval: str = "@weekly",
+        dataset_id: str = "onix",
+        schema_folder: str = default_schema_folder(),
+        source_format: str = SourceFormat.NEWLINE_DELIMITED_JSON,
+        catchup: bool = False,
+        workflow_id: int = None,
+        host_name: str = "https://export.thoth.pub",
+        format_specification: str = DEFAULT_FORMAT_SPECIFICATION,
+        download_file_name: str = "thoth_onix.xml",
+        transform_file_name: str = "thoth_onix.jsonl",
+        dataset_description: str = "Thoth ONIX Feed",
+    ):
+        """Construct an ThothOnixTelescope instance.
+
+        :param organisation_name: the organisation name.
+        :param project_id: the Google Cloud project id.
+        :param download_bucket: the Google Cloud download bucket.
+        :param transform_bucket: the Google Cloud transform bucket.
+        :param data_location: the location for the BigQuery dataset.
+        :param publisher_id: the publisher ID. Can be found using Thoth's GrapihQL API
+        :param airflow_vars: list of airflow variable dependencies, for each connection, it is checked if it exists in airflow.
+        :param dag_id: the id of the DAG, by default this is automatically generated based on the DAG_ID_PREFIX
+        and the organisation name.
+        :param start_date: the start date of the DAG.
+        :param schedule_interval: the schedule interval of the DAG.
+        :param dataset_id: the BigQuery dataset id.
+        :param schema_folder: the SQL schema path.
+        :param source_format: the format of the data to load into BigQuery.
+        :param catchup: whether to catchup the DAG or not.
+        :param workflow_id: api workflow id.
+        :param format_specification: The format to use when downloadin Thoth's metadata
+        :param download_file_name: The name of the file to write the ONIX data to
+        :param transform_file_name: The name of the file to write the transformed ONIX data to
+        :param dataset_description: The description to give to the BigQuery table
+        """
+
+        if airflow_vars is None:
+            airflow_vars = [
+                AirflowVars.DATA_PATH,
+                AirflowVars.PROJECT_ID,
+                AirflowVars.DATA_LOCATION,
+                AirflowVars.DOWNLOAD_BUCKET,
+                AirflowVars.TRANSFORM_BUCKET,
+            ]
+
+        # Cloud workspace settings
+        self.project_id = project_id
+        self.download_bucket = download_bucket
+        self.transform_bucket = transform_bucket
+
+        # Databse settings
+        self.dataset_description = dataset_description
+        self.dataset_id = dataset_id
+        self.data_location = data_location
+        self.source_format = source_format
+        self.schema_folder = schema_folder
+
+        # Thoth settings
+        self.publisher_id = publisher_id
+        self.host_name = host_name
+        self.format_specification = format_specification
+        self.download_file_name = download_file_name
+        self.transform_file_name = transform_file_name
+
+        # Initialise folders
+        self.download_folder = None
+        self.transform_folder = None
+
+        super().__init__(
+            dag_id=dag_id,
+            start_date=start_date,
+            schedule_interval=schedule_interval,
+            catchup=catchup,
+            airflow_vars=airflow_vars,
+            workflow_id=workflow_id,
+        )
+
+        # self.organisation = organisation
+        self.add_setup_task(self.check_dependencies)
+        self.add_task(self.download)
+        self.add_task(self.upload_downloaded)
+        self.add_task(self.transform)
+        self.add_task(self.upload_transformed)
+        self.add_task(self.bq_load)
+        self.add_task(self.cleanup)
+        self.add_task(self.add_new_dataset_releases)
+
+    def make_release(self, **kwargs) -> ThothRelease:
+        """Creates a new Thoth release instance
+
+        :return: The Thoth release instance
+        """
+        release_date = make_release_date(**kwargs)
+        release = ThothRelease(dag_id=self.dag_id, release_date=release_date)
+        self.workflow_folder = make_workflow_folder(self.dag_id, release_date)
+        self.download_folder = make_workflow_folder(self.dag_id, release_date, SubFolder.downloaded.value)
+        self.transform_folder = make_workflow_folder(self.dag_id, release_date, SubFolder.transformed.value)
+        return release
+
+    def download(self, release: ThothRelease, **kwargs) -> None:
+        """Task to download the ONIX release from Thoth.
+
+        :param release: The Thoth release instance
+        """
+        thoth_download_onix(
+            publisher_id=self.publisher_id,
+            download_folder=self.download_folder,
+            format_spec=self.format_specification,
+        )
+
+    def upload_downloaded(self, release: ThothRelease, **kwargs) -> None:
+        """Upload the downloaded thoth onix XML to google cloud bucket
+
+        :param release: The Thoth release instance
+        :raises AirflowException: Raised if there is not exactly 1 file in the donwload folder matching the expected name
+        """
+        download_files = list_files(self.download_folder, self.download_file_name)
+        if len(download_files) != 1:
+            raise AirflowException(
+                f"Unexpected number of files in download folder. Expected 1, found {len(download_files)}"
+            )
+
+        blob = blob_name_from_path(download_files[0])
+        success = upload_files_to_cloud_storage(self.download_bucket, [blob], download_files)
+        if not success:
+            raise AirflowException("Blob could not be uploaded to cloud storage")
+
+    def transform(self, release: ThothRelease, **kwargs) -> None:
+        """Task to transform the Thoth ONIX data
+
+        :param release: The Thoth release instance
+        """
+        parse_onix(self.download_folder, self.transform_folder)
+        # Rename file
+        shutil.move(
+            os.path.join(self.transform_folder, "full.jsonl"),
+            os.path.join(self.transform_folder, self.transform_file_name),
+        )
+
+    def upload_transformed(self, release: ThothRelease, **kwargs) -> None:
+        """Upload the downloaded thoth onix .jsonl to google cloud bucket
+
+        :param release: The Thoth release instance
+        """
+        transform_files = list_files(self.transform_folder, self.transform_file_name)
+        if len(transform_files) != 1:
+            raise AirflowException(
+                f"Unexpected number of files in transform folder. Expected 1, found {len(transform_files)}"
+            )
+        blob = blob_name_from_path(transform_files[0])
+        success = upload_files_to_cloud_storage(self.transform_bucket, [blob], transform_files)
+        if not success:
+            raise AirflowException("Blob could not be uploaded to cloud storage")
+
+    def bq_load(self, release: ThothRelease, **kwargs) -> None:
+        """Task to load the transformed ONIX jsonl file to BigQuery.
+        The table_id is set to the file name without the extension.
+
+        :param release: The Thoth release instance
+        """
+        transform_files = list_files(self.transform_folder, self.transform_file_name)
+        if len(transform_files) != 1:
+            raise AirflowException(
+                f"Unexpected number of files in transform folder. Expected 1, found {len(transform_files)}"
+            )
+        # Load each transformed release
+        transform_blob = blob_name_from_path(transform_files[0])
+        table_id, _ = table_ids_from_path(transform_files[0])
+        schema_file_path = find_schema(path=self.schema_folder, table_name="onix")
+        bq_load_shard(
+            schema_file_path=schema_file_path,
+            project_id=self.project_id,
+            transform_bucket=self.transform_bucket,
+            transform_blob=transform_blob,
+            dataset_id=self.dataset_id,
+            data_location=self.data_location,
+            table_id=table_id,
+            release_date=release.release_date,
+            source_format=self.source_format,
+            dataset_description=self.dataset_description,
+        )
+
+    def cleanup(self, release: ThothRelease, **kwargs) -> None:
+        """Delete all files, folders and XComs associated with this release.
+
+        :param release: The Thoth release instance
+        """
+        cleanup(dag_id=self.dag_id, execution_date=kwargs["execution_date"], workflow_folder=self.workflow_folder)
+
+
+def thoth_download_onix(
+    publisher_id: str,
+    download_folder: str,
+    download_filename: str = "thoth_onix.xml",
+    host_name: str = DEFAULT_HOST_NAME,
+    format_spec: str = "onix_3.0::oapen",
+    num_retries: int = 3,
+) -> None:
+    """Hits the Thoth API and requests the ONIX feed for a particular publisher.
+    Creates a file called onix.xml at the specified location
+
+    :param publisher_id: The ID of the publisher. Can be found using Thoth GraphiQL API
+    :param download_folder: The path of the download folder
+    :param download_filename: The name of the downloaded file
+    :param host_name: The Thoth host URL
+    :param format_spec: The ONIX format to use. Options can be found with the /formats endpoint of the API
+    :param num_retries: The number of times to retry the download, given an unsuccessful return code
+    """
+    url = THOTH_URL.format(host_name=host_name, format_specification=format_spec, publisher_id=publisher_id)
+    logging.info(f"Downloading ONIX XML from {url}")
+    response = retry_session(num_retries=num_retries).get(url)
+    if response.status_code != 200:
+        raise AirflowException(
+            f"Request for URL {url} was unsuccessful with code: {response.status_code}\nContent response: {response.content.decode('utf-8')}"
+        )
+    download_path = os.path.join(download_folder, download_filename)
+    with open(download_path, "wb") as f:
+        f.write(response.content)
+
+
+def make_workflow_folder(dag_id: str, release_date: pendulum.DateTime, *subdirs: str) -> str:
+    """Return the path to this dag release's workflow folder. Will also create it if it doesn't exist
+
+    :param dag_id: The ID of the dag. This is used to find/create the workflow folder
+    :param release_date: The release date
+    :param subdirs: The folder path structure (if any) to create inside the workspace. e.g. 'download' or 'transform'
+    :return: the path of the workflow folder
+    """
+    release_string = release_date.format("YYYY_MM_DD")
+    path = os.path.join(get_data_path(), dag_id, f"{dag_id}_{release_string}", *subdirs)
+    os.makedirs(path, exist_ok=True)
+    return path
+
+
+# bucket_name/dag_name/dag_id/transform/file_name
+def blob_name_from_path(local_filepath: str) -> str:
+    """Creates a blob name from a local file path
+
+    :param local_filepath: The local filepath
+    :return: The name of the blob on cloud storage
+    """
+    # Get the workflow folder for this file and find where the data path starts
+    data_path = get_data_path()
+    if not local_filepath.startswith(data_path):
+        raise AirflowException("Provided local path does not begin with the DATA PATH variable")
+    blob = local_filepath[len(data_path) :]
+    blob = blob.strip(os.path.sep)  # Remove leading/trailing slashes
+    return blob
+
+
+def get_data_path() -> str:
+    """Grabs the DATA_PATH airflow vairable
+
+    :raises AirflowException: Raised if the variable does not exist
+    :return: DATA_PATH variable contents
+    """
+    # Try to get value from env variable first, saving costs from GC secret usage
+    data_path = EnvironmentVariablesBackend().get_variable(AirflowVars.DATA_PATH)
+    if not data_path:
+        data_path = Variable.get(AirflowVars.DATA_PATH)
+    if not data_path:
+        raise AirflowException("DATA_PATH variable could not be found.")
+    return data_path
+
+
+def cleanup(dag_id: str, execution_date: str, workflow_folder: str = None, retention_days=31) -> None:
+    """Delete all files, folders and XComs associated with this release.
+
+    :param dag_id: The ID of the DAG to remove XComs
+    :param execution_date: The execution date of the DAG run
+    :param workflow_folder: The top-level workflow folder to clean up
+    :param retention_days: How many days of Xcom messages to retain
+    """
+    if workflow_folder:
+        try:
+            shutil.rmtree(workflow_folder)
+        except FileNotFoundError as e:
+            logging.warning(f"No such file or directory {workflow_folder}: {e}")
+
+    delete_old_xcoms(dag_id=dag_id, execution_date=execution_date, retention_days=retention_days)


### PR DESCRIPTION
# Thoth

This is a PR for the creation of the Thoth telescope into OAEBU workflows.

This also updates the API seeding to create the Open Book Publishers organisation and the relevant workflows.

## Design

The design of this telescope varies from others, as we wanted to minimise the layers of abstraction (inheritance) and the reliance on the release class. Comments and suggestions are very welcome!

The Thoth release class holds only the release date and DAG ID (this too can be removed using dynamic airflow tasks post version upgrade #112). The rest of the information normally held in the release class has been delegated to the telescope class.

The telescope inherits from the base 'Workflow' class rather than any of the specific telescope classes. This removes one layer of inheritance in its design, making its functionality and operation more transparent. This also means that some functions that would normally be called from the specific telescope classes (ie. streamtelescope, snapshottelescope) have been recreated as standalone functions (get_data_path(), blob_name_from_path(), make_workflow_folder()). Currently these functions are stored in thoth_telescope.py, but these should be moved to a more generic utility file as more telescopes make use of them.

Recreating some of the core functions of the telescope allows for the redesign of the folder hierarchy. The updated hierarchy can be deduced from [this line](https://github.com/The-Academic-Observatory/oaebu-workflows/pull/119/files#diff-9bd08955dc1abcb10519d5f53eb247208b1fe879a5dfd5a0826866ac76985ae3R297). The result should look like this:
data_path/thoth_onix_org/thoth_onix_org_2023_01_01/download
data_path/thoth_onix_org/thoth_onix_org_2023_01_01/transform

## Workflow
The workflow for Thoth is quite simple:
1. Download publisher metadata (ONIX file)
2. Transform the metadata in much the same way as the ONIX telescope
3. Upload the ONIX feed to Bigquery

Since this is effectively an alternate way of retrieving an ONIX feed, it uses some of the ONIX labelling (including having the same dataset ID). However, the DAG ID and download files are prefixed with "thoth" to avoid confusion. The workflow also shares the same 'onix.json' schema file, as we would expect this to be no different to the onix telescope's.