### PR TITLE
templated ga3 views type

### DIFF
--- a/oaebu_workflows/database/sql/create_book_products.sql.jinja2
+++ b/oaebu_workflows/database/sql/create_book_products.sql.jinja2
@@ -351,7 +351,7 @@ empty_google_analytics as (
         CAST(null as STRING) as publication_format,
         STRUCT(
             [STRUCT(CAST(NULL as STRING) as name, CAST(null as INT64) as value)] as country
-        ) as page_views
+        ) as {{ ga3_views_field }}
 ),
 
 empty_internet_archive as (
@@ -500,51 +500,51 @@ google_analytics_grouped_metrics AS(
   IF
     (publication_format = 'PDF'
       AND publication_whole_or_part = 'whole',
-      group_items_google_analytics(ARRAY_CONCAT_AGG(page_views.country)),
+      group_items_google_analytics(ARRAY_CONCAT_AGG({{ ga3_views_field }}.country)),
       ARRAY_AGG(STRUCT(CAST(NULL as STRING) as name, CAST(null as INT64) as value))) AS pdf_book_country,
   IF
     (publication_format = 'PDF'
       AND publication_whole_or_part = 'part',
-      group_items_google_analytics(ARRAY_CONCAT_AGG(page_views.country)),
+      group_items_google_analytics(ARRAY_CONCAT_AGG({{ ga3_views_field }}.country)),
       ARRAY_AGG(STRUCT(CAST(NULL as STRING) as name, CAST(null as INT64) as value))) AS pdf_chapter_country,
   IF
     (publication_format = 'HTML'
       AND publication_whole_or_part = 'whole',
-      group_items_google_analytics(ARRAY_CONCAT_AGG(page_views.country)),
+      group_items_google_analytics(ARRAY_CONCAT_AGG({{ ga3_views_field }}.country)),
       ARRAY_AGG(STRUCT(CAST(NULL as STRING) as name, CAST(null as INT64) as value))) AS html_book_country,
   IF
     (publication_format = 'HTML'
       AND publication_whole_or_part = 'part',
-      group_items_google_analytics(ARRAY_CONCAT_AGG(page_views.country)),
+      group_items_google_analytics(ARRAY_CONCAT_AGG({{ ga3_views_field }}.country)),
       ARRAY_AGG(STRUCT(CAST(NULL as STRING) as name, CAST(null as INT64) as value))) AS html_chapter_country,
   IF
     (publication_format = 'EPUB'
       AND publication_whole_or_part = 'whole',
-      group_items_google_analytics(ARRAY_CONCAT_AGG(page_views.country)),
+      group_items_google_analytics(ARRAY_CONCAT_AGG({{ ga3_views_field }}.country)),
       ARRAY_AGG(STRUCT(CAST(NULL as STRING) as name, CAST(null as INT64) as value))) AS epub_book_country,
   IF
     (publication_format = 'EPUB'
       AND publication_whole_or_part = 'part',
-      group_items_google_analytics(ARRAY_CONCAT_AGG(page_views.country)),
+      group_items_google_analytics(ARRAY_CONCAT_AGG({{ ga3_views_field }}.country)),
       ARRAY_AGG(STRUCT(CAST(NULL as STRING) as name, CAST(null as INT64) as value))) AS epub_chapter_country,
   IF
     (publication_format = 'MOBI'
       AND publication_whole_or_part = 'whole',
-      group_items_google_analytics(ARRAY_CONCAT_AGG(page_views.country)),
+      group_items_google_analytics(ARRAY_CONCAT_AGG({{ ga3_views_field }}.country)),
       ARRAY_AGG(STRUCT(CAST(NULL as STRING) as name, CAST(null as INT64) as value))) AS mobi_book_country,
   IF
     (publication_format = 'MOBI'
       AND publication_whole_or_part = 'part',
-      group_items_google_analytics(ARRAY_CONCAT_AGG(page_views.country)),
+      group_items_google_analytics(ARRAY_CONCAT_AGG({{ ga3_views_field }}.country)),
       ARRAY_AGG(STRUCT(CAST(NULL as STRING) as name, CAST(null as INT64) as value))) AS mobi_chapter_country,
   IF
     (publication_format IN ('PDF','HTML', 'EPUB', 'MOBI')
       AND publication_whole_or_part IN ('whole', 'part'),
-      group_items_google_analytics(ARRAY_CONCAT_AGG(page_views.country)),
+      group_items_google_analytics(ARRAY_CONCAT_AGG({{ ga3_views_field }}.country)),
       ARRAY_AGG(STRUCT(CAST(NULL as STRING) as name, CAST(null as INT64) as value))) AS downloads_total_country,
   IF
     (publication_whole_or_part = '(citation)',
-      group_items_google_analytics(ARRAY_CONCAT_AGG(page_views.country)),
+      group_items_google_analytics(ARRAY_CONCAT_AGG({{ ga3_views_field }}.country)),
       ARRAY_AGG(STRUCT(CAST(NULL as STRING) as name, CAST(null as INT64) as value))) AS views_total_country,
   FROM
     `{{ google_analytics_table_id }}`

--- a/oaebu_workflows/workflows/onix_workflow.py
+++ b/oaebu_workflows/workflows/onix_workflow.py
@@ -152,6 +152,7 @@ class OnixWorkflow(Workflow):
         oaebu_intermediate_match_suffix: str = "_matched",
         # Run parameters
         data_partners: List[Union[str, OaebuPartner]] = None,
+        ga3_views_field="page_views",
         schema_folder: str = default_schema_folder(),
         mailto: str = "agent@observatory.academy",
         crossref_start_date: pendulum.DateTime = pendulum.datetime(2018, 5, 14),
@@ -198,6 +199,7 @@ class OnixWorkflow(Workflow):
         :param oaebu_intermediate_match_suffix: Suffix to append to intermediate tables
 
         :param data_partners: OAEBU data sources.
+        :param ga3_views_field: The name of the GA3 views field - should be either 'page_views' or 'unique_views'
         :param schema_folder: the SQL schema path.
         :param mailto: email address used to identify the user when sending requests to an API.
         :param crossref_start_date: The starting date of crossref's API calls
@@ -248,6 +250,7 @@ class OnixWorkflow(Workflow):
         self.oaebu_intermediate_match_suffix = oaebu_intermediate_match_suffix
         # Run parameters
         self.data_partners = data_partners
+        self.ga3_views_field = ga3_views_field
         self.schema_folder = schema_folder
         self.mailto = mailto
         self.crossref_start_date = crossref_start_date
@@ -775,6 +778,7 @@ class OnixWorkflow(Workflow):
             country_table_id=country_table_id,
             workid_table_id=workid_table_id,
             workfamilyid_table_id=workfamilyid_table_id,
+            ga3_views_field=self.ga3_views_field,
             onix_workflow=True,
         )
         schema_file_path = bq_find_schema(path=self.schema_folder, table_name=self.bq_book_product_table_name)
@@ -792,7 +796,7 @@ class OnixWorkflow(Workflow):
         release: OnixWorkflowRelease,
         **kwargs,
     ):
-        """Create an intermediate oaebu table.  They are of the form datasource_matched<date>"""
+        """Create an intermediate oaebu table. They are of the form datasource_matched<date>"""
         output_table: str = kwargs["output_table"]
         query_template: str = kwargs["query_template"]
         bq_create_dataset(


### PR DESCRIPTION
We changed the field to page_views from unique_views in #95. We now need access to either the unique OR page views depending on the publisher. To accomplish this, I altered the book_product sql to template out the google_analytics views field. This requires the views_field to be supplied when rendering - it defaults to page_views in the ONIX_WF telescope.

Note - we'll have to add the ga3_views_field to the config file ONIX WFs that contain google_analytics as data partner. 