### PR TITLE
Updated filenames in dag to use telescope default

### DIFF
--- a/oaebu_workflows/dags/thoth_telescope.py
+++ b/oaebu_workflows/dags/thoth_telescope.py
@@ -56,8 +56,6 @@ for workflow in workflows:
         source_format=SourceFormat.NEWLINE_DELIMITED_JSON,
         catchup=False,
         format_specification="onix_3.0::oapen",
-        download_file_name="thoth_onix.xml",
-        transform_file_name="thoth_onix.jsonl",
         dataset_description=dataset_description,
     )
 


### PR DESCRIPTION
The onix table name derives from the file names used to create them. It is therefore imperative that the files are correctly named. The file names were recently updated on the telescope, but I forgot to update them as they are passed from the dag creation. I think that it is better to have the dag simply use the default of the telescope to avoid this in future.