### PR TITLE
BAD-490: Removed field selection from crossref metadata uri

### DIFF
--- a/oaebu_workflows/fixtures/onix_workflow/crossref_download_function_test.yaml
+++ b/oaebu_workflows/fixtures/onix_workflow/crossref_download_function_test.yaml
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6d6b48018687179befecea91cd0d58c4bc1ff2b8127b72b01c02f0ad8a6770a7
-size 7513
+oid sha256:4ba18567d55144c134de71bd4f237b161388016b489d9d20d25332e244a14bfd
+size 6923

--- a/oaebu_workflows/fixtures/onix_workflow/crossref_metadata_request.yaml
+++ b/oaebu_workflows/fixtures/onix_workflow/crossref_metadata_request.yaml
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:096ff018e2e87ed0724b97b426993e9fa2be6f6d0eb495e2b8e1225838bcc137
-size 21144
+oid sha256:d4ab06bf71c4a234e66c5dd230bd3e61d8cd3c992f7e37d6c57d0833e08c6fa5
+size 18820

--- a/oaebu_workflows/workflows/tests/test_onix_workflow.py
+++ b/oaebu_workflows/workflows/tests/test_onix_workflow.py
@@ -39,6 +39,7 @@ from oaebu_workflows.workflows.onix_workflow import (
     OnixWorkflow,
     OnixWorkflowRelease,
     CROSSREF_METADATA_URL,
+    METADATA_FIELDS,
     CROSSREF_EVENT_URL_TEMPLATE,
     CROSSREF_DELETED_EVENT_URL_TEMPLATE,
     CROSSREF_EDITED_EVENT_URL_TEMPLATE,
@@ -1944,7 +1945,7 @@ class TestOnixWorkflowFunctional(ObservatoryTestCase):
             test_fixtures_folder("onix_workflow", "crossref_download_function_test.yaml"), record_mode="none"
         ):
             metadata_url = CROSSREF_METADATA_URL.format(isbn=good_test_isbn)
-            metadata = download_crossref_isbn_metadata(metadata_url, i=0)
+            metadata = download_crossref_isbn_metadata(metadata_url, fields=['passed'], i=0)
             assert metadata == [{"passed": True}], f"Metadata return incorrect. Got {metadata}"
 
             events_start = pendulum.date(2020, 1, 1)


### PR DESCRIPTION
It has been recommended to us that we refrain from using too many field selections when accessing the crossref metadata API as these are expensive for crossref. Instead, we can return all of the fields from the API and filter the ones we need.