### PR TITLE
BAD-412: Added view creation to onix workflow

### DIFF
--- a/docs/oaebu_workflows/workflows/onix_workflow_step_3.md
+++ b/docs/oaebu_workflows/workflows/onix_workflow_step_3.md
@@ -1,12 +1,13 @@
-ONIX workflow Step 3 - Exporting to Elasticsearch
-==================================================
+# ONIX workflow Step 3 - Exporting to Elasticsearch/Looker
 
-Step three of the ONIX workflow is to export the book_product table to a sequence of flattened data export tables that can be exported to Elasticsearch. The data in these tables is not materially different to the book product table, just organised in a way, better suited for dashboards in Kibana.
+Step three of the ONIX workflow is to export the book_product table to a sequence of flattened data export tables that can be exported to Elasticsearch. The data in these tables is not materially different to the book product table, just organised in a way better suited for dashboards in Kibana.
 
-``` eval_rst
+```eval_rst
 .. image:: ../static/onix_workflow_3.png
    :width: 650
 ```
+
+Since these are date-sharded tables, their names will be updated each time the workflow is run. When using Google's Looker (previously Data Studio), it is prefereable for us to use a static naming scheme. For this reason, after creating the (sharded) _export_ and _quality analysis_ tables, we also create/update a _view_ for table. These views have a static name. By referencing the view, we can keep the Looker dashboards up-to-date without manual intervention.
 
 ## Book Metric
 
@@ -16,7 +17,7 @@ This table is a list of each Book Product. It is primarily used for drop-down fi
 
 [Link to Query](https://github.com/The-Academic-Observatory/oaebu-workflows/blob/develop/oaebu_workflows/database/sql/export_book_list.sql.jinja2)
 
-``` eval_rst
+```eval_rst
 .. csv-table::
    :file: ../../schemas/oaebu_publisher_book_product_list_latest.csv
    :width: 100%
@@ -29,7 +30,7 @@ This table contains metrics, organised by month, that are linked to each book. T
 
 [Link to Query](https://github.com/The-Academic-Observatory/oaebu-workflows/blob/develop/oaebu_workflows/database/sql/export_book_metrics.sql.jinja2)
 
-``` eval_rst
+```eval_rst
 .. csv-table::
    :file: ../../schemas/oaebu_publisher_book_product_metrics_latest.csv
    :width: 100%
@@ -42,7 +43,7 @@ This table contains metrics, organised by month and author, that are linked to e
 
 [Link to Query](https://github.com/The-Academic-Observatory/oaebu-workflows/blob/develop/oaebu_workflows/database/sql/export_book_author_metrics.sql.jinja2)
 
-``` eval_rst
+```eval_rst
 .. csv-table::
    :file: ../../schemas/oaebu_publisher_book_product_author_metrics_latest.csv
    :width: 100%
@@ -55,7 +56,7 @@ This table contains metrics, organised by published year and month, that are lin
 
 [Link to Query](https://github.com/The-Academic-Observatory/oaebu-workflows/blob/develop/oaebu_workflows/database/sql/export_book_year_metrics.sql.jinja2)
 
-``` eval_rst
+```eval_rst
 .. csv-table::
    :file: ../../schemas/oaebu_publisher_book_product_year_metrics_latest.csv
    :width: 100%
@@ -68,7 +69,7 @@ This table contains metrics, organised by month and crossref event type, that ar
 
 [Link to Query](https://github.com/The-Academic-Observatory/oaebu-workflows/blob/develop/oaebu_workflows/database/sql/export_book_metrics_event.sql.jinja2)
 
-``` eval_rst
+```eval_rst
 .. csv-table::
    :file: ../../schemas/oaebu_publisher_book_product_metrics_events_latest.csv
    :width: 100%
@@ -81,7 +82,7 @@ This table contains metrics, organised by month and city of measured usage, that
 
 [Link to Query](https://github.com/The-Academic-Observatory/oaebu-workflows/blob/develop/oaebu_workflows/database/sql/export_book_metrics_city.sql.jinja2)
 
-``` eval_rst
+```eval_rst
 .. csv-table::
    :file: ../../schemas/oaebu_publisher_book_product_metrics_city_latest.csv
    :width: 100%
@@ -94,7 +95,7 @@ This table contains metrics, organised by month and country of measured usage, t
 
 [Link to Query](https://github.com/The-Academic-Observatory/oaebu-workflows/blob/develop/oaebu_workflows/database/sql/export_book_metrics_country.sql.jinja2)
 
-``` eval_rst
+```eval_rst
 .. csv-table::
    :file: ../../schemas/oaebu_publisher_book_product_metrics_country_latest.csv
    :width: 100%
@@ -105,20 +106,20 @@ This table contains metrics, organised by month and country of measured usage, t
 
 This table is a list of each unique Country or Territory. It is primarily used for drop-down fields.
 
-``` eval_rst
+```eval_rst
 .. csv-table::
    :file: ../../schemas/oaebu_public_data_country_list_latest.csv
    :width: 100%
    :header-rows: 1
 ```
- 
+
 ### Book Product Metrics Events Schema
 
 This table contains metrics, organised by month and crossref event type, that are linked to each book.
 
 [Link to Query](https://github.com/The-Academic-Observatory/oaebu-workflows/blob/develop/oaebu_workflows/database/sql/export_book_metrics_event.sql.jinja2)
 
-``` eval_rst
+```eval_rst
 .. csv-table::
    :file: ../../schemas/oaebu_publisher_book_product_metrics_events_latest.csv
    :width: 100%
@@ -131,7 +132,7 @@ This table is a list of each unique Institution where metrics are linked too. It
 
 [Link to Query](https://github.com/The-Academic-Observatory/oaebu-workflows/blob/develop/oaebu_workflows/database/sql/export_book_metrics_institution.sql.jinja2)
 
-``` eval_rst
+```eval_rst
 .. csv-table::
    :file: ../../schemas/oaebu_publisher_institution_list_latest.csv
    :width: 100%
@@ -144,7 +145,7 @@ This table contains metrics, organised by month and institution for which there 
 
 [Link to Query](https://github.com/The-Academic-Observatory/oaebu-workflows/blob/develop/oaebu_workflows/database/sql/export_institution_list.sql.jinja2)
 
-``` eval_rst
+```eval_rst
 .. csv-table::
    :file: ../../schemas/oaebu_publisher_book_product_metrics_institution_latest.csv
    :width: 100%
@@ -153,11 +154,11 @@ This table contains metrics, organised by month and institution for which there 
 
 ### Book Product Metrics Publisher Schema
 
-This index contains a summary of metrics, organised by month that are linked to each publisher. 
+This index contains a summary of metrics, organised by month that are linked to each publisher.
 
 [Link to Query](https://github.com/The-Academic-Observatory/oaebu-workflows/blob/develop/oaebu_workflows/database/sql/export_book_publisher_metrics.sql.jinja2)
 
-``` eval_rst
+```eval_rst
 .. csv-table::
    :file: ../../schemas/oaebu_publisher_book_product_publisher_metrics_latest.csv
    :width: 100%
@@ -170,7 +171,7 @@ This table contains metrics, organised by month and BIC subject type, that are l
 
 [Link to Query](https://github.com/The-Academic-Observatory/oaebu-workflows/blob/develop/oaebu_workflows/database/sql/export_book_subject_bic_metrics.sql.jinja2)
 
-``` eval_rst
+```eval_rst
 .. csv-table::
    :file: ../../schemas/oaebu_publisher_book_product_subject_bic_metrics_latest.csv
    :width: 100%
@@ -183,7 +184,7 @@ This table contains metrics, organised by month and BISAC subject type, that are
 
 [Link to Query](https://github.com/The-Academic-Observatory/oaebu-workflows/blob/develop/oaebu_workflows/database/sql/export_book_subject_bisac_metrics.sql.jinja2)
 
-``` eval_rst
+```eval_rst
 .. csv-table::
    :file: ../../schemas/oaebu_publisher_book_product_subject_bisac_metrics_latest.csv
    :width: 100%
@@ -196,7 +197,7 @@ This table contains metrics, organised by month and THEMA subject type, that are
 
 [Link to Query](https://github.com/The-Academic-Observatory/oaebu-workflows/blob/develop/oaebu_workflows/database/sql/export_book_subject_thema_metrics.sql.jinja2)
 
-``` eval_rst
+```eval_rst
 .. csv-table::
    :file: ../../schemas/oaebu_publisher_book_product_subject_thema_metrics_latest.csv
    :width: 100%
@@ -209,7 +210,7 @@ This table contains metrics, organised by published year and month and currently
 
 [Link to Query](https://github.com/The-Academic-Observatory/oaebu-workflows/blob/develop/oaebu_workflows/database/sql/export_book_subject_year_metrics.sql.jinja2)
 
-``` eval_rst
+```eval_rst
 .. csv-table::
    :file: ../../schemas/oaebu_publisher_book_product_subject_year_metrics_latest.csv
    :width: 100%
@@ -224,7 +225,7 @@ This dataset is helpful for understanding where metrics and books defined in the
 
 [Link to Query](https://github.com/The-Academic-Observatory/oaebu-workflows/blob/develop/oaebu_workflows/database/sql/export_unmatched_metrics.sql.jinja2)
 
-``` eval_rst
+```eval_rst
 .. csv-table::
    :file: ../../schemas/oaebu_publisher_unmatched_book_metrics_latest.csv
    :width: 100%

--- a/oaebu_workflows/fixtures/onix_workflow/onix_query_test.jsonl
+++ b/oaebu_workflows/fixtures/onix_workflow/onix_query_test.jsonl
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:47e44ea0f888e081b8e289876c4b932dea89f910df2c403723b44a11cd3a29aa
+oid sha256:9d19c42f2c8a11b13b5fdc5402f30082a53e43899f56562fdc1af722e57f85a4
 size 131


### PR DESCRIPTION
Since we are using GCP's Looker, we need a set of statically named export tables that the dashboard can pull from. 

This PR creates a step at the end of the Onix Workflow to create a set of BigQuery views for each updated data export and QA table.