### PR TITLE
Added InvertedPersonName field

### DIFF
--- a/oaebu_workflows/database/schema/book_product.json
+++ b/oaebu_workflows/database/schema/book_product.json
@@ -73,7 +73,13 @@
             "mode": "NULLABLE",
             "name": "PersonName",
             "type": "STRING",
-            "description": "The Authors Full Name"
+            "description": "The Author's Full Name in the format '[first name] [last name]'"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "PersonNameInverted",
+            "type": "STRING",
+            "description": "The Authors Full Name in the format '[last name], [first name]'"
           },
           {
             "mode": "NULLABLE",

--- a/oaebu_workflows/database/schema/oaebu_publisher_book_product_author_metrics.json
+++ b/oaebu_workflows/database/schema/oaebu_publisher_book_product_author_metrics.json
@@ -3,7 +3,13 @@
     "mode": "NULLABLE",
     "name": "PersonName",
     "type": "STRING",
-    "description": "Author's Name"
+    "description": "The author's full name in the format '[first name] [last name]'"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "PersonNameInverted",
+    "type": "STRING",
+    "description": "The author's full name in the format '[last name], [first name]'"
   },
   {
     "mode": "NULLABLE",

--- a/oaebu_workflows/database/schema/oaebu_publisher_book_product_list.json
+++ b/oaebu_workflows/database/schema/oaebu_publisher_book_product_list.json
@@ -76,5 +76,31 @@
     "name": "keywords",
     "type": "STRING",
     "description": "A list of keywords"
+  },
+  {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "PersonName",
+        "type": "STRING",
+        "description": "The author's full name in the format '[first name] [last name]'"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "PersonNameInverted",
+        "type": "STRING",
+        "description": "The author's full name in the format '[last name], [first name]'"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "ORCID",
+        "type": "STRING",
+        "description": "The Authors ORCID ID"
+      }
+    ],
+    "mode": "REPEATED",
+    "name": "authors",
+    "type": "RECORD",
+    "description": "A list of Book Authors"
   }
 ]

--- a/oaebu_workflows/database/schema/oaebu_publisher_book_product_metrics.json
+++ b/oaebu_workflows/database/schema/oaebu_publisher_book_product_metrics.json
@@ -29,7 +29,13 @@
         "mode": "NULLABLE",
         "name": "PersonName",
         "type": "STRING",
-        "description": "The Author's Name"
+        "description": "The author's full name in the format '[first name] [last name]'"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "PersonNameInverted",
+        "type": "STRING",
+        "description": "The author's full name in the format '[last name], [first name]'"
       },
       {
         "mode": "NULLABLE",

--- a/oaebu_workflows/database/sql/create_book_products.sql.jinja2
+++ b/oaebu_workflows/database/sql/create_book_products.sql.jinja2
@@ -460,7 +460,7 @@ onix_ebook_titles_raw as (
             (SELECT
                 ARRAY(
                     SELECT as STRUCT
-                        PersonName, ORCID
+                        PersonName, PersonNameInverted, ORCID
                     FROM UNNEST(onix.Contributors) as contributor
                 )
             ) as authors

--- a/oaebu_workflows/database/sql/export_book_author_metrics.sql.jinja2
+++ b/oaebu_workflows/database/sql/export_book_author_metrics.sql.jinja2
@@ -26,6 +26,7 @@ CREATE TEMP FUNCTION group_counts(counts ARRAY<STRUCT<name STRING, value INT64>>
 
 SELECT
     author.PersonName,
+    MAX(author.PersonNameInverted) as PersonNameInverted,
     MAX(author.ORCID) as orcid,
     count(ISBN13) as unique_books,
     month.month,

--- a/oaebu_workflows/database/sql/export_book_list.sql.jinja2
+++ b/oaebu_workflows/database/sql/export_book_list.sql.jinja2
@@ -31,5 +31,6 @@ SELECT
     onix.bic_subjects,
     onix.bisac_subjects,
     onix.thema_subjects,
-    onix.keywords
+    onix.keywords,
+    onix.authors
 FROM `{{ book_product_table_id }}`

--- a/oaebu_workflows/fixtures/oapen_metadata/test_table.json
+++ b/oaebu_workflows/fixtures/oapen_metadata/test_table.json
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ac5d2396c8f0ca22ba624ca9be009ec88efcec870a8916bf1b428dcb50df60b7
-size 14774
+oid sha256:26a0d93b56fbfede3a9de66c614ad9943041d5c9acd25d51443dae0003622c39
+size 14834

--- a/oaebu_workflows/fixtures/onix_workflow/e2e_inputs/onix.jsonl
+++ b/oaebu_workflows/fixtures/onix_workflow/e2e_inputs/onix.jsonl
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5ad211532482c4a2920f86aad95924ced884e7220c0fc200dbdb6988d1785502
-size 1611
+oid sha256:e58bc98d322590f4ac7dfdbcc2579fff047fe0b9e879d6a856d44a414f574870
+size 1852

--- a/oaebu_workflows/fixtures/onix_workflow/e2e_outputs/book_product.json
+++ b/oaebu_workflows/fixtures/onix_workflow/e2e_outputs/book_product.json
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:efe4817976826fcd49d8e3b873d3f3d8f8b13224bc7828fb36dce3ef22385673
-size 43944
+oid sha256:1e6b925f9108d2d57ff2c692579e6c1aec65fa934ac968bd2ab9909f20837da2
+size 44312

--- a/oaebu_workflows/fixtures/onix_workflow/e2e_outputs/book_product_ga.json
+++ b/oaebu_workflows/fixtures/onix_workflow/e2e_outputs/book_product_ga.json
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:456101aa11aa4ff1d3dc93a59448148d37a66f31e23785395ab5899c5d6e06ce
-size 45762
+oid sha256:c82336d93cea0006d0e8f0888b7a04a933dd06518442bff5d530254be97a73e3
+size 46130

--- a/oaebu_workflows/fixtures/onix_workflow/e2e_outputs/book_product_list.json
+++ b/oaebu_workflows/fixtures/onix_workflow/e2e_outputs/book_product_list.json
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6a649c71d53b3003b2c3f0862fe4b2e78efefe2bc7bd868ef6cc82873f403fd7
-size 1741
+oid sha256:dd23bb8891b00ab3e4c98f41b5b7af19a912ad454b13c2dc548cf75a5f21c5c9
+size 2153

--- a/oaebu_workflows/fixtures/thoth/test_table.json
+++ b/oaebu_workflows/fixtures/thoth/test_table.json
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5992f1ca7557f2453057cf3dd4a51067e95b53368aa1ad1b4d227168819767d6
-size 24358
+oid sha256:a53a747d7aa31e9b46bca83849b8af3b72142fd077c84041d04daaa40e4ac155
+size 24401

--- a/oaebu_workflows/onix.py
+++ b/oaebu_workflows/onix.py
@@ -80,21 +80,26 @@ def onix_collapse_subjects(onix: List[dict]) -> List[dict]:
     return onix
 
 
-def onix_create_personname_field(onix: List[dict]) -> List[dict]:
-    """Given an ONIX feed, attempts to populate the Contributors.PersonName field by concatenating the
-    Contributors.NamesBeforeKey and Contributors.KeyNames fields where possible
+def onix_create_personname_fields(onix: List[dict]) -> List[dict]:
+    """Given an ONIX feed, attempts to populate the Contributors.PersonName and/or Contributors.PersonNameInverted
+    fields by concatenating the Contributors.NamesBeforeKey and Contributors.KeyNames fields where possible
 
     :param onix: The input onix feed
-    :return: The onix feed with the PersonName field populated where possible
+    :return: The onix feed with the additional fields populated where possible
     """
 
     def _can_make_personname(contributor: dict) -> bool:
-        return contributor.get("KeyNames") and contributor.get("NamesBeforeKey") and not contributor.get("PersonName")
+        return contributor.get("KeyNames") and contributor.get("NamesBeforeKey")
+
+    def _can_make_personname_inverted(contributor: dict) -> bool:
+        return contributor.get("NamesBeforeKey") and contributor.get("KeyNames")
 
     for entry in [i for i in onix if i.get("Contributors")]:
         for c in entry["Contributors"]:
             if _can_make_personname(c) and not c.get("PersonName"):
                 c["PersonName"] = f"{c['NamesBeforeKey']} {c['KeyNames']}"
+            if _can_make_personname_inverted(c) and not c.get("PersonNameInverted"):
+                c["PersonNameInverted"] = f"{c['KeyNames']}, {c['NamesBeforeKey']}"
     return onix
 
 

--- a/oaebu_workflows/tests/test_onix.py
+++ b/oaebu_workflows/tests/test_onix.py
@@ -22,7 +22,7 @@ from unittest.mock import patch
 
 from oaebu_workflows.onix import (
     onix_collapse_subjects,
-    onix_create_personname_field,
+    onix_create_personname_fields,
     onix_parser_download,
     onix_parser_execute,
 )
@@ -98,23 +98,65 @@ class TestOnixFunctions(ObservatoryTestCase):
         self.assertEqual(len(actual_onix), len(expected_onix))
         self.assertEqual(json.dumps(actual_onix, sort_keys=True), json.dumps(expected_onix, sort_keys=True))
 
-    def test_onix_create_personname_field(self):
+    def test_onix_create_personname_fields(self):
         """Tests the function that creates the personname field"""
         input_onix = [
-            {"Contributors": [{"PersonName": "John Doe", "KeyNames": None, "NamesBeforeKey": None}]},
-            {"Contributors": [{"PersonName": None, "KeyNames": "Doe", "NamesBeforeKey": "John"}]},
-            {"Contributors": [{"PersonName": None, "KeyNames": "Doe", "NamesBeforeKey": None}]},
-            {"Contributors": [{"PersonName": None, "KeyNames": None, "NamesBeforeKey": None}]},
+            {
+                "Contributors": [
+                    {"PersonName": "John Doe", "PersonNameInverted": None, "KeyNames": None, "NamesBeforeKey": None}
+                ]
+            },
+            {
+                "Contributors": [
+                    {"PersonName": None, "PersonNameInverted": None, "KeyNames": "Doe", "NamesBeforeKey": "John"}
+                ]
+            },
+            {
+                "Contributors": [
+                    {"PersonName": None, "PersonNameInverted": "Doe, John", "KeyNames": "Doe", "NamesBeforeKey": None}
+                ]
+            },
+            {
+                "Contributors": [
+                    {"PersonName": None, "PersonNameInverted": None, "KeyNames": None, "NamesBeforeKey": None}
+                ]
+            },
             {"empty": "empty"},
         ]
         expected_out = [
-            {"Contributors": [{"PersonName": "John Doe", "KeyNames": None, "NamesBeforeKey": None}]},
-            {"Contributors": [{"PersonName": "John Doe", "KeyNames": "Doe", "NamesBeforeKey": "John"}]},
-            {"Contributors": [{"PersonName": None, "KeyNames": "Doe", "NamesBeforeKey": None}]},
-            {"Contributors": [{"PersonName": None, "KeyNames": None, "NamesBeforeKey": None}]},
+            {
+                "Contributors": [
+                    {
+                        "PersonName": "John Doe",
+                        "PersonNameInverted": None,
+                        "KeyNames": None,
+                        "NamesBeforeKey": None,
+                    }
+                ]
+            },
+            {
+                "Contributors": [
+                    {
+                        "PersonName": "John Doe",
+                        "PersonNameInverted": "Doe, John",
+                        "KeyNames": "Doe",
+                        "NamesBeforeKey": "John",
+                    }
+                ]
+            },
+            {
+                "Contributors": [
+                    {"PersonName": None, "PersonNameInverted": "Doe, John", "KeyNames": "Doe", "NamesBeforeKey": None}
+                ]
+            },
+            {
+                "Contributors": [
+                    {"PersonName": None, "PersonNameInverted": None, "KeyNames": None, "NamesBeforeKey": None}
+                ]
+            },
             {"empty": "empty"},
         ]
-        output_onix = onix_create_personname_field(input_onix)
+        output_onix = onix_create_personname_fields(input_onix)
         self.assertEqual(len(output_onix), len(expected_out))
         for actual, expected in zip(output_onix, expected_out):
             self.assertDictEqual(actual, expected)

--- a/oaebu_workflows/workflows/oapen_metadata_telescope.py
+++ b/oaebu_workflows/workflows/oapen_metadata_telescope.py
@@ -42,7 +42,7 @@ from oaebu_workflows.config import schema_folder as default_schema_folder
 from oaebu_workflows.onix import (
     onix_parser_download,
     onix_parser_execute,
-    onix_create_personname_field,
+    onix_create_personname_fields,
 )
 from observatory.api.client.model.dataset_release import DatasetRelease
 from observatory.platform.api import make_observatory_api
@@ -225,7 +225,7 @@ class OapenMetadataTelescope(Workflow):
             set_task_state(success, task_id=kwargs["ti"].task_id, release=release)
 
         # Add the Contributors.PersonName field
-        onix = onix_create_personname_field(load_jsonl(release.parsed_onix))
+        onix = onix_create_personname_fields(load_jsonl(release.parsed_onix))
         save_jsonl_gz(release.transform_path, onix)
 
     def upload_transformed(self, release: OapenMetadataRelease, **kwargs) -> None:

--- a/oaebu_workflows/workflows/tests/test_onix_workflow.py
+++ b/oaebu_workflows/workflows/tests/test_onix_workflow.py
@@ -1105,7 +1105,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
                 self.assertEqual(records[0]["no_relatedproducts"], 3)
                 self.assertEqual(records[0]["no_doi"], 4)
                 self.assertEqual(records[0]["no_productform"], 0)
-                self.assertEqual(records[0]["no_contributors"], 4)
+                self.assertEqual(records[0]["no_contributors"], 2)
                 self.assertEqual(records[0]["no_titledetails"], 4)
                 self.assertEqual(records[0]["no_publisher_urls"], 4)
 
@@ -1176,7 +1176,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
                     ("book_product_subject_thema_metrics", 0),
                     ("book_product_year_metrics", 2),
                     ("book_product_subject_year_metrics", 0),
-                    ("book_product_author_metrics", 0),
+                    ("book_product_author_metrics", 1),
                 ]
 
                 export_prefix = self.gcp_project_id.replace("-", "_")

--- a/oaebu_workflows/workflows/tests/test_thoth_telescope.py
+++ b/oaebu_workflows/workflows/tests/test_thoth_telescope.py
@@ -162,7 +162,7 @@ class TestThothTelescope(ObservatoryTestCase):
                 )
 
                 # Transformed file
-                self.assert_file_integrity(release.transform_path, "f384ecd8", "gzip_crc")
+                self.assert_file_integrity(release.transform_path, "1b12c3a9", "gzip_crc")
 
                 # Uploaded transform blob
                 self.assert_blob_integrity(

--- a/oaebu_workflows/workflows/thoth_telescope.py
+++ b/oaebu_workflows/workflows/thoth_telescope.py
@@ -25,7 +25,7 @@ from oaebu_workflows.onix import (
     onix_parser_download,
     onix_parser_execute,
     onix_collapse_subjects,
-    onix_create_personname_field,
+    onix_create_personname_fields,
 )
 from oaebu_workflows.config import schema_folder as default_schema_folder
 from observatory.api.client.model.dataset_release import DatasetRelease
@@ -178,9 +178,8 @@ class ThothTelescope(Workflow):
             parser_path, input_dir=release.download_folder, output_dir=release.transform_folder
         )
         set_task_state(success, task_id=kwargs["ti"].task_id, release=release)
-        logging.info("Transforming onix feed - collapsing keywords")
         transformed = onix_collapse_subjects(load_jsonl(os.path.join(release.transform_folder, "full.jsonl")))
-        transformed = onix_create_personname_field(transformed)
+        transformed = onix_create_personname_fields(transformed)
         save_jsonl_gz(release.transform_path, transformed)
 
     def upload_transformed(self, release: ThothRelease, **kwargs) -> None:


### PR DESCRIPTION
Added the InvertedPersonName fields to the book_product table. This flows through to the author_metrics export table. Much like the PersonName field, this field is created for the oapen_metadata and thoth feeds where possible by concatenating the first and last names.

Also added the author information to the book_product_list export table.