### PR TITLE
Added clone protection

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -28,7 +28,8 @@ jobs:
 
           cd ..
           # Clone protection required until fix - https://github.com/git-lfs/git-lfs/issues/5749
-          git clone GIT_CLONE_PROTECTION_ACTIVE=false -b feature/astro-refactor https://github.com/The-Academic-Observatory/observatory-platform.git 
+          GIT_CLONE_PROTECTION_ACTIVE=false 
+          git clone -b feature/astro-refactor https://github.com/The-Academic-Observatory/observatory-platform.git 
           cd observatory-platform
           pip install -e .[tests] --constraint https://raw.githubusercontent.com/apache/airflow/constraints-2.7.3/constraints-no-providers-${{ matrix.python-version }}.txt
           cd ..

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -27,7 +27,8 @@ jobs:
           python -m pip install --upgrade pip
 
           cd ..
-          git clone -b feature/astro-refactor https://github.com/The-Academic-Observatory/observatory-platform.git
+          # Clone protection required until fix - https://github.com/git-lfs/git-lfs/issues/5749
+          git clone GIT_CLONE_PROTECTION_ACTIVE=false -b feature/astro-refactor https://github.com/The-Academic-Observatory/observatory-platform.git 
           cd observatory-platform
           pip install -e .[tests] --constraint https://raw.githubusercontent.com/apache/airflow/constraints-2.7.3/constraints-no-providers-${{ matrix.python-version }}.txt
           cd ..

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -28,7 +28,7 @@ jobs:
 
           cd ..
           # Clone protection required until fix - https://github.com/git-lfs/git-lfs/issues/5749
-          GIT_CLONE_PROTECTION_ACTIVE=false 
+          export GIT_CLONE_PROTECTION_ACTIVE=false 
           git clone -b feature/astro-refactor https://github.com/The-Academic-Observatory/observatory-platform.git 
           cd observatory-platform
           pip install -e .[tests] --constraint https://raw.githubusercontent.com/apache/airflow/constraints-2.7.3/constraints-no-providers-${{ matrix.python-version }}.txt


### PR DESCRIPTION
Git clone fails because of an introduced issue in git lfs (originating in git) https://github.com/git-lfs/git-lfs/issues/5749

I've implemented the recommended temporary fix until the issue is resolved.