### PR TITLE
INF-604: Crossref pools for the ONIX workflow

### DIFF
--- a/oaebu_workflows/workflows/tests/test_onix_workflow.py
+++ b/oaebu_workflows/workflows/tests/test_onix_workflow.py
@@ -213,7 +213,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
         configuration = Configuration(host=f"http://{self.host}:{self.port}")
         api_client = ApiClient(configuration)
         self.api = ObservatoryApi(api_client=api_client)  # noqa: E501
-        self.env = ObservatoryApiEnvironment(host=self.host, port=self.port)
+        self.env = ObservatoryEnvironment(self.project_id, self.data_location, api_host=self.host, api_port=self.port)
 
         # Onix data partner to pass to the telescope for initialisation
         self.fake_onix_data_partner = OaebuPartner(
@@ -1945,7 +1945,7 @@ class TestOnixWorkflowFunctional(ObservatoryTestCase):
             test_fixtures_folder("onix_workflow", "crossref_download_function_test.yaml"), record_mode="none"
         ):
             metadata_url = CROSSREF_METADATA_URL.format(isbn=good_test_isbn)
-            metadata = download_crossref_isbn_metadata(metadata_url, fields=['passed'], i=0)
+            metadata = download_crossref_isbn_metadata(metadata_url, fields=["passed"], i=0)
             assert metadata == [{"passed": True}], f"Metadata return incorrect. Got {metadata}"
 
             events_start = pendulum.date(2020, 1, 1)


### PR DESCRIPTION
This PR creates a pool for each of the crossref (metadata and event) APIs used by the ONIX workflow. This is necessary because many of the workflows can run at once, each of which will throttle themselves without knowledge of outside tasks.

The pool sizes were chosen based only on my experimentation. The slots that each task take up will be equal to the number of threads used for each process, thereby effectively limiting the total number of active threads across all tasks using the same pool.

Tested locally and appears to work as intended. Although it's difficult because running 5 tasks at once tanks my computer.