### PR TITLE
INF-598: ONIX telescope keyword parsing

### DIFF
--- a/oaebu_workflows/fixtures/onix/test_subjects_expected.json
+++ b/oaebu_workflows/fixtures/onix/test_subjects_expected.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7448d3d1248c028aba632719120d4912e1a5d0f4276d55efa4bfa5191a0c398d
+size 4026

--- a/oaebu_workflows/fixtures/onix/test_subjects_input.json
+++ b/oaebu_workflows/fixtures/onix/test_subjects_input.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fede1b2563b1097eb90201b4d64837360344aa4c6b699a3d94678946296c6a14
+size 6686

--- a/oaebu_workflows/fixtures/thoth/test_subjects_expected.json
+++ b/oaebu_workflows/fixtures/thoth/test_subjects_expected.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:80fe96ebf1e00faa110b27c9b8f21413654d404424e54f584fc12cda2971f318
-size 4010

--- a/oaebu_workflows/fixtures/thoth/test_subjects_input.json
+++ b/oaebu_workflows/fixtures/thoth/test_subjects_input.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b9fa23ada3d6b8a23ee65e1af41fbfe6a4371026b761cf28a51403ca1f04b16c
-size 6626

--- a/oaebu_workflows/workflows/tests/test_thoth_telescope.py
+++ b/oaebu_workflows/workflows/tests/test_thoth_telescope.py
@@ -17,7 +17,6 @@
 import os
 from tempfile import TemporaryDirectory
 from unittest.mock import patch
-import json
 
 import pendulum
 import vcr
@@ -28,7 +27,6 @@ from oaebu_workflows.config import test_fixtures_folder
 from oaebu_workflows.workflows.thoth_telescope import (
     ThothTelescope,
     thoth_download_onix,
-    thoth_collapse_subjects,
     blob_name_from_path,
     DEFAULT_FORMAT_SPECIFICATION,
     DEFAULT_HOST_NAME,
@@ -85,8 +83,6 @@ class TestThothTelescope(ObservatoryTestCase):
         # Fixtures
         self.download_cassette = os.path.join(test_fixtures_folder("thoth"), "thoth_download_cassette.yaml")
         self.test_table = os.path.join(test_fixtures_folder("thoth"), "test_table.jsonl")
-        self.test_subjects_input = os.path.join(test_fixtures_folder("thoth"), "test_subjects_input.json")
-        self.test_subjects_expected = os.path.join(test_fixtures_folder("thoth"), "test_subjects_expected.json")
 
     def setup_api(self):
         name = "Thoth Telescope"
@@ -276,17 +272,6 @@ class TestThothTelescope(ObservatoryTestCase):
             self.assert_file_integrity(
                 os.path.join(tempdir, "fake_download.xml"), "78b8c27c9c63fb0f2d721b7d856f4e3c", "md5"
             )
-
-    def test_thoth_collapse_subjects(self):
-        """Tests the thoth_collapse_subjects function"""
-        with open(self.test_subjects_input, "r") as f:
-            onix = json.load(f)
-        actual_onix = thoth_collapse_subjects(onix)
-        with open(self.test_subjects_expected, "r") as f:
-            expected_onix = json.load(f)
-
-        assert len(actual_onix) == len(expected_onix)
-        assert json.dumps(actual_onix, sort_keys=True) == json.dumps(expected_onix, sort_keys=True)
 
     def test_thoth_api(self):
         """Tests that HTTP requests to the thoth API are successful"""


### PR DESCRIPTION
We are running issues when making the book_product table for many of the new telescopes. Each time it errors, it's because the _Subjects.SubjectHeadingText_ field is improperly populated for _Keywords_. The Keywords should not be a repeated field, but a single string where each keyword is separated by a semicolon. This is the only format that the SQL will reliably work with. This PR adds a step during the transform phase of the ONIX telescope to collapse repeated keywords into a single string and also attempts to change incorrect separators (commas, colons) to semicolons (as these also cause errors).