### PR TITLE
BAD-507: Add personname field to Thoth feed

### DIFF
--- a/oaebu_workflows/fixtures/thoth/test_table.jsonl
+++ b/oaebu_workflows/fixtures/thoth/test_table.jsonl
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1df286557c069cad5e35f93025261e03220375f1b3224b5a4c93fd076dddbdba
-size 15141
+oid sha256:6dc6cafeb30e8992b1e49c54e52c62118712a2d47f81d3e2fc859fc795b68f67
+size 24334

--- a/oaebu_workflows/fixtures/thoth/test_table.jsonl
+++ b/oaebu_workflows/fixtures/thoth/test_table.jsonl
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:36318711fa09dd1ead2d5452933b1be583149622f7c06a0a41db8837de95f483
-size 15102
+oid sha256:1df286557c069cad5e35f93025261e03220375f1b3224b5a4c93fd076dddbdba
+size 15141

--- a/oaebu_workflows/fixtures/thoth/thoth_download_cassette.yaml
+++ b/oaebu_workflows/fixtures/thoth/thoth_download_cassette.yaml
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ab2e365f7474df0fd353407d705a9e2e0e118d2961f54b77379b76094a4f979c
-size 26029
+oid sha256:6bcc82719c25de49eab7876a2cc87ef7b4f60dedb314928d2f59d60f99de5305
+size 25980

--- a/oaebu_workflows/workflows/tests/test_thoth_telescope.py
+++ b/oaebu_workflows/workflows/tests/test_thoth_telescope.py
@@ -30,12 +30,16 @@ from oaebu_workflows.workflows.thoth_telescope import (
 )
 from oaebu_workflows.config import test_fixtures_folder
 from observatory.platform.api import get_dataset_releases
-from observatory.platform.files import load_jsonl
 from observatory.platform.bigquery import bq_sharded_table_id
 from observatory.platform.gcs import gcs_blob_name_from_path
 from observatory.platform.utils.url_utils import retry_get_url
 from observatory.platform.observatory_config import Workflow
-from observatory.platform.observatory_environment import ObservatoryEnvironment, ObservatoryTestCase, find_free_port
+from observatory.platform.observatory_environment import (
+    ObservatoryEnvironment,
+    ObservatoryTestCase,
+    find_free_port,
+    load_and_parse_json,
+)
 
 
 FAKE_PUBLISHER_ID = "fake_publisher_id"
@@ -149,7 +153,7 @@ class TestThothTelescope(ObservatoryTestCase):
                 )
 
                 # Downloaded file
-                self.assert_file_integrity(release.download_path, "78b8c27c9c63fb0f2d721b7d856f4e3c", "md5")
+                self.assert_file_integrity(release.download_path, "6d0f31c315dab144054e2fde9ad7f8ab", "md5")
 
                 # Uploaded download blob
                 self.assert_blob_integrity(
@@ -157,7 +161,7 @@ class TestThothTelescope(ObservatoryTestCase):
                 )
 
                 # Transformed file
-                self.assert_file_integrity(release.transform_path, "bda19178", "gzip_crc")
+                self.assert_file_integrity(release.transform_path, "f384ecd8", "gzip_crc")
 
                 # Uploaded transform blob
                 self.assert_blob_integrity(
@@ -172,7 +176,7 @@ class TestThothTelescope(ObservatoryTestCase):
                     release.snapshot_date,
                 )
                 self.assert_table_integrity(table_id, expected_rows=2)
-                self.assert_table_content(table_id, load_jsonl(self.test_table), primary_key="DOI")
+                self.assert_table_content(table_id, load_and_parse_json(self.test_table), primary_key="DOI")
 
                 # add_dataset_release_task
                 dataset_releases = get_dataset_releases(dag_id=telescope.dag_id, dataset_id=telescope.api_dataset_id)
@@ -200,7 +204,7 @@ class TestThothTelescope(ObservatoryTestCase):
                     FAKE_PUBLISHER_ID, download_path=os.path.join(tempdir, "fake_download.xml"), num_retries=0
                 )
             self.assert_file_integrity(
-                os.path.join(tempdir, "fake_download.xml"), "78b8c27c9c63fb0f2d721b7d856f4e3c", "md5"
+                os.path.join(tempdir, "fake_download.xml"), "6d0f31c315dab144054e2fde9ad7f8ab", "md5"
             )
 
     def test_thoth_api(self):

--- a/oaebu_workflows/workflows/thoth_telescope.py
+++ b/oaebu_workflows/workflows/thoth_telescope.py
@@ -24,6 +24,7 @@ from google.cloud.bigquery import SourceFormat
 
 from oaebu_workflows.config import schema_folder as default_schema_folder
 from oaebu_workflows.workflows.onix_telescope import parse_onix, onix_collapse_subjects
+from oaebu_workflows.workflows.oapen_metadata_telescope import create_personname_field
 from observatory.api.client.model.dataset_release import DatasetRelease
 from observatory.platform.api import make_observatory_api
 from observatory.platform.airflow import AirflowConns
@@ -173,6 +174,7 @@ class ThothTelescope(Workflow):
         parse_onix(release.download_folder, release.transform_folder)
         logging.info("Transforming onix feed - collapsing keywords")
         transformed = onix_collapse_subjects(load_jsonl(os.path.join(release.transform_folder, "full.jsonl")))
+        transformed = create_personname_field(transformed)
         save_jsonl_gz(release.transform_path, transformed)
 
     def upload_transformed(self, release: ThothRelease, **kwargs) -> None:


### PR DESCRIPTION
The Thoth ONIX feeds do not have the personname field populated by default. This PR uses the same function created for OAPEN (#135) to create the field from two other fields (should they exist)