### PR TITLE
fix to gitbook link

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Onix, UCL Discovery and an Onix Workflow for combining all of this data.
 
 
 ## Documentation
-For detailed documentation about the Book Usage Data Workflows hosted on GitBook, [click here](documentation.book-analytics.org). Thank you to GitBook for the supporting this repository under their Open Source plan.
+For detailed documentation about the Book Usage Data Workflows hosted on GitBook, [click here](https://documentation.book-analytics.org). Thank you to GitBook for the supporting this repository under their Open Source plan.
 
 ## Other requirements to create the Book Usage Datasets
 The Observatory Platform, an environment for fetching, processing and analysing data, see the Repository  [https://github.com/The-Academic-Observatory/observatory-platform](https://github.com/The-Academic-Observatory/observatory-platform)


### PR DESCRIPTION
Apologies @keegansmith21 - without https:// in front of the documentation.book-analytics.org link, the rendered markdown link fails. 