### PR TITLE
Feature/crossref events doi prefix query

### DIFF
--- a/dags/oaebu_workflows/onix_workflow/onix_workflow.py
+++ b/dags/oaebu_workflows/onix_workflow/onix_workflow.py
@@ -1087,18 +1087,17 @@ def get_doi_prefixes(dois: Iterable[str]) -> set[str]:
 
 
 def dois_from_table(
-    table_id: str, doi_column_name: str = "DOI", distinct: str = True, client: Client = None
+    table_id: str, doi_column_name: str = "DOI", client: Client = None
 ) -> set[str]:
     """
-    Queries a metadata table to retrieve the unique DOIs. Provided the DOIs are not in a nested structure.
+    Queries a metadata table to retrieve the distinct / unique DOIs. Provided the DOIs are not in a nested structure.
 
     :param table_id: The fully qualified ID of the metadata table on GCP
     :param doi_column_name: The name of the DOI column
-    :param distinct: Whether to retrieve only unique DOIs
     :return: All DOIs present in the metadata table
     """
 
-    select_field = f"DISTINCT({doi_column_name})" if distinct else doi_column_name
+    select_field = f"DISTINCT({doi_column_name})"
     sql = f"SELECT {select_field} FROM `{table_id}`"
     query_results = bq_run_query(sql, client=client)
     dois = {r["DOI"] for r in query_results}

--- a/tests/onix_workflow/fixtures/crossref_download_function_test.yaml
+++ b/tests/onix_workflow/fixtures/crossref_download_function_test.yaml
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4ba18567d55144c134de71bd4f237b161388016b489d9d20d25332e244a14bfd
-size 6923

--- a/tests/onix_workflow/fixtures/crossref_events_api_calls.yaml
+++ b/tests/onix_workflow/fixtures/crossref_events_api_calls.yaml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ccbea9f763b958410daa46fe585039c9be2fa358e732a8a8c8abcab77e3390dd
+size 4856419

--- a/tests/onix_workflow/fixtures/crossref_events_request.yaml
+++ b/tests/onix_workflow/fixtures/crossref_events_request.yaml
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3ebb811f555d547129e5982533775ac5b4fe5d97a2befa522e9cdbd46beac9d7
-size 7955234
+oid sha256:cb730f8464bc82b07113515eb4c097d31002167703d5f0918e11e80bf86dbe0e
+size 11274

--- a/tests/onix_workflow/fixtures/crossref_events_request.yaml
+++ b/tests/onix_workflow/fixtures/crossref_events_request.yaml
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8f98ce1d52adc15cba007cb0dd900766bfdf96bf7c3c6c0d00ddd4db5c24b953
-size 10742
+oid sha256:3ebb811f555d547129e5982533775ac5b4fe5d97a2befa522e9cdbd46beac9d7
+size 7955234

--- a/tests/onix_workflow/test_onix_workflow.py
+++ b/tests/onix_workflow/test_onix_workflow.py
@@ -1013,7 +1013,6 @@ class TestOnixWorkflow(SandboxTestCase):
                 sensor_dag_ids=sensor_dag_ids,
                 start_date=start_date,
                 crossref_start_date=pendulum.datetime(year=2018, month=5, day=14),
-                max_threads=1,  # Use 1 thread for tests
             )
 
             # Skip dag existence check in sensor.

--- a/tests/onix_workflow/test_onix_workflow.py
+++ b/tests/onix_workflow/test_onix_workflow.py
@@ -180,7 +180,8 @@ class TestOnixWorkflow(SandboxTestCase):
                     os.path.join(release.transform_folder, "crossref_metadata.jsonl.gz"),
                 )
                 self.assertEqual(
-                    release.crossref_events_path, os.path.join(release.transform_folder, "crossref_events.jsonl.gz")
+                    release.transformed_crossref_events_path,
+                    os.path.join(release.transform_folder, "crossref_events.jsonl"),
                 )
 
                 # Test that the onix and crossref snapshots are as expected
@@ -240,7 +241,8 @@ class TestOnixWorkflow(SandboxTestCase):
                     os.path.join(release.transform_folder, "crossref_metadata.jsonl.gz"),
                 )
                 self.assertEqual(
-                    release.crossref_events_path, os.path.join(release.transform_folder, "crossref_events.jsonl.gz")
+                    release.transformed_crossref_events_path,
+                    os.path.join(release.transform_folder, "crossref_events.jsonl"),
                 )
 
                 # Test that the onix table and crossref snapshots are as expected
@@ -741,18 +743,12 @@ class TestOnixWorkflow(SandboxTestCase):
                 project_id=self.gcp_project_id,
             )
             table_id = bq_table_id(self.gcp_project_id, fake_doi_isbn_dataset_id, "doi_isbn_test")
-            actual_dois = dois_from_table(table_id, doi_column_name="DOI", distinct=True)
-            fake_doi_isbns = [entry["DOI"] for entry in fake_doi_isbn_table]
+            actual_dois = dois_from_table(table_id, doi_column_name="DOI")
+            fake_doi_isbns = {entry["DOI"] for entry in fake_doi_isbn_table}
 
             # Check there are no duplicates and the contents are the same
-            self.assertEqual(len(actual_dois), len(set(fake_doi_isbns)))
-            self.assertEqual(set(actual_dois), set(fake_doi_isbns))
-
-            # Do the same but allow duplicates
-            actual_dois = dois_from_table(table_id, doi_column_name="DOI", distinct=False)
-            fake_doi_isbns = [entry["DOI"] for entry in fake_doi_isbn_table]
             self.assertEqual(len(actual_dois), len(fake_doi_isbns))
-            self.assertEqual(sorted(actual_dois), sorted(fake_doi_isbns))
+            self.assertEqual(actual_dois, fake_doi_isbns)
 
             #############################################
             ### Test copy_latest_export_tables ###

--- a/tests/onix_workflow/test_onix_workflow.py
+++ b/tests/onix_workflow/test_onix_workflow.py
@@ -30,13 +30,11 @@ from oaebu_workflows.config import test_fixtures_folder
 from oaebu_workflows.oaebu_partners import OaebuPartner, OAEBU_DATA_PARTNERS, OAEBU_METADATA_PARTNERS, partner_from_str
 from oaebu_workflows.onix_workflow.onix_workflow import (
     OnixWorkflowRelease,
-    CROSSREF_EVENT_URL_TEMPLATE,
     create_dag,
     download_crossref_events,
     transform_crossref_events,
     transform_event,
     dois_from_table,
-    download_crossref_event_url,
     copy_latest_export_tables,
     get_onix_records,
     insert_into_schema,
@@ -1094,7 +1092,7 @@ class TestOnixWorkflow(SandboxTestCase):
 
                 # Load crossref event table into bigquery
                 with vcr.use_cassette(
-                    self.events_cassette, record_mode="none", before_record_request=vcr_ignore_condition
+                    self.events_cassette, record_mode=vcr.record_mode.RecordMode.ONCE, before_record_request=vcr_ignore_condition
                 ):
                     ti = env.run_task("create_crossref_events_table")
                 self.assertEqual(ti.state, State.SUCCESS)


### PR DESCRIPTION
Re-work the ONIX Workflow so that it fetches Crossref Events in a more reliable way (hopefully):
* Fetch events via DOI prefix rather than individual DOIs.
* Remove threaded requests, since multiple workflows will be running anyway.
* To make better use of memory: save events to disk, then when transforming, read each event, transform it and write in same loop.