### PR TITLE
Alternative ONIX snapshot date source

### DIFF
--- a/dags/oaebu_workflows/oaebu_partners.py
+++ b/dags/oaebu_workflows/oaebu_partners.py
@@ -80,7 +80,6 @@ class OaebuPartner:
     :param title_field_name: Name of the field containing the Title.
     :param sharded: whether the table is sharded or not.
     :param schema_path: The path of the partner's schema folder.
-    :param source_table: For views, the the source
     """
 
     type_id: str

--- a/dags/oaebu_workflows/oaebu_partners.py
+++ b/dags/oaebu_workflows/oaebu_partners.py
@@ -73,13 +73,14 @@ class DataPartnerFiles:
 class OaebuPartner:
     """Class for storing information about data sources we are using to produce oaebu intermediate tables for.
 
-    :param type_id: The dataset type id. Should be the same as its dictionary key
+    :param type_id: The dataset type id. Should be the same as its dictionary key.
     :param bq_dataset_id: The BigQuery dataset ID Bigquery Dataset ID.
-    :param bq_table_name: The BigQuery table name Bigquery Table name
+    :param bq_table_name: The BigQuery table name.
     :param isbn_field_name: Name of the field containing the ISBN.
     :param title_field_name: Name of the field containing the Title.
     :param sharded: whether the table is sharded or not.
     :param schema_path: The path of the partner's schema folder.
+    :param source_table: For views, the the source
     """
 
     type_id: str
@@ -177,6 +178,15 @@ OAEBU_METADATA_PARTNERS = dict(
         isbn_field_name="ISBN13",
         title_field_name="TitleDetails.TitleElements.TitleText",
         sharded=True,
+        schema_path=os.path.join(schema_folder(workflow_module="onix_telescope"), "onix.json"),
+    ),
+    onix_view=OaebuPartner(
+        type_id="onix_view",
+        bq_dataset_id="onix",
+        bq_table_name="onix",
+        isbn_field_name="ISBN13",
+        title_field_name="TitleDetails.TitleElements.TitleText",
+        sharded=False,
         schema_path=os.path.join(schema_folder(workflow_module="onix_telescope"), "onix.json"),
     ),
 )

--- a/dags/oaebu_workflows/onix_workflow/onix_workflow.py
+++ b/dags/oaebu_workflows/onix_workflow/onix_workflow.py
@@ -392,14 +392,19 @@ def create_dag(
             )
 
             # Fetch ONIX data
-            sharded_onix_table = bq_sharded_table_id(
-                cloud_workspace.project_id,
-                metadata_partner.bq_dataset_id,
-                metadata_partner.bq_table_name,
-                release.onix_snapshot_date,
-            )
+            if metadata_partner.sharded:
+                onix_table = bq_sharded_table_id(
+                    cloud_workspace.project_id,
+                    metadata_partner.bq_dataset_id,
+                    metadata_partner.bq_table_name,
+                    release.onix_snapshot_date,
+                )
+            else:
+                onix_table = bq_table_id(
+                    cloud_workspace.project_id, metadata_partner.bq_dataset_id, metadata_partner.bq_table_name
+                )
             client = Client(project=cloud_workspace.project_id)
-            products = get_onix_records(sharded_onix_table, client=client)
+            products = get_onix_records(onix_table, client=client)
 
             # Aggregate into works
             agg = BookWorkAggregator(products)

--- a/dags/oaebu_workflows/onix_workflow/onix_workflow.py
+++ b/dags/oaebu_workflows/onix_workflow/onix_workflow.py
@@ -202,6 +202,7 @@ def create_dag(
     dag_id: str,
     cloud_workspace: CloudWorkspace,
     metadata_partner: Union[str, OaebuPartner],
+    source_onix_project: Optional[str] = None,
     # Bigquery parameters
     bq_master_crossref_project_id: str = "academic-observatory",
     bq_master_crossref_dataset_id: str = "crossref_metadata",
@@ -246,6 +247,8 @@ def create_dag(
 
     :param dag_id: DAG ID.
     :param cloud_workspace: The CloudWorkspace object for this DAG
+    :param metadata_partner: The Oaebu Metadata partner
+    :param source_onix_project: If using a view of an onix table, specify this as the project of the onix source table
 
     :param bq_master_crossref_project_id: GCP project ID of crossref master data
     :param bq_master_crossref_dataset_id: GCP dataset ID of crossref master data
@@ -333,8 +336,10 @@ def create_dag(
             """
 
             # Get ONIX release date
+            # We need the snapshot date - we can't get that from a view so we need the source table
+            onix_project_id = source_onix_project if source_onix_project else cloud_workspace.project_id
             onix_table_id = bq_table_id(
-                project_id=cloud_workspace.project_id,
+                project_id=onix_project_id,
                 dataset_id=metadata_partner.bq_dataset_id,
                 table_id=metadata_partner.bq_table_name,
             )


### PR DESCRIPTION
This PR adds an optional input to the onix_workflow dag that allows for an alternative onix table to be queried for the purposes of obtaining a snapshot date during make_release. 

The reason for this change is to accommodate the use of views as an alternative to creating redundant onix tables. A view cannot be sharded and thus cannot be queried for its shard date. A workaround to this limitation is to provide the source onix table that the view queries, and instead extract the snapshot date from that.