### PR TITLE
Oapen metadata structure change and personname field

### DIFF
--- a/docs/oaebu_workflows/telescopes/oapen_metadata.md
+++ b/docs/oaebu_workflows/telescopes/oapen_metadata.md
@@ -9,7 +9,7 @@ See the [OAPEN Metadata webpage](https://www.oapen.org/resources/15635975-metada
 +------------------------------+------------+
 | Summary                      |            |
 +==============================+============+
-| Average runtime              |  5min      |
+| Average runtime              |  10min     |
 +------------------------------+------------+
 | Average download size        |  150-200MB |
 +------------------------------+------------+
@@ -17,7 +17,7 @@ See the [OAPEN Metadata webpage](https://www.oapen.org/resources/15635975-metada
 +------------------------------+------------+
 | Harvest Frequency            | Weekly     |
 +------------------------------+------------+
-| Runs on remote worker        | True       |
+| Runs on remote worker        | False      |
 +------------------------------+------------+
 | Catchup missed runs          | False      |
 +------------------------------+------------+
@@ -35,13 +35,7 @@ See the [OAPEN Metadata webpage](https://www.oapen.org/resources/15635975-metada
 
 ### Airflow Connections
 
-The OAPEN metadata is freely accessible, so no credentials are required for it. However, the telescope will upload the XML to the SFTP server once finished processing.
-
-The (url-encoded) ssh username, password and host key to connect to the SFTP server:
-
-```bash
-sftp_service: ssh://user-name:password@host-name:port?host_key=host-key
-```
+The OAPEN metadata is freely accessible, so no credentials are required for it.
 
 ## Schedule
 
@@ -49,7 +43,7 @@ The XML file containing metadata is updated daily at +0000GMT. This telescope is
 
 ## Results
 
-There are no resulting tables from this telescope. Its purpose is to transfrom the OAPEN Metadata into a valid ONIX file. This can then be picked up and loaded by the [ONIX Telescope](onix.md).
+The resulting ONIX table will be stored in BigQuery - `oaebu-oapen.onix.onixYYYYMMDD`
 
 ## Tasks
 
@@ -81,6 +75,6 @@ The transform step modifies the downloaded metadata into a valid ONIX format. Th
    :header-rows: 1
 ```
 
-### Upload to SFTP Server
+### Load to BigQuery
 
-After checking that the metadata is now in a valid ONIX format, the ONIX XML is uploaded to the SFTP server. This can then be picked up by the [ONIX telescope](onix.md) and integrated into the proceeding workflows as normal.
+The valid ONIX feed can now be loaded from the transform bucket into a BigQuery sharded table.

--- a/oaebu_workflows/dags/oapen_metadata_telescope.py
+++ b/oaebu_workflows/dags/oapen_metadata_telescope.py
@@ -26,5 +26,16 @@ api = make_observatory_api()
 workflow_type = api.get_workflow_type(type_id=WorkflowTypes.oapen_metadata)
 workflows = api.get_workflows(workflow_type_id=workflow_type.id, limit=1)
 if len(workflows):
-    workflow = OapenMetadataTelescope(workflow_id=workflows[0].id, dag_id=OapenMetadataTelescope.DAG_ID)
+    organisation = workflows[0].organisation
+    project_id = organisation.project_id
+    download_bucket = organisation.download_bucket
+    transform_bucket = organisation.transform_bucket
+    workflow = OapenMetadataTelescope(
+        workflow_id=workflows[0].id,
+        dag_id=OapenMetadataTelescope.DAG_ID,
+        download_bucket=download_bucket,
+        transform_bucket=transform_bucket,
+        data_location="us",
+        project_id=project_id,
+    )
     globals()[workflow.dag_id] = workflow.make_dag()

--- a/oaebu_workflows/seed/dataset_info.py
+++ b/oaebu_workflows/seed/dataset_info.py
@@ -41,7 +41,7 @@ def get_dataset_info(api: ObservatoryApi):
         name=name,
         service="google",
         address="oaebu-oapen.onix.onix",
-        workflow=workflows["OAPEN Press ONIX Telescope"],
+        workflow=workflows["OAPEN Metadata"],
         dataset_type=get_dataset_type(api=api, type_id=DatasetTypeId.onix),
     )
     name = "ANU Press Onix Dataset"

--- a/oaebu_workflows/seed/workflow_info.py
+++ b/oaebu_workflows/seed/workflow_info.py
@@ -46,14 +46,6 @@ def get_workflow_info(api: ObservatoryApi):
         extra={},
         tags='["oaebu"]',
     )
-    name = "OAPEN Press ONIX Telescope"
-    workflow_info[name] = Workflow(
-        name=name,
-        organisation=Organisation(id=orgids["OAPEN Press"]),
-        workflow_type=WorkflowType(id=wftids[WorkflowTypeId.onix]),
-        extra={"date_regex": "\\d{8}", "sensor_dag_ids": ["oapen_metadata"]},
-        tags='["oaebu"]',
-    )
     name = "ANU Press ONIX Telescope"
     workflow_info[name] = Workflow(
         name=name,
@@ -100,7 +92,7 @@ def get_workflow_info(api: ObservatoryApi):
         organisation=Organisation(id=orgids["CEU Press"]),
         workflow_type=WorkflowType(id=wftids[WorkflowTypeId.onix]),
         extra={"date_format": "%Y%m%d", "date_regex": "\\d{8}"},
-        tags=None,
+        tags='["oaebu"]',
     )
     name = "ANU Press Google Analytics Telescope"
     workflow_info[name] = Workflow(

--- a/oaebu_workflows/workflows/onix_workflow.py
+++ b/oaebu_workflows/workflows/onix_workflow.py
@@ -417,10 +417,11 @@ class OnixWorkflow(Workflow):
         partner_data_dag_prefix_ids.sort()  # Sort so that order is deterministic
         # Assert that there is an onix dataset for this workflow
         if not DatasetTypeId.onix in [partner.dataset_type_id for partner in data_partners]:
-            raise AirflowException(f"No ONIX task is configured for this workflow. {data_partners}")
+            raise AirflowException(f"No ONIX task is configured for this workflow: {self.dag_id}")
         with self.parallel_tasks():
             for dag_prefix in partner_data_dag_prefix_ids:
-                ext_dag_id = make_dag_id(dag_prefix, org_name)
+                # oapen metadata is a special case, making its own onix feed
+                ext_dag_id = make_dag_id(dag_prefix, org_name) if dag_prefix != "oapen_metadata" else "oapen_metadata"
                 sensor = DagRunSensor(
                     task_id=f"{ext_dag_id}_sensor",
                     external_dag_id=ext_dag_id,


### PR DESCRIPTION
Added personname to oapen metadata

Also changed the structure of the telescope. It now parses the ONIX data and pushes it directly to bigquery rather than uploading it to the SFTP server, to be picked up by the OAPEN ONIX telescope. As such, the OAPEN ONIX telescope is no longer necessary.

I have added a logical statement in the onix workflow to properly create the sensor for this telescope. It's not the cleanest solution, but I believe it can be removed soon as we are moving to a configuration-file setup.