### PR TITLE
BAD-687

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Onix, UCL Discovery and an Onix Workflow for combining all of this data.
 
 
 ## Documentation
-For detailed documentation about the Book Usage Data Workflows see the Read the Docs website  [https://oaebu-workflows.readthedocs.io](https://oaebu-workflows.readthedocs.io)
+For detailed documentation about the Book Usage Data Workflows hosted on GitBook, [click here](documentation.book-analytics.org). Thank you to GitBook for the supporting this repository under their Open Source plan.
 
 ## Other requirements to create the Book Usage Datasets
 The Observatory Platform, an environment for fetching, processing and analysing data, see the Repository  [https://github.com/The-Academic-Observatory/observatory-platform](https://github.com/The-Academic-Observatory/observatory-platform)

--- a/docs/bad_project/help/index.rst
+++ b/docs/bad_project/help/index.rst
@@ -1,6 +1,8 @@
 More information
 _________
 
+Our documentation on Read the Docs is no longer updated. Please see our latest documentation `here <https://documentation.book-analytics.org>`_
+
 .. toctree::
     :maxdepth: 1
     

--- a/docs/bad_project/index.rst
+++ b/docs/bad_project/index.rst
@@ -1,6 +1,8 @@
 Overview
 ##########################
 
+Our documentation on Read the Docs is no longer updated. Please see our latest documentation `here <https://documentation.book-analytics.org>`_
+
 .. toctree::
     :maxdepth: 2
 

--- a/docs/bad_project/overview/background.md
+++ b/docs/bad_project/overview/background.md
@@ -1,6 +1,8 @@
 Book Analytics Dashboard
 =======================
 
+## Our documentation on Read the Docs is no longer updated. Please see our latest documentation [here](https://documentation.book-analytics.org).
+
 ## How can the Book Analytics Dashboard help me?
 Whether you’re a publisher, librarian, funder, administrator, or other stakeholder in the scholarly communications community, the Dashboard can help you gain a fuller view of book usage data.
 

--- a/docs/bad_project/overview/index.rst
+++ b/docs/bad_project/overview/index.rst
@@ -1,6 +1,8 @@
 Dashboard overview
 _________
 
+Our documentation on Read the Docs is no longer updated. Please see our latest documentation `here <https://documentation.book-analytics.org>`_
+
 .. toctree::
     :maxdepth: 1
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,6 +1,8 @@
 Book Analytics Dashboard 
 =======================
 
+Our documentation on Read the Docs is no longer updated. Please see our latest documentation `here <https://documentation.book-analytics.org>`_
+
 Documentation on how the Dashboard works and information on the data sources used.
 
 .. toctree::
@@ -16,6 +18,8 @@ Documentation on how the Dashboard works and information on the data sources use
 
 Book Usage Data Workflows
 =======================
+
+Our documentation on Read the Docs is no longer updated. Please see our latest documentation `here <https://documentation.book-analytics.org>`_
 
 Documentation about the code/files hosted in the Book Usage Data Worfklows Github repository. This includes (technical) documentation on the telescope/analytical workflows that are a part of this repository, license info & contributing guidelines and auto-generated API reference documentation.
 

--- a/docs/oaebu_workflows/index.rst
+++ b/docs/oaebu_workflows/index.rst
@@ -1,5 +1,6 @@
 Book Usage Data Workflows
 -------------------------
+Our documentation on Read the Docs is no longer updated. Please see our latest documentation `here <https://documentation.book-analytics.org>`_
 
 Book Usage Data Workflows provides Apache Airflow workflows for fetching, processing and analysing data about Open Access Books.
 


### PR DESCRIPTION
-  link to new GitBook docs page added to index pages and the Background page that is commonly linked to.
-  acknowledgement of GitBook support in README
- links to schema tables will not be updated as we've migrated the documentation to gitbook (schema files are now included in individual telescope folders) 