### PR TITLE
Updated collections regex

### DIFF
--- a/oaebu_workflows/jstor_telescope/jstor_telescope.py
+++ b/oaebu_workflows/jstor_telescope/jstor_telescope.py
@@ -729,8 +729,8 @@ class JstorCollectionsAPI(JstorAPI):
             "maxResults": 500,
         }
         available_reports = []
-        country_regex = rf"^{self.entity_id}_Open_Country_Usage\.csv$"
-        institution_regex = rf"^{self.entity_id}_Open_Institution_Usage\.csv$"
+        country_regex = rf"^{self.entity_id}_(Open_Country|Country_Open)_Usage\.csv$"
+        institution_regex = rf"^{self.entity_id}_(Open_Institution|Institution_Open)_Usage\.csv$"
         for message_info in self.get_messages(list_params):
             message_id = message_info["id"]
             message = self.service.users().messages().get(userId="me", id=message_id).execute()

--- a/oaebu_workflows/jstor_telescope/tests/test_jstor_telescope.py
+++ b/oaebu_workflows/jstor_telescope/tests/test_jstor_telescope.py
@@ -837,7 +837,7 @@ def collection_http_mock_sequence(country_json: str, institution_json: str) -> l
             "parts": [
                 {"partId": "0", "filename": "", "body": {"attachmentId": "0"}},
                 {"partId": "1", "filename": "BTAA_Overall_Open_Usage.xlsx", "body": {"attachmentId": "1"}},
-                {"partId": "2", "filename": "BTAA_Open_Country_Usage.csv", "body": {"attachmentId": "2"}},
+                {"partId": "2", "filename": "BTAA_Country_Open_Usage.csv", "body": {"attachmentId": "2"}},
                 {"partId": "3", "filename": "BTAA_Open_Institution_Usage.csv", "body": {"attachmentId": "3"}},
             ],
         },


### PR DESCRIPTION
JSTOR reports for SHMP are formatted differently to those from BTAA. The regex pattern was missing them. This PR updates the pattern to capture both formats.