### PR TITLE
Fixed the file matching regex

### DIFF
--- a/oaebu_workflows/workflows/onix_telescope.py
+++ b/oaebu_workflows/workflows/onix_telescope.py
@@ -153,7 +153,7 @@ class OnixTelescope(Workflow):
         with make_sftp_connection(self.sftp_service_conn_id) as sftp:
             files = sftp.listdir(self.sftp_folders.upload)
             for file_name in files:
-                if re.match(self.date_regex, file_name):
+                if re.match(r"^.*\.(onx|xml)$", file_name):
                     try:
                         date_str = re.search(self.date_regex, file_name).group(0)
                     except AttributeError:


### PR DESCRIPTION
The date matching regex was being used for the file match on the server onix files. This would not match on the file as it's meant to be used as a search. I altered the regex match to just match on the entire files