### PR TITLE
Update ONIX parsing and function consolidation

### DIFF
--- a/oaebu_workflows/onix.py
+++ b/oaebu_workflows/onix.py
@@ -1,0 +1,134 @@
+# Copyright 2023 Curtin University
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Author: Keegan Smith
+import os
+import subprocess
+import logging
+from glob import glob
+from typing import List, Tuple
+from dataclasses import dataclass
+
+from observatory.platform.config import observatory_home
+from observatory.platform.utils.http_download import download_file
+from observatory.platform.utils.proc_utils import wait_for_process
+
+
+@dataclass
+class OnixParser:
+    """Class for storing infromation on the java ONIX parser
+
+    :param filename: The name of the java ONIX parser file
+    :param url: The url to use for downloading the parser
+    :param bash template: The path to the bash template "onix_parser.sh.jinja2"
+    """
+
+    filename = "coki-onix-parser-1.2-SNAPSHOT-shaded.jar"
+    url = "https://github.com/The-Academic-Observatory/onix-parser/releases/download/v1.3.0/coki-onix-parser-1.2-SNAPSHOT-shaded.jar"
+    cmd = "java -jar {parser_path} {input_dir} {output_dir}"
+
+
+def onix_collapse_subjects(onix: List[dict]) -> List[dict]:
+    """The book product table creation requires the keywords (under Subjects.SubjectHeadingText) to occur only once
+    Some ONIX feeds return all keywords as separate entires. This function finds and collapses each keyword into a
+    semi-colon separated string. Other common separators will be replaced with semi-colons.
+
+    :param onix: The onix feed
+    :return: The onix feed after collapsing the keywords of each row
+    """
+    for row in onix:
+        # Create the joined keywords in this row
+        keywords = []
+        for subject in row["Subjects"]:
+            if subject["SubjectSchemeIdentifier"] != "Keywords":
+                continue
+            subject_heading_text = [i for i in subject["SubjectHeadingText"] if i is not None]  # Remove Nones
+            if not subject_heading_text:  # Empty list
+                continue
+            keywords.append("; ".join(subject_heading_text))
+        # Enforce a split by semicolon
+        keywords = "; ".join(keywords)
+        keywords = keywords.replace(",", ";")
+        keywords = keywords.replace(":", ";")
+
+        # Replace one of the subrows with the new keywords string
+        keywords_replaced = False
+        remove_indexes = []
+        for i, subject in enumerate(row["Subjects"]):
+            if subject["SubjectSchemeIdentifier"] == "Keywords":
+                if not keywords_replaced:
+                    subject["SubjectHeadingText"] = [keywords]
+                    keywords_replaced = True
+                else:
+                    remove_indexes.append(i)
+
+        # Remove additional "keywords" subrows
+        for i in sorted(remove_indexes, reverse=True):
+            del row["Subjects"][i]
+
+    return onix
+
+
+def onix_create_personname_field(onix: List[dict]) -> List[dict]:
+    """Given an ONIX feed, attempts to populate the Contributors.PersonName field by concatenating the
+    Contributors.NamesBeforeKey and Contributors.KeyNames fields where possible
+
+    :param onix: The input onix feed
+    :return: The onix feed with the PersonName field populated where possible
+    """
+
+    def _can_make_personname(contributor: dict) -> bool:
+        return contributor.get("KeyNames") and contributor.get("NamesBeforeKey") and not contributor.get("PersonName")
+
+    for entry in [i for i in onix if i.get("Contributors")]:
+        for c in entry["Contributors"]:
+            if _can_make_personname(c) and not c.get("PersonName"):
+                c["PersonName"] = f"{c['NamesBeforeKey']} {c['KeyNames']}"
+    return onix
+
+
+def onix_parser_download(download_dir: str = observatory_home("bin")) -> Tuple[bool, str]:
+    """Downloads the ONIX parser from Github
+
+    :param download_dir: The directory to download the file to
+    :return: (Whether the download operation was a success, The (expected) location of the downloaded file)
+    """
+    success, _ = download_file(url=OnixParser.url, prefix_dir=download_dir, filename=OnixParser.filename)
+    parser_path = os.path.join(download_dir, OnixParser.filename)
+    success = os.path.isfile(parser_path) if success else success  # Second check for file existence
+    return success, parser_path
+
+
+def onix_parser_execute(parser_path: str, input_dir: str, output_dir: str) -> bool:
+    """Executes the Java ONIX parser. Requires a .xml file in the input directory.
+
+    :param parser_path: Filepath of the parser
+    :param input_dir: The input directory - first argument of the parser
+    :param output_dir: The output directory - second argument of the parser
+    :return: Whether the task succeeded or not (return code 0 means success)
+    """
+    if not glob(os.path.join(input_dir, "*.xml")):
+        logging.error(f"No .xml file found in input directory: {input_dir}")
+        return False
+
+    cmd = OnixParser.cmd.format(parser_path=parser_path, input_dir=input_dir, output_dir=output_dir)
+    process = subprocess.Popen(cmd.split(" "), shell=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    stdout, stderr = wait_for_process(process)
+    if stdout:
+        logging.info(stdout)
+    if process.returncode != 0:
+        logging.error(f"Bash command failed `{cmd}`: {stderr}")
+        return False
+
+    return True

--- a/oaebu_workflows/tests/test_onix.py
+++ b/oaebu_workflows/tests/test_onix.py
@@ -1,0 +1,120 @@
+# Copyright 2023 Curtin University
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Author: Keegan Smith
+
+import os
+import shutil
+from tempfile import TemporaryDirectory
+import json
+from unittest.mock import patch
+
+from oaebu_workflows.onix import (
+    onix_collapse_subjects,
+    onix_create_personname_field,
+    onix_parser_download,
+    onix_parser_execute,
+)
+from oaebu_workflows.config import test_fixtures_folder
+from observatory.platform.observatory_environment import ObservatoryTestCase
+
+
+class TestOnixFunctions(ObservatoryTestCase):
+    """Tests for the ONIX telescope"""
+
+    def __init__(self, *args, **kwargs):
+        """Constructor which sets up variables used by tests.
+
+        :param args: arguments.
+        :param kwargs: keyword arguments.
+        """
+        super(TestOnixFunctions, self).__init__(*args, **kwargs)
+        self.project_id = os.getenv("TEST_GCP_PROJECT_ID")
+        self.data_location = os.getenv("TEST_GCP_DATA_LOCATION")
+        self.onix_test_path = test_fixtures_folder("onix", "20210330_CURTINPRESS_ONIX.xml")
+
+    def test_onix_parser_download_execute(self):
+        """Tests the onix_parser_download and onix_parser_execute functions"""
+        with TemporaryDirectory() as tempdir:
+            ### Test parser download - fails ###
+            with patch("oaebu_workflows.onix.download_file") as mock_download:
+                mock_download.return_value = (False, "")
+                success, parser_path = onix_parser_download(download_dir=tempdir)
+                self.assertEqual(success, False)
+                mock_download.return_value = (True, "/this/path/does/not/exist")
+                success, parser_path = onix_parser_download(download_dir=tempdir)
+                self.assertEqual(success, False)
+
+            ### Test parser download - succeeds ###
+            success, parser_path = onix_parser_download(download_dir=tempdir)
+            self.assertIn(tempdir, parser_path)
+            self.assertEqual(success, True)
+
+            ### Test parser_execute: onix.xml does not exist in input folder ###
+            input_dir = os.path.join(tempdir, "input")
+            output_dir = os.path.join(tempdir, "output")
+            os.mkdir(input_dir)
+            os.mkdir(output_dir)
+            success = onix_parser_execute(parser_path=parser_path, input_dir=input_dir, output_dir=output_dir)
+            self.assertEqual(success, False)
+
+            ### Test parser_execute: nonzero returncode ###
+            shutil.copy(self.onix_test_path, input_dir)
+            with patch("oaebu_workflows.onix.wait_for_process") as mock_wfp:
+                mock_wfp.return_value = ("stdout", "stderr")
+                with patch("oaebu_workflows.onix.subprocess.Popen") as mock_popen:
+                    mock_popen.returncode = 1
+                    success = onix_parser_execute(parser_path=parser_path, input_dir=input_dir, output_dir=output_dir)
+            self.assertEqual(success, False)
+
+            ### Test Case: Successful run ###
+            success = onix_parser_execute(parser_path=parser_path, input_dir=input_dir, output_dir=output_dir)
+            output_file = os.path.join(output_dir, "full.jsonl")
+            self.assertEqual(success, True)
+            self.assertTrue(os.path.isfile(output_file))
+            self.assert_file_integrity(output_file, "84d46e2942df615f18d270e18e0ebb26", "md5")
+
+    def test_onix_collapse_subjects(self):
+        """Tests the thoth_collapse_subjects function"""
+        test_subjects_input = os.path.join(test_fixtures_folder("onix"), "test_subjects_input.json")
+        test_subjects_expected = os.path.join(test_fixtures_folder("onix"), "test_subjects_expected.json")
+        with open(test_subjects_input, "r") as f:
+            onix = json.load(f)
+        actual_onix = onix_collapse_subjects(onix)
+        with open(test_subjects_expected, "r") as f:
+            expected_onix = json.load(f)
+
+        self.assertEqual(len(actual_onix), len(expected_onix))
+        self.assertEqual(json.dumps(actual_onix, sort_keys=True), json.dumps(expected_onix, sort_keys=True))
+
+    def test_onix_create_personname_field(self):
+        """Tests the function that creates the personname field"""
+        input_onix = [
+            {"Contributors": [{"PersonName": "John Doe", "KeyNames": None, "NamesBeforeKey": None}]},
+            {"Contributors": [{"PersonName": None, "KeyNames": "Doe", "NamesBeforeKey": "John"}]},
+            {"Contributors": [{"PersonName": None, "KeyNames": "Doe", "NamesBeforeKey": None}]},
+            {"Contributors": [{"PersonName": None, "KeyNames": None, "NamesBeforeKey": None}]},
+            {"empty": "empty"},
+        ]
+        expected_out = [
+            {"Contributors": [{"PersonName": "John Doe", "KeyNames": None, "NamesBeforeKey": None}]},
+            {"Contributors": [{"PersonName": "John Doe", "KeyNames": "Doe", "NamesBeforeKey": "John"}]},
+            {"Contributors": [{"PersonName": None, "KeyNames": "Doe", "NamesBeforeKey": None}]},
+            {"Contributors": [{"PersonName": None, "KeyNames": None, "NamesBeforeKey": None}]},
+            {"empty": "empty"},
+        ]
+        output_onix = onix_create_personname_field(input_onix)
+        self.assertEqual(len(output_onix), len(expected_out))
+        for actual, expected in zip(output_onix, expected_out):
+            self.assertDictEqual(actual, expected)

--- a/oaebu_workflows/workflows/tests/test_oapen_metadata_telescope.py
+++ b/oaebu_workflows/workflows/tests/test_oapen_metadata_telescope.py
@@ -27,14 +27,12 @@ from airflow.utils.state import State
 
 from oaebu_workflows.config import test_fixtures_folder
 from oaebu_workflows.workflows.oapen_metadata_telescope import (
-    OapenMetadataRelease,
     OapenMetadataTelescope,
     download_oapen_metadata,
     oapen_metadata_parse,
     remove_invalid_products,
     find_onix_product,
     process_xml_element,
-    create_personname_field,
 )
 from observatory.platform.api import get_dataset_releases
 from observatory.platform.observatory_config import Workflow
@@ -372,24 +370,3 @@ class TestOapenMetadataTelescope(ObservatoryTestCase):
         assert (
             expected_xml == test_xml
         ), f"Processed XML is not equal to expected XML. Expected {expected_xml}, got {test_xml}"
-
-    def test_create_personname_field(self):
-        """Tests the function that creates the personname field"""
-        input_onix = [
-            {"Contributors": [{"PersonName": "John Doe", "KeyNames": None, "NamesBeforeKey": None}]},
-            {"Contributors": [{"PersonName": None, "KeyNames": "Doe", "NamesBeforeKey": "John"}]},
-            {"Contributors": [{"PersonName": None, "KeyNames": "Doe", "NamesBeforeKey": None}]},
-            {"Contributors": [{"PersonName": None, "KeyNames": None, "NamesBeforeKey": None}]},
-            {"empty": "empty"},
-        ]
-        expected_out = [
-            {"Contributors": [{"PersonName": "John Doe", "KeyNames": None, "NamesBeforeKey": None}]},
-            {"Contributors": [{"PersonName": "John Doe", "KeyNames": "Doe", "NamesBeforeKey": "John"}]},
-            {"Contributors": [{"PersonName": None, "KeyNames": "Doe", "NamesBeforeKey": None}]},
-            {"Contributors": [{"PersonName": None, "KeyNames": None, "NamesBeforeKey": None}]},
-            {"empty": "empty"},
-        ]
-        output_onix = create_personname_field(input_onix)
-        self.assertEqual(len(output_onix), len(expected_out))
-        for actual, expected in zip(output_onix, expected_out):
-            self.assertDictEqual(actual, expected)


### PR DESCRIPTION
Originally I had attempted to alter the ONIX parser execution to use a BashOperator, rather than pipe the command to a subprocss in python. This proved to be unexpectedly difficult for many reasons. This may be an easier task once we upgrade airflow and have access to dynamic tasks. For now, I have updated the parser call to run without the shell environment (shell=False).

I have consolidated the onix-related functions into a new file called onix.py. The reason for this is that there are three telescopes that use common onix related functions and I would prefer not to have to import a function from a telescope in another telescope.

Due to the recent refactor, the sftp file directories have changed. This necessitates a change to both the sftp server directories and also the sftp root directory in the onix telescope. With the consideration that the SftpFolders class now generates a unique folder based on the dag_id, I think that it is unnecessarily complex to have an alternate sftp root directory for each onix telescope. Therefore, I have set the default to the root of the filesystem ("/"). Should we require more functionality, this will need to be changed, but it is not in the foreseeable future.