### PR TITLE
Renamed pool to comply with standard

### DIFF
--- a/dags/oaebu_workflows/airflow_pools.py
+++ b/dags/oaebu_workflows/airflow_pools.py
@@ -50,5 +50,5 @@ class CrossrefEventsPool(AirflowPool):
         :param pool_slots: The number of slots assigned to this pool
         """
         super().__init__(
-            pool_name="Crossref Events Pool", pool_slots=pool_slots, pool_description="Crossref Events API Pool"
+            pool_name="crossref_events_pool", pool_slots=pool_slots, pool_description="Crossref Events API Pool"
         )


### PR DESCRIPTION
Astro is giving an error with the crossref pool name:

```
    raise InvalidStatsNameException(
airflow.exceptions.InvalidStatsNameException: The stat name (pool.deferred_slots.Crossref Events Pool) has to be composed of ASCII alphabets, numbers, or the underscore, dot, or dash characters.
```

This didn't seem to be an issue before the move, but now the pool isn't editable using the web UI. If the pool isn't working, it may be the cause of the 429 errors we're now receiving from crossref