### PR TITLE
Fix published_date for YYYY entries

### DIFF
--- a/oaebu_workflows/database/sql/create_book_products.sql.jinja2
+++ b/oaebu_workflows/database/sql/create_book_products.sql.jinja2
@@ -433,10 +433,12 @@ onix_ebook_titles_raw as (
                 SUBSTRING(CAST(dates.Date as STRING), 0, 4)
             FROM UNNEST(onix.PublishingDates) as dates
             WHERE dates.PublishingDateRole = "Publication date")[SAFE_OFFSET(0)] as published_year,
-            ARRAY(SELECT
-                PARSE_DATE("%Y%m%d", SUBSTRING(CAST(dates.Date as STRING), 0, 8))
-            FROM UNNEST(onix.PublishingDates) as dates
-            WHERE dates.PublishingDateRole = "Publication date")[SAFE_OFFSET(0)] as published_date,
+            # This subquery creates the published_date when the date.Date field is 8 characters long (YYYYMMDD)
+            ARRAY(SELECT 
+                SAFE.PARSE_DATE("%Y%m%d", SUBSTRING(SAFE_CAST(dates.Date AS STRING), 0, 8))
+            FROM UNNEST(onix.PublishingDates) AS dates
+            WHERE dates.PublishingDateRole = "Publication date" AND 
+                CHAR_LENGTH(SAFE_CAST(dates.Date AS STRING)) = 8 )[SAFE_OFFSET(0)] AS published_date,
             # The following four sub-queries all pull data from the onix.subjects array, but neatly organised the values into the 4 current classification systems
             ARRAY(
                 SELECT

--- a/oaebu_workflows/fixtures/onix_workflow/e2e_inputs/onix.jsonl
+++ b/oaebu_workflows/fixtures/onix_workflow/e2e_inputs/onix.jsonl
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e58bc98d322590f4ac7dfdbcc2579fff047fe0b9e879d6a856d44a414f574870
-size 1852
+oid sha256:d6c1a670137b4efcd1bf78e55b6fea1321bf9ee8730c89257bb5948fcb6f5246
+size 1848

--- a/oaebu_workflows/fixtures/onix_workflow/e2e_outputs/book_product.json
+++ b/oaebu_workflows/fixtures/onix_workflow/e2e_outputs/book_product.json
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1e6b925f9108d2d57ff2c692579e6c1aec65fa934ac968bd2ab9909f20837da2
-size 44312
+oid sha256:99f15a64449d44230d3601dbf8b2d24a4e6793b3d587827e9c6bdc67a66d2ee0
+size 44306

--- a/oaebu_workflows/fixtures/onix_workflow/e2e_outputs/book_product_ga.json
+++ b/oaebu_workflows/fixtures/onix_workflow/e2e_outputs/book_product_ga.json
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c82336d93cea0006d0e8f0888b7a04a933dd06518442bff5d530254be97a73e3
-size 46130
+oid sha256:ed829e45917ded159766ff74a895e1e90a0a9203a918d46cc684c9e8ceac6781
+size 46124

--- a/oaebu_workflows/fixtures/onix_workflow/e2e_outputs/book_product_list.json
+++ b/oaebu_workflows/fixtures/onix_workflow/e2e_outputs/book_product_list.json
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:dd23bb8891b00ab3e4c98f41b5b7af19a912ad454b13c2dc548cf75a5f21c5c9
-size 2153
+oid sha256:599c6b50a019db96045b6ea3dd4e3f92744b2dcd34c3554410d8ddb581a6f470
+size 2147


### PR DESCRIPTION
Some metadata feeds have the publishing date in YYYY format - which is perfectly acceptable by ONIX standards. The book_product query breaks when encountering something like this though. This PR changes the query to ignore the published_date field if the ONIX PublishingDate field is not in YYYYMMDD format (ie. 8 characters long).