### PR TITLE
INF-591: Updated HTTP requests to use new retry function

### DIFF
--- a/oaebu_workflows/workflows/doab_telescope.py
+++ b/oaebu_workflows/workflows/doab_telescope.py
@@ -27,7 +27,7 @@ from oaebu_workflows.api_type_ids import DatasetTypeId
 from oaebu_workflows.config import schema_folder as default_schema_folder
 from observatory.platform.utils.airflow_utils import AirflowVars
 from observatory.platform.utils.file_utils import list_to_jsonl_gz
-from observatory.platform.utils.url_utils import get_user_agent, retry_session
+from observatory.platform.utils.url_utils import get_user_agent, retry_get_url
 from observatory.platform.utils.workflow_utils import convert, upload_files_from_list
 from observatory.platform.workflows.stream_telescope import (
     StreamRelease,
@@ -64,7 +64,7 @@ class DoabRelease(StreamRelease):
         """
         logging.info(f"Downloading csv from url: {DoabTelescope.CSV_URL}")
         headers = {"User-Agent": f"{get_user_agent(package_name='oaebu_workflows')}"}
-        response = retry_session().get(DoabTelescope.CSV_URL, headers=headers)
+        response = retry_get_url(DoabTelescope.CSV_URL, headers=headers)
         if response.status_code == 200:
             with open(self.csv_path, "w") as f:
                 f.write(response.content.decode("utf-8"))

--- a/oaebu_workflows/workflows/doab_telescope.py
+++ b/oaebu_workflows/workflows/doab_telescope.py
@@ -65,12 +65,9 @@ class DoabRelease(StreamRelease):
         logging.info(f"Downloading csv from url: {DoabTelescope.CSV_URL}")
         headers = {"User-Agent": f"{get_user_agent(package_name='oaebu_workflows')}"}
         response = retry_get_url(DoabTelescope.CSV_URL, headers=headers)
-        if response.status_code == 200:
-            with open(self.csv_path, "w") as f:
-                f.write(response.content.decode("utf-8"))
-            logging.info(f"Downloaded csv successful to {self.csv_path}")
-        else:
-            raise AirflowException(f"Download csv unsuccessful, {response.text}")
+        with open(self.csv_path, "w") as f:
+            f.write(response.content.decode("utf-8"))
+        logging.info(f"Downloaded csv successful to {self.csv_path}")
 
         with open(self.csv_path, "r") as f:
             csv_dict = [row for row in csv.DictReader(f)]

--- a/oaebu_workflows/workflows/tests/test_doab_telescope.py
+++ b/oaebu_workflows/workflows/tests/test_doab_telescope.py
@@ -362,7 +362,7 @@ class TestDoabTelescope(ObservatoryTestCase):
 
     @patch("observatory.platform.utils.workflow_utils.Variable.get")
     def test_download(self, mock_variable_get):
-        """Download release and check exception is raised when response is not 200 or csv is empty.
+        """Download release and check exception is raised when csv is empty.
 
         :param mock_variable_get: Mock result of airflow's Variable.get() function
         :return:
@@ -373,13 +373,6 @@ class TestDoabTelescope(ObservatoryTestCase):
 
         with CliRunner().isolated_filesystem():
             mock_variable_get.return_value = "data"
-
-            # Test exception is raised for invalid status code
-            with httpretty.enabled():
-                httpretty.register_uri(httpretty.GET, DoabTelescope.CSV_URL, status=400)
-
-                with self.assertRaises(AirflowException):
-                    release.download()
 
             # Test exception is raised for empty csv file
             with httpretty.enabled():

--- a/oaebu_workflows/workflows/tests/test_thoth_telescope.py
+++ b/oaebu_workflows/workflows/tests/test_thoth_telescope.py
@@ -50,13 +50,13 @@ from observatory.platform.utils.airflow_utils import AirflowConns
 from observatory.platform.utils.file_utils import load_jsonl
 from observatory.platform.utils.gc_utils import bigquery_sharded_table_id
 from observatory.platform.utils.release_utils import get_dataset_releases
+from observatory.platform.utils.url_utils import retry_get_url
 from observatory.platform.utils.test_utils import (
     ObservatoryEnvironment,
     ObservatoryTestCase,
     module_file_path,
     find_free_port,
 )
-from observatory.platform.utils.url_utils import retry_session
 
 FAKE_ORG_NAME = "fake_org_name"
 FAKE_PUBLISHER_ID = "fake_publisher_id"
@@ -325,9 +325,9 @@ class TestThothTelescope(ObservatoryTestCase):
 
     def test_thoth_api(self):
         """Tests that HTTP requests to the thoth API are successful"""
-        base_response = retry_session(num_retries=2).get(DEFAULT_HOST_NAME)
-        format_response = retry_session(num_retries=2).get(
-            f"{DEFAULT_HOST_NAME}/specifications/{DEFAULT_FORMAT_SPECIFICATION}"
+        base_response = retry_get_url(DEFAULT_HOST_NAME, num_retries=2)
+        format_response = retry_get_url(
+            f"{DEFAULT_HOST_NAME}/specifications/{DEFAULT_FORMAT_SPECIFICATION}", num_retries=2
         )
         self.assertEqual(base_response.status_code, 200)
         self.assertEqual(format_response.status_code, 200)

--- a/oaebu_workflows/workflows/thoth_telescope.py
+++ b/oaebu_workflows/workflows/thoth_telescope.py
@@ -29,7 +29,7 @@ from observatory.platform.utils.airflow_utils import AirflowVars
 from oaebu_workflows.config import schema_folder as default_schema_folder
 from oaebu_workflows.workflows.onix_telescope import parse_onix
 from observatory.platform.utils.config_utils import find_schema
-from observatory.platform.utils.url_utils import retry_session
+from observatory.platform.utils.url_utils import retry_get_url
 from observatory.platform.utils.file_utils import list_files
 from observatory.platform.utils.gc_utils import upload_files_to_cloud_storage
 from observatory.platform.utils.workflow_utils import (
@@ -287,7 +287,7 @@ def thoth_download_onix(
     """
     url = THOTH_URL.format(host_name=host_name, format_specification=format_spec, publisher_id=publisher_id)
     logging.info(f"Downloading ONIX XML from {url}")
-    response = retry_session(num_retries=num_retries).get(url)
+    response = retry_get_url(url, num_retries=num_retries)
     if response.status_code != 200:
         raise AirflowException(
             f"Request for URL {url} was unsuccessful with code: {response.status_code}\nContent response: {response.content.decode('utf-8')}"

--- a/oaebu_workflows/workflows/ucl_discovery_telescope.py
+++ b/oaebu_workflows/workflows/ucl_discovery_telescope.py
@@ -29,7 +29,7 @@ from oaebu_workflows.config import schema_folder as default_schema_folder
 from observatory.api.client.model.organisation import Organisation
 from observatory.platform.utils.airflow_utils import AirflowVars
 from observatory.platform.utils.file_utils import list_to_jsonl_gz
-from observatory.platform.utils.url_utils import retry_session
+from observatory.platform.utils.url_utils import retry_get_url
 from observatory.platform.utils.workflow_utils import add_partition_date, make_dag_id
 from observatory.platform.workflows.organisation_telescope import OrganisationRelease, OrganisationTelescope
 from oaebu_workflows.dag_tag import Tag
@@ -87,7 +87,7 @@ class UclDiscoveryRelease(OrganisationRelease):
         :return: None.
         """
         logging.info(f"Downloading metadata from {self.eprint_metadata_url}")
-        response = retry_session(num_retries=5).get(self.eprint_metadata_url)
+        response = retry_get_url(self.eprint_metadata_url, num_retries=5)
         if response.status_code == 200:
             response_content = response.content.decode("utf-8")
             csv_reader = csv.DictReader(response_content.splitlines())
@@ -313,7 +313,7 @@ def get_downloads_per_country(countries_url: str) -> Tuple[List[dict], int]:
     :param countries_url: The url to the downloads per country info
     :return: Number of total downloads and list of downloads per country, country code and country name.
     """
-    response = retry_session(num_retries=5).get(countries_url)
+    response = retry_get_url(countries_url, num_retries=5)
     response_content = response.content.decode("utf-8")
     if response_content == "\n":
         return [], 0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ faker>=8.12.1,<9
 Markdown==3.3.4 # prevent error: INSTALLED_EXTENSIONS = metadata.entry_points(group='markdown.extensions') TypeError: entry_points() got an unexpected keyword argument 'group'
 responses==0.20.*
 onixcheck==0.9.7
+ratelimit==2.2.1


### PR DESCRIPTION
This PR updates GET requests to use the retry_get_url function.

While doing this, I have also altered the default max_threads for onix_workflows and the crossref_events download task. This has become necessary as the oapen onix_workflow makes almost 190k http requests. Taking up to 24 hours to complete. The increase in threads used should decrease the time taken appreciably. The crossref events API limits requests to 15 per second, so I have limited the maximum threads for the download job to 15. Going beyond this number is counter-productive as a 429 is returned from crossref, prompting a short (but noticeable) wait before retrying the request.