### PR TITLE
Changed crossref metadata table load

### DIFF
--- a/oaebu_workflows/database/sql/crossref_metadata_filter_isbn.sql.jinja2
+++ b/oaebu_workflows/database/sql/crossref_metadata_filter_isbn.sql.jinja2
@@ -19,39 +19,45 @@ This script creates a temporary table full of the supplied ISBNs.
 It then joins these ISBNs on the Crossref Metadata table. 
 This gives the same result as using a WHERE statement for each ISBN.
 */
-CREATE TEMPORARY TABLE isbn_table (ISBN STRING);
 
-INSERT INTO isbn_table (ISBN) VALUES {% for isbn in isbns %}('{{ isbn }}'){% if not loop.last %},{% endif %}{% endfor %};
-
+WITH isbns AS (
+  SELECT
+    DISTINCT(ISBN13)
+  FROM
+    `{{ onix_table_id }}`
+)
 SELECT
-    xref.DOI,
-    xref.URL,
-    xref.type,
-    xref.title,
-    xref.abstract,
-    xref.issued,
-    xref.ISSN,
-    xref.ISBN,
-    xref.issn_type,
-    xref.publisher_location,
-    xref.publisher,
-    xref.member,
-    xref.prefix,
-    xref.container_title,
-    xref.short_container_title,
-    xref.group_title,
-    xref.references_count,
-    xref.is_referenced_by_count,
-    xref.subject,
-    xref.published_print,
-    xref.license,
-    xref.volume,
-    xref.funder,
-    xref.page,
-    xref.author,
-    xref.link,
-    xref.clinical_trial_number,
-    xref.alternative_id
+  xref.DOI,
+  xref.URL,
+  xref.type,
+  xref.title,
+  xref.abstract,
+  xref.issued,
+  xref.ISSN,
+  xref.ISBN,
+  xref.issn_type,
+  xref.publisher_location,
+  xref.publisher,
+  xref.member,
+  xref.prefix,
+  xref.container_title,
+  xref.short_container_title,
+  xref.group_title,
+  xref.references_count,
+  xref.is_referenced_by_count,
+  xref.subject,
+  xref.published_print,
+  xref.license,
+  xref.volume,
+  xref.funder,
+  xref.page,
+  xref.author,
+  xref.link,
+  xref.clinical_trial_number,
+  xref.alternative_id
 FROM
-    `{{ project_id }}.{{ dataset_id }}.{{ crossref_metadata_table_id }}` xref
-    JOIN isbn_table i ON i.ISBN in UNNEST(xref.ISBN)
+  `{{ crossref_metadata_table_id }}` xref
+JOIN
+  isbns i
+ON
+  i.ISBN13 IN UNNEST(xref.ISBN)

--- a/oaebu_workflows/workflows/tests/test_onix_workflow.py
+++ b/oaebu_workflows/workflows/tests/test_onix_workflow.py
@@ -43,9 +43,6 @@ from oaebu_workflows.workflows.onix_workflow import (
     download_crossref_events,
     transform_crossref_events,
     transform_event,
-    transform_crossref_metadata,
-    transform_metadata_item,
-    isbns_from_onix,
     dois_from_onix,
     download_crossref_event_url,
     create_latest_views_from_dataset,
@@ -1976,47 +1973,7 @@ class TestOnixWorkflowFunctional(ObservatoryTestCase):
         assert not bad_events, f"Events should have returned nothing, instead returned {bad_events}"
 
     def test_crossref_transform(self):
-        # Test transformation functions
-        input_metadata = [
-            {
-                "publisher": "University of Minnesota Press",
-                "published-print": {"date-parts": [["2017", "10", "24"]]},
-                "DOI": "10.5749/j.ctt1pwt6tp",
-                "type": "monograph",
-                "is-referenced-by-count": 10,
-                "title": ["Postcolonial Automobility"],
-                "prefix": "10.5749",
-                "author": [{"given": "Lindsey B.", "family": "Green-Simms", "sequence": "first", "affiliation": []}],
-                "member": "3779",
-                "issued": {"date-parts": [[]]},
-                "ISBN": ["9780136019701"],
-                "references-count": 0,
-            }
-        ]
-        expected_transformed_metadata = [
-            {
-                "publisher": "University of Minnesota Press",
-                "published_print": {"date_parts": [["2017", "10", "24"]]},
-                "DOI": "10.5749/j.ctt1pwt6tp",
-                "type": "monograph",
-                "is_referenced_by_count": 10,
-                "title": ["Postcolonial Automobility"],
-                "prefix": "10.5749",
-                "author": [{"given": "Lindsey B.", "family": "Green-Simms", "sequence": "first", "affiliation": []}],
-                "member": "3779",
-                "issued": {"date_parts": [[]]},
-                "ISBN": ["9780136019701"],
-                "references_count": 0,
-            }
-        ]
-
-        # Standalone transform
-        actual_transformed_metadata = transform_metadata_item(input_metadata[0])
-        expected_transformed_metadata[0] == actual_transformed_metadata
-        # List transform
-        actual_transformed_metadata = transform_crossref_metadata(input_metadata)
-        assert len(actual_transformed_metadata) == 1
-        assert expected_transformed_metadata == actual_transformed_metadata
+        """Test the function that transforms the crossref events data"""
 
         input_events = [
             {
@@ -2119,14 +2076,10 @@ class TestOnixWorkflowFunctional(ObservatoryTestCase):
                 project_id=self.gcp_project_id,
             )
 
-            actual_isbns = isbns_from_onix(self.gcp_project_id, fake_onix_dataset_id, "onix")
             actual_dois = dois_from_onix(self.gcp_project_id, fake_onix_dataset_id, "onix")
-            fake_isbns = [entry["ISBN13"] for entry in fake_onix]
             fake_dois = [entry["DOI"] for entry in fake_onix]
 
             # Check there are no duplicates and the contents are the same
-            assert len(actual_isbns) == len(set(fake_isbns))
-            assert set(actual_isbns) == set(fake_isbns)
             assert len(actual_dois) == len(set(fake_dois))
             assert set(actual_dois) == set(fake_dois)
 
@@ -2662,15 +2615,15 @@ class TestOnixWorkflowFunctional(ObservatoryTestCase):
                 actual_content = json.loads(json.dumps([dict(row) for row in rows], default=str))
                 for row in actual_content:
                     if "metadata" in row:  # TODO: remove this necessity
-                        row['metadata']["crossref_objects"] = sorted(
-                            row['metadata']["crossref_objects"], key=lambda x: x["published_year_month"]
+                        row["metadata"]["crossref_objects"] = sorted(
+                            row["metadata"]["crossref_objects"], key=lambda x: x["published_year_month"]
                         )
                 self.assertIsNotNone(rows)
                 if expected_content is not None:
                     for row in expected_content:
                         if "metadata" in row:  # TODO: remove this necessity
-                            row['metadata']["crossref_objects"] = sorted(
-                                row['metadata']["crossref_objects"], key=lambda x: x["published_year_month"]
+                            row["metadata"]["crossref_objects"] = sorted(
+                                row["metadata"]["crossref_objects"], key=lambda x: x["published_year_month"]
                             )
                         self.assertIn(row, actual_content)
                         actual_content.remove(row)


### PR DESCRIPTION
The fix from #144 has unfortunately failed in production as BigQuery gives an error when inserting too many rows into a temporary table (query too complex). This PR takes a new approach (and what I believe to be a cleaner one) to the issue. Instead of retrieving the ISBNs from the ONIX feed in python, this is collapsed into the SQL query. This removed the necessity of the isbns_from_onix() function entirely (it's not used for anything else). Furthermore, @jdddog mentioned that it'd be better to simply make the metadata table directly from the query (using create_bigquery_table_from_query()). I have implemented this change as well, which simplifies the metadata table creation significantly. The metadata transform functions are no longer necessary as the data should be transformed prior to the master metadata table creation.