### PR TITLE
Added the LCCN column to the ONIX schema

### DIFF
--- a/oaebu_workflows/database/schema/onix.json
+++ b/oaebu_workflows/database/schema/onix.json
@@ -18,6 +18,12 @@
     "description": "An ONIX description which indicates the type of source which has issued the ONIX record. Optional and non-\nrepeating, independently of the occurrence of any other field."
   },
   {
+    "mode": "NULLABLE",
+    "name": "LCCN",
+    "type": "STRING",
+    "description": "Library of Congress Control Number"
+  },
+  {
     "fields": [
       {
         "fields": [

--- a/oaebu_workflows/fixtures/oapen_metadata/oapen_metadata_parsed.json
+++ b/oaebu_workflows/fixtures/oapen_metadata/oapen_metadata_parsed.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8930e8000ba6262cdb841875049bbc8379d98430cce28a66f13f2db0264bbbde
+size 10083

--- a/oaebu_workflows/fixtures/onix/20210330_CURTINPRESS_ONIX.json
+++ b/oaebu_workflows/fixtures/onix/20210330_CURTINPRESS_ONIX.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:674430921fdd4219041950f15e4aed210f6f6dc93d6516c73ad6945526f86df1
+size 9360

--- a/oaebu_workflows/fixtures/thoth/test_table.json
+++ b/oaebu_workflows/fixtures/thoth/test_table.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5992f1ca7557f2453057cf3dd4a51067e95b53368aa1ad1b4d227168819767d6
+size 24358

--- a/oaebu_workflows/fixtures/thoth/test_table.jsonl
+++ b/oaebu_workflows/fixtures/thoth/test_table.jsonl
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6dc6cafeb30e8992b1e49c54e52c62118712a2d47f81d3e2fc859fc795b68f67
-size 24334

--- a/oaebu_workflows/workflows/tests/test_oapen_metadata_telescope.py
+++ b/oaebu_workflows/workflows/tests/test_oapen_metadata_telescope.py
@@ -38,7 +38,12 @@ from observatory.platform.api import get_dataset_releases
 from observatory.platform.observatory_config import Workflow
 from observatory.platform.gcs import gcs_blob_name_from_path
 from observatory.platform.bigquery import bq_sharded_table_id
-from observatory.platform.observatory_environment import ObservatoryEnvironment, ObservatoryTestCase, find_free_port
+from observatory.platform.observatory_environment import (
+    ObservatoryEnvironment,
+    ObservatoryTestCase,
+    find_free_port,
+    load_and_parse_json,
+)
 
 
 class TestOapenMetadataTelescope(ObservatoryTestCase):
@@ -63,7 +68,7 @@ class TestOapenMetadataTelescope(ObservatoryTestCase):
             "oapen_metadata", "oapen_metadata_cassette_header_only.yaml"
         )
 
-        # XML files for testing
+        # Files for testing
         self.valid_download_xml = test_fixtures_folder("oapen_metadata", "oapen_metadata_download_valid.xml")
         self.invalid_download_xml = test_fixtures_folder("oapen_metadata", "oapen_metadata_download_invalid.xml")
         self.empty_xml = test_fixtures_folder("oapen_metadata", "oapen_metadata_download_empty.xml")
@@ -73,6 +78,7 @@ class TestOapenMetadataTelescope(ObservatoryTestCase):
         self.processing_test_before = test_fixtures_folder("oapen_metadata", "processing_test_before.xml")
         self.processing_test_after = test_fixtures_folder("oapen_metadata", "processing_test_after.xml")
         self.invalid_products_xml = test_fixtures_folder("oapen_metadata", "oapen_metadata_invalid_products.xml")
+        self.parsed_json = test_fixtures_folder("oapen_metadata", "oapen_metadata_parsed.json")
         # Valid fields json for the xml processing test
         self.processing_test_fields = test_fixtures_folder("oapen_metadata", "processing_test_valid_fields.json")
 
@@ -204,6 +210,7 @@ class TestOapenMetadataTelescope(ObservatoryTestCase):
                     release.snapshot_date,
                 )
                 self.assert_table_integrity(table_id, expected_rows=2)
+                self.assert_table_content(table_id, load_and_parse_json(self.parsed_json), primary_key="ISBN13")
 
                 # Add_dataset_release_task
                 dataset_releases = get_dataset_releases(dag_id=telescope.dag_id, dataset_id=telescope.api_dataset_id)

--- a/oaebu_workflows/workflows/tests/test_thoth_telescope.py
+++ b/oaebu_workflows/workflows/tests/test_thoth_telescope.py
@@ -58,7 +58,7 @@ class TestThothTelescope(ObservatoryTestCase):
 
         # Fixtures
         self.download_cassette = os.path.join(test_fixtures_folder("thoth"), "thoth_download_cassette.yaml")
-        self.test_table = os.path.join(test_fixtures_folder("thoth"), "test_table.jsonl")
+        self.test_table = os.path.join(test_fixtures_folder("thoth"), "test_table.json")
 
     def test_dag_structure(self):
         """Test that the ONIX DAG has the correct structure."""
@@ -177,7 +177,7 @@ class TestThothTelescope(ObservatoryTestCase):
                     release.snapshot_date,
                 )
                 self.assert_table_integrity(table_id, expected_rows=2)
-                self.assert_table_content(table_id, load_and_parse_json(self.test_table), primary_key="DOI")
+                self.assert_table_content(table_id, load_and_parse_json(self.test_table), primary_key="ISBN13")
 
                 # add_dataset_release_task
                 dataset_releases = get_dataset_releases(dag_id=telescope.dag_id, dataset_id=telescope.api_dataset_id)


### PR DESCRIPTION
Added a new field to the ONIX schema: "Library of Congress Control Number"
This is a field that is parsed by the ONIX parser, but we've not come across it until now because ebooks can't have a LCCN. #146 removed the filter and now we are parsing non-ebooks. 