### PR TITLE
Handle case: OAPEN Metadata returns only the XML header

### DIFF
--- a/oaebu_workflows/fixtures/oapen_metadata/oapen_metadata_cassette_header_only.yaml
+++ b/oaebu_workflows/fixtures/oapen_metadata/oapen_metadata_cassette_header_only.yaml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0cc5b0e1271e76bd2f010c818c8b09357660abddb91cee6ec5e457c43dc037f5
+size 1895

--- a/oaebu_workflows/workflows/tests/test_oapen_metadata_telescope.py
+++ b/oaebu_workflows/workflows/tests/test_oapen_metadata_telescope.py
@@ -92,6 +92,9 @@ class TestOapenMetadataTelescope(ObservatoryTestCase):
         self.invalid_download_cassette = test_fixtures_folder("oapen_metadata", "oapen_metadata_cassette_invalid.yaml")
         self.bad_response_cassette = test_fixtures_folder("oapen_metadata", "oapen_metadata_cassette_bad_response.yaml")
         self.empty_download_cassette = test_fixtures_folder("oapen_metadata", "oapen_metadata_cassette_empty.yaml")
+        self.header_only_download_cassette = test_fixtures_folder(
+            "oapen_metadata", "oapen_metadata_cassette_header_only.yaml"
+        )
 
         # XML files for testing
         self.valid_download_xml = test_fixtures_folder("oapen_metadata", "oapen_metadata_download_valid.xml")
@@ -324,6 +327,12 @@ class TestOapenMetadataTelescope(ObservatoryTestCase):
         # For empty XML
         with vcr.VCR().use_cassette(self.empty_download_cassette, record_mode="none", allow_playback_repeats=True):
             self.assertRaises(ElementTree.ParseError, download_oapen_metadata, download_file.name)
+
+        # For only-header XML
+        with vcr.VCR().use_cassette(
+            self.header_only_download_cassette, record_mode="none", allow_playback_repeats=True
+        ):
+            self.assertRaises(AirflowException, download_oapen_metadata, download_file.name)
 
         # For non-200 response code
         with vcr.VCR().use_cassette(self.bad_response_cassette, record_mode="none", allow_playback_repeats=True):


### PR DESCRIPTION
Oapen will sometimes only return a header when requesting the metadata. No idea why. But it doesn't fall under any of the error cases in the download task. This PR causes an error to be raised if no XML "Product" is found in the downloaded content