### PR TITLE
Oapen metadata transform bucket consistency

### DIFF
--- a/oaebu_workflows/workflows/oapen_metadata_telescope.py
+++ b/oaebu_workflows/workflows/oapen_metadata_telescope.py
@@ -244,7 +244,7 @@ class OapenMetadataTelescope(SnapshotTelescope):
         bq_load_shard(
             schema_file_path=schema_file_path,
             project_id=self.project_id,
-            transform_bucket=release.transform_bucket,
+            transform_bucket=self.transform_bucket,
             transform_blob=transform_blob,
             dataset_id=self.dataset_id,
             data_location=self.data_location,


### PR DESCRIPTION
The bucket name for bq_load was using the release bucket ID. This got past the tests... but we're refactoring them soon so I didn't bother adding this check to the test.