### PR TITLE
Removed additional table load in test

### DIFF
--- a/oaebu_workflows/workflows/tests/test_oapen_metadata_telescope.py
+++ b/oaebu_workflows/workflows/tests/test_oapen_metadata_telescope.py
@@ -201,8 +201,6 @@ class TestOapenMetadataTelescope(ObservatoryTestCase):
                 )
 
                 # Test that table is loaded to BQ
-                ti = env.run_task(telescope.bq_load.__name__)
-                self.assertEqual(ti.state, State.SUCCESS)
                 table_id = bq_sharded_table_id(
                     telescope.cloud_workspace.project_id,
                     telescope.bq_dataset_id,


### PR DESCRIPTION
The PR from the observatory platform (The-Academic-Observatory/observatory-platform#623) has revealed a small bug in one of the oapen metadata telescope tests. This PR fixes it.