### PR TITLE
Fixed GA partition date and added tests

### DIFF
--- a/oaebu_workflows/fixtures/google_analytics/test_table.json
+++ b/oaebu_workflows/fixtures/google_analytics/test_table.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e710bd4f4fabb23925ba5dee504aeb7be6a5b7e9fc04fa252c41c1f767aca5c5
+size 4333

--- a/oaebu_workflows/fixtures/google_analytics/test_table_anu.json
+++ b/oaebu_workflows/fixtures/google_analytics/test_table_anu.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b527970796c8a63c9f54ae1ad4153c4be723cc952f1875925af26b88bdf51697
+size 5061

--- a/oaebu_workflows/workflows/google_analytics_telescope.py
+++ b/oaebu_workflows/workflows/google_analytics_telescope.py
@@ -202,7 +202,7 @@ class GoogleAnalyticsTelescope(Workflow):
                 ),  # Subtract 1 day because GA uses inclusive dates, Airlfow data intervals are not
             )
             results = add_partition_date(
-                results, release.data_interval_end, TimePartitioningType.MONTH, partition_field="release_date"
+                results, release.partition_date, TimePartitioningType.MONTH, partition_field="release_date"
             )
             if results:
                 save_jsonl_gz(release.transform_path, results)

--- a/oaebu_workflows/workflows/tests/test_google_analytics_telescope.py
+++ b/oaebu_workflows/workflows/tests/test_google_analytics_telescope.py
@@ -26,6 +26,7 @@ from googleapiclient.discovery import build
 from googleapiclient.http import HttpMockSequence
 
 from oaebu_workflows.workflows.google_analytics_telescope import GoogleAnalyticsTelescope
+from oaebu_workflows.config import test_fixtures_folder
 from observatory.platform.api import get_dataset_releases
 from observatory.platform.observatory_config import Workflow
 from observatory.platform.gcs import gcs_blob_name_from_path
@@ -34,6 +35,7 @@ from observatory.platform.observatory_environment import (
     ObservatoryEnvironment,
     ObservatoryTestCase,
     find_free_port,
+    load_and_parse_json,
 )
 
 
@@ -51,6 +53,8 @@ class TestGoogleAnalyticsTelescope(ObservatoryTestCase):
         self.view_id = "11235141"
         self.pagepath_regex = r".*regex$"
         self.organisation_name = "UCL Press"
+        self.test_table = os.path.join(test_fixtures_folder("google_analytics"), "test_table.json")
+        self.test_table_anu = os.path.join(test_fixtures_folder("google_analytics"), "test_table_anu.json")
 
     def test_dag_structure(self):
         """Test that the Google Analytics DAG has the correct structure.
@@ -253,6 +257,11 @@ class TestGoogleAnalyticsTelescope(ObservatoryTestCase):
                     telescope.cloud_workspace.project_id, telescope.bq_dataset_id, telescope.bq_table_name
                 )
                 self.assert_table_integrity(table_id, expected_rows=3)
+                self.assert_table_content(
+                    table_id,
+                    load_and_parse_json(self.test_table, date_fields=["release_date", "start_date", "end_date"]),
+                    primary_key="url",
+                )
 
                 # Add_dataset_release_task
                 dataset_releases = get_dataset_releases(dag_id=telescope.dag_id, dataset_id=telescope.api_dataset_id)
@@ -429,6 +438,11 @@ class TestGoogleAnalyticsTelescope(ObservatoryTestCase):
                     telescope.cloud_workspace.project_id, telescope.bq_dataset_id, telescope.bq_table_name
                 )
                 self.assert_table_integrity(table_id, expected_rows=3)
+                self.assert_table_content(
+                    table_id,
+                    load_and_parse_json(self.test_table_anu, date_fields=["release_date", "start_date", "end_date"]),
+                    primary_key="url",
+                )
 
                 # add_dataset_release_task
                 dataset_releases = get_dataset_releases(dag_id=telescope.dag_id, dataset_id=telescope.api_dataset_id)


### PR DESCRIPTION
The partition date was incorrectly set as the data_interval_end rather than the data_interval start. This caused the GA telescope's release date to be one month ahead of what it was supposed to be. 
I added some test files and an assertion to avoid scenarios like this in the future.