### PR TITLE
Remove ISBN filter on OA books

### DIFF
--- a/oaebu_workflows/database/sql/create_book_products.sql.jinja2
+++ b/oaebu_workflows/database/sql/create_book_products.sql.jinja2
@@ -442,8 +442,6 @@ onix_ebook_titles_raw as (
             ) as authors
         ) as onix
     FROM `{{ onix_table_id }}` as onix
-
-    WHERE ProductForm = "Digital download and online" OR ProductForm = "Digital (delivered electronically)" OR ProductForm = "Digital download"
 ),
 
 {#

--- a/oaebu_workflows/fixtures/onix_workflow/e2e_inputs/onix.jsonl
+++ b/oaebu_workflows/fixtures/onix_workflow/e2e_inputs/onix.jsonl
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3e030df2331c63083c7bb4553409229662125e75a7f251583b38d09c28ae5f05
-size 1324
+oid sha256:1fb9a1467a7724d42fed46655efd7dd5e95cafe641244b8228a0d1ce2caf852c
+size 1315

--- a/oaebu_workflows/fixtures/onix_workflow/e2e_outputs/book_product.json
+++ b/oaebu_workflows/fixtures/onix_workflow/e2e_outputs/book_product.json
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0f61bd295ae70042799e4e6b50bcc507cda8c0a08ff56204a1b8694b62ba16f3
-size 39062
+oid sha256:f1a1f94113fd3f98abde0ad775a4d53deeaf71a302aca0884733385d50bb2858
+size 39054

--- a/oaebu_workflows/fixtures/onix_workflow/e2e_outputs/book_product_ga.json
+++ b/oaebu_workflows/fixtures/onix_workflow/e2e_outputs/book_product_ga.json
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b5a05ee169c7a3cf1f854399baed6248c243a1601c8d24d3d99608a68e6e99af
-size 40880
+oid sha256:f011577af9355d0486c84b5fd2992f570363a5ed9131f4952e9fc5a6f34794af
+size 40872

--- a/oaebu_workflows/fixtures/onix_workflow/e2e_outputs/book_product_list.json
+++ b/oaebu_workflows/fixtures/onix_workflow/e2e_outputs/book_product_list.json
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:297b2db9fa326cdaad63b5affae905f01cabff1e9203a8917f8aee2d262afbe5
-size 1721
+oid sha256:6e45824bfb3cc56fefeca640698cab73475c91a9ba4e7c47d30109689bb60cb2
+size 1713


### PR DESCRIPTION
We are transitioning to the option of processing all book titles - rather than just digital open access. For publishers that want only OA titles, the supplied ONIX feed remains the source of truth.