### PR TITLE
Dataset API and Release updates

### DIFF
--- a/dags/oaebu_workflows/google_books_telescope/google_books_telescope.py
+++ b/dags/oaebu_workflows/google_books_telescope/google_books_telescope.py
@@ -119,7 +119,7 @@ def create_dag(
     bq_dataset_description: str = "Data from Google sources",
     bq_sales_table_description: str = None,
     bq_traffic_table_description: str = None,
-    api_dataset_id: str = "dataset_api",
+    api_bq_dataset_id: str = "dataset_api",
     sftp_service_conn_id: str = "sftp_service",
     catchup: bool = False,
     schedule: str = "0 12 * * Sun",  # Midday every sunday
@@ -137,7 +137,7 @@ def create_dag(
     :param bq_dataset_description: Description for the BigQuery dataset
     :param bq_sales_table_description: Description for the BigQuery Google Books Sales table
     :param bq_traffic_table_description: Description for the BigQuery Google Books Traffic table
-    :param api_dataset_id: The name of the Bigquery dataset to store the API release(s)
+    :param api_bq_dataset_id: The name of the Bigquery dataset to store the API release(s)
     :param sftp_service_conn_id: Airflow connection ID for the SFTP service
     :param catchup: Whether to catchup the DAG or not
     :param schedule: The schedule interval of the DAG
@@ -327,7 +327,9 @@ def create_dag(
 
                 release = GoogleBooksRelease.from_dict(release)
                 client = Client(project=cloud_workspace.project_id)
-                api = DatasetAPI(bq_project_id=cloud_workspace.project_id, bq_dataset_id=api_dataset_id, client=client)
+                api = DatasetAPI(
+                    bq_project_id=cloud_workspace.project_id, bq_dataset_id=api_bq_dataset_id, client=client
+                )
                 api.seed_db()
                 # Google Books sales
                 dataset_release = DatasetRelease(

--- a/dags/oaebu_workflows/google_books_telescope/google_books_telescope.py
+++ b/dags/oaebu_workflows/google_books_telescope/google_books_telescope.py
@@ -327,11 +327,24 @@ def create_dag(
 
                 release = GoogleBooksRelease.from_dict(release)
                 client = Client(project=cloud_workspace.project_id)
-                api = DatasetAPI(project_id=cloud_workspace.project_id, dataset_id=api_dataset_id, client=client)
+                api = DatasetAPI(bq_project_id=cloud_workspace.project_id, bq_dataset_id=api_dataset_id, client=client)
                 api.seed_db()
+                # Google Books sales
                 dataset_release = DatasetRelease(
                     dag_id=dag_id,
-                    dataset_id=api_dataset_id,
+                    entity_id="google_books_sales",
+                    dag_run_id=release.run_id,
+                    created=pendulum.now(),
+                    modified=pendulum.now(),
+                    data_interval_start=context["data_interval_start"],
+                    data_interval_end=context["data_interval_end"],
+                    partition_date=release.partition_date,
+                )
+                # Google Books traffic
+                api.add_dataset_release(dataset_release)
+                dataset_release = DatasetRelease(
+                    dag_id=dag_id,
+                    entity_id="google_books_traffic",
                     dag_run_id=release.run_id,
                     created=pendulum.now(),
                     modified=pendulum.now(),

--- a/dags/oaebu_workflows/irus_fulcrum_telescope/irus_fulcrum_telescope.py
+++ b/dags/oaebu_workflows/irus_fulcrum_telescope/irus_fulcrum_telescope.py
@@ -117,7 +117,7 @@ def create_dag(
     data_partner: Union[str, OaebuPartner] = "irus_fulcrum",
     bq_dataset_description: str = "IRUS dataset",
     bq_table_description: str = "Fulcrum metrics as recorded by the IRUS platform",
-    api_dataset_id: str = "dataset_api",
+    api_bq_dataset_id: str = "dataset_api",
     irus_oapen_api_conn_id: str = "irus_api",
     catchup: bool = True,
     schedule: str = "0 0 4 * *",  # Run on the 4th of every month
@@ -133,7 +133,7 @@ def create_dag(
     :param data_partner: The name of the data partner
     :param bq_dataset_description: Description for the BigQuery dataset
     :param bq_table_description: Description for the biguery table
-    :param api_dataset_id: The name of the Bigquery dataset to store the API release(s)
+    :param api_bq_dataset_id: The name of the Bigquery dataset to store the API release(s)
     :param irus_oapen_api_conn_id: Airflow connection ID OAPEN IRUS UK (counter 5)
     :param catchup: Whether to catchup the DAG or not
     :param schedule: The schedule interval of the DAG
@@ -279,7 +279,7 @@ def create_dag(
 
             release = IrusFulcrumRelease.from_dict(release)
             client = Client(project=cloud_workspace.project_id)
-            api = DatasetAPI(bq_project_id=cloud_workspace.project_id, bq_dataset_id=api_dataset_id, client=client)
+            api = DatasetAPI(bq_project_id=cloud_workspace.project_id, bq_dataset_id=api_bq_dataset_id, client=client)
             api.seed_db()
             dataset_release = DatasetRelease(
                 dag_id=dag_id,

--- a/dags/oaebu_workflows/irus_fulcrum_telescope/irus_fulcrum_telescope.py
+++ b/dags/oaebu_workflows/irus_fulcrum_telescope/irus_fulcrum_telescope.py
@@ -279,11 +279,11 @@ def create_dag(
 
             release = IrusFulcrumRelease.from_dict(release)
             client = Client(project=cloud_workspace.project_id)
-            api = DatasetAPI(project_id=cloud_workspace.project_id, dataset_id=api_dataset_id, client=client)
+            api = DatasetAPI(bq_project_id=cloud_workspace.project_id, bq_dataset_id=api_dataset_id, client=client)
             api.seed_db()
             dataset_release = DatasetRelease(
                 dag_id=dag_id,
-                dataset_id=api_dataset_id,
+                entity_id="irus_fulcrum",
                 dag_run_id=release.run_id,
                 created=pendulum.now(),
                 modified=pendulum.now(),

--- a/dags/oaebu_workflows/irus_oapen_telescope/irus_oapen_telescope.py
+++ b/dags/oaebu_workflows/irus_oapen_telescope/irus_oapen_telescope.py
@@ -133,7 +133,7 @@ def create_dag(
     bq_table_description: str = "OAPEN metrics as recorded by the IRUS platform",
     gdpr_oapen_project_id: str = "oapen-usage-data-gdpr-proof",
     gdpr_oapen_bucket_id: str = "oapen-usage-data-gdpr-proof_cloud-function",
-    api_dataset_id: str = "dataset_api",
+    api_bq_dataset_id: str = "dataset_api",
     max_cloud_function_instances: int = 0,
     geoip_license_conn_id: str = "geoip_license_key",
     irus_oapen_api_conn_id: str = "irus_api",
@@ -155,7 +155,7 @@ def create_dag(
     :param bq_table_description: Description for the biguery table
     :param gdpr_oapen_project_id: The gdpr-proof oapen project id.
     :param gdpr_oapen_bucket_id: The gdpr-proof oapen bucket
-    :param api_dataset_id: The name of the Bigquery dataset to store the API release(s)
+    :param api_bq_dataset_id: The name of the Bigquery dataset to store the API release(s)
     :param max_cloud_function_instances:
     :param geoip_license_conn_id: The Airflow connection ID for the GEOIP license
     :param irus_oapen_api_conn_id: The Airflow connection ID for IRUS API - for counter 5
@@ -375,7 +375,9 @@ def create_dag(
 
                 release = IrusOapenRelease.from_dict(release)
                 client = Client(project=cloud_workspace.project_id)
-                api = DatasetAPI(bq_project_id=cloud_workspace.project_id, bq_dataset_id=api_dataset_id, client=client)
+                api = DatasetAPI(
+                    bq_project_id=cloud_workspace.project_id, bq_dataset_id=api_bq_dataset_id, client=client
+                )
                 api.seed_db()
                 dataset_release = DatasetRelease(
                     dag_id=dag_id,

--- a/dags/oaebu_workflows/irus_oapen_telescope/irus_oapen_telescope.py
+++ b/dags/oaebu_workflows/irus_oapen_telescope/irus_oapen_telescope.py
@@ -375,11 +375,11 @@ def create_dag(
 
                 release = IrusOapenRelease.from_dict(release)
                 client = Client(project=cloud_workspace.project_id)
-                api = DatasetAPI(project_id=cloud_workspace.project_id, dataset_id=api_dataset_id, client=client)
+                api = DatasetAPI(bq_project_id=cloud_workspace.project_id, bq_dataset_id=api_dataset_id, client=client)
                 api.seed_db()
                 dataset_release = DatasetRelease(
                     dag_id=dag_id,
-                    dataset_id=api_dataset_id,
+                    entity_id="irus_oapen",
                     dag_run_id=release.run_id,
                     created=pendulum.now(),
                     modified=pendulum.now(),

--- a/dags/oaebu_workflows/jstor_telescope/jstor_telescope.py
+++ b/dags/oaebu_workflows/jstor_telescope/jstor_telescope.py
@@ -369,11 +369,24 @@ def create_dag(
 
                 release = JstorRelease.from_dict(release)
                 client = Client(project=cloud_workspace.project_id)
-                api = DatasetAPI(project_id=cloud_workspace.project_id, dataset_id=api_dataset_id, client=client)
+                api = DatasetAPI(bq_project_id=cloud_workspace.project_id, bq_dataset_id=api_dataset_id, client=client)
                 api.seed_db()
+                # JSTOR country
                 dataset_release = DatasetRelease(
                     dag_id=dag_id,
-                    dataset_id=api_dataset_id,
+                    entity_id="jstor_country",
+                    dag_run_id=release.run_id,
+                    created=pendulum.now(),
+                    modified=pendulum.now(),
+                    data_interval_start=release.data_interval_start,
+                    data_interval_end=release.data_interval_end,
+                    partition_date=release.partition_date,
+                )
+                api.add_dataset_release(dataset_release)
+                # JSTOR insitution
+                dataset_release = DatasetRelease(
+                    dag_id=dag_id,
+                    entity_id="jstor_institution",
                     dag_run_id=release.run_id,
                     created=pendulum.now(),
                     modified=pendulum.now(),

--- a/dags/oaebu_workflows/jstor_telescope/jstor_telescope.py
+++ b/dags/oaebu_workflows/jstor_telescope/jstor_telescope.py
@@ -162,7 +162,7 @@ def create_dag(
     bq_dataset_description: str = "Data from JSTOR sources",
     bq_country_table_description: Optional[str] = None,
     bq_institution_table_description: Optional[str] = None,
-    api_dataset_id: str = "dataset_api",
+    api_bq_dataset_id: str = "dataset_api",
     gmail_api_conn_id: str = "gmail_api",
     catchup: bool = False,
     schedule: str = "0 0 4 * *",  # 4th day of every month
@@ -181,7 +181,7 @@ def create_dag(
     :param bq_dataset_description: Description for the BigQuery dataset
     :param bq_country_table_description: Description for the BigQuery JSTOR country table
     :param bq_institution_table_description: Description for the BigQuery JSTOR institution table
-    :param api_dataset_id: The name of the Bigquery dataset to store the API release(s)
+    :param api_bq_dataset_id: The name of the Bigquery dataset to store the API release(s)
     :param gmail_api_conn_id: Airflow connection ID for the Gmail API
     :param catchup: Whether to catchup the DAG or not
     :param max_active_runs: The maximum number of DAG runs that can be run concurrently
@@ -369,7 +369,9 @@ def create_dag(
 
                 release = JstorRelease.from_dict(release)
                 client = Client(project=cloud_workspace.project_id)
-                api = DatasetAPI(bq_project_id=cloud_workspace.project_id, bq_dataset_id=api_dataset_id, client=client)
+                api = DatasetAPI(
+                    bq_project_id=cloud_workspace.project_id, bq_dataset_id=api_bq_dataset_id, client=client
+                )
                 api.seed_db()
                 # JSTOR country
                 dataset_release = DatasetRelease(

--- a/dags/oaebu_workflows/oapen_metadata_telescope/oapen_metadata_telescope.py
+++ b/dags/oaebu_workflows/oapen_metadata_telescope/oapen_metadata_telescope.py
@@ -109,7 +109,7 @@ def create_dag(
     elevate_related_products: bool = False,
     bq_dataset_description: str = "OAPEN Metadata converted to ONIX",
     bq_table_description: str = None,
-    api_dataset_id: str = "dataset_api",
+    api_bq_dataset_id: str = "dataset_api",
     catchup: bool = False,
     start_date: pendulum.DateTime = pendulum.datetime(2018, 5, 14),
     schedule: str = "0 12 * * Sun",  # Midday every sunday
@@ -125,7 +125,7 @@ def create_dag(
     :param elevate_related_products: Whether to pull out the related products to the product level.
     :param bq_dataset_description: Description for the BigQuery dataset
     :param bq_table_description: Description for the biguery table
-    :param api_dataset_id: The name of the Bigquery dataset to store the API release(s)
+    :param api_bq_dataset_id: The name of the Bigquery dataset to store the API release(s)
     :param catchup: Whether to catchup the DAG or not
     :param start_date: The start date of the DAG
     :param schedule: The schedule interval of the DAG
@@ -258,7 +258,7 @@ def create_dag(
 
             release = OapenMetadataRelease.from_dict(release)
             client = Client(project=cloud_workspace.project_id)
-            api = DatasetAPI(bq_project_id=cloud_workspace.project_id, bq_dataset_id=api_dataset_id, client=client)
+            api = DatasetAPI(bq_project_id=cloud_workspace.project_id, bq_dataset_id=api_bq_dataset_id, client=client)
             api.seed_db()
             dataset_release = DatasetRelease(
                 dag_id=dag_id,

--- a/dags/oaebu_workflows/oapen_metadata_telescope/oapen_metadata_telescope.py
+++ b/dags/oaebu_workflows/oapen_metadata_telescope/oapen_metadata_telescope.py
@@ -258,11 +258,11 @@ def create_dag(
 
             release = OapenMetadataRelease.from_dict(release)
             client = Client(project=cloud_workspace.project_id)
-            api = DatasetAPI(project_id=cloud_workspace.project_id, dataset_id=api_dataset_id, client=client)
+            api = DatasetAPI(bq_project_id=cloud_workspace.project_id, bq_dataset_id=api_dataset_id, client=client)
             api.seed_db()
             dataset_release = DatasetRelease(
                 dag_id=dag_id,
-                dataset_id=api_dataset_id,
+                entity_id="oapen_metadata",
                 dag_run_id=release.run_id,
                 created=pendulum.now(),
                 modified=pendulum.now(),

--- a/dags/oaebu_workflows/onix_telescope/onix_telescope.py
+++ b/dags/oaebu_workflows/onix_telescope/onix_telescope.py
@@ -107,7 +107,7 @@ def create_dag(
     elevate_related_products: bool = False,
     bq_dataset_description: str = "ONIX data provided by Org",
     bq_table_description: str = None,
-    api_dataset_id: str = "dataset_api",
+    api_bq_dataset_id: str = "dataset_api",
     sftp_service_conn_id: str = "sftp_service",
     catchup: bool = False,
     schedule: str = "0 12 * * Sun",  # Midday every sunday
@@ -125,7 +125,7 @@ def create_dag(
     :param date_regex: Regular expression for extracting a date string from an ONIX file name
     :param bq_dataset_description: Description for the BigQuery dataset
     :param bq_table_description: Description for the biguery table
-    :param api_dataset_id: The name of the Bigquery dataset to store the API release(s)
+    :param api_bq_dataset_id: The name of the Bigquery dataset to store the API release(s)
     :param sftp_service_conn_id: Airflow connection ID for the SFTP service
     :param catchup: Whether to catchup the DAG or not
     :param schedule: The schedule interval of the DAG
@@ -284,7 +284,9 @@ def create_dag(
 
                 release = OnixRelease.from_dict(release)
                 client = Client(project=cloud_workspace.project_id)
-                api = DatasetAPI(bq_project_id=cloud_workspace.project_id, bq_dataset_id=api_dataset_id, client=client)
+                api = DatasetAPI(
+                    bq_project_id=cloud_workspace.project_id, bq_dataset_id=api_bq_dataset_id, client=client
+                )
                 api.seed_db()
                 dataset_release = DatasetRelease(
                     dag_id=dag_id,

--- a/dags/oaebu_workflows/onix_telescope/onix_telescope.py
+++ b/dags/oaebu_workflows/onix_telescope/onix_telescope.py
@@ -284,11 +284,11 @@ def create_dag(
 
                 release = OnixRelease.from_dict(release)
                 client = Client(project=cloud_workspace.project_id)
-                api = DatasetAPI(project_id=cloud_workspace.project_id, dataset_id=api_dataset_id, client=client)
+                api = DatasetAPI(bq_project_id=cloud_workspace.project_id, bq_dataset_id=api_dataset_id, client=client)
                 api.seed_db()
                 dataset_release = DatasetRelease(
                     dag_id=dag_id,
-                    dataset_id=api_dataset_id,
+                    entity_id="onix",
                     dag_run_id=release.run_id,
                     created=pendulum.now(),
                     modified=pendulum.now(),

--- a/dags/oaebu_workflows/onix_workflow/onix_workflow.py
+++ b/dags/oaebu_workflows/onix_workflow/onix_workflow.py
@@ -999,11 +999,11 @@ def create_dag(
 
             release = OnixWorkflowRelease.from_dict(release)
             client = Client(project=cloud_workspace.project_id)
-            api = DatasetAPI(project_id=cloud_workspace.project_id, dataset_id=api_dataset_id, client=client)
+            api = DatasetAPI(bq_project_id=cloud_workspace.project_id, bq_dataset_id=api_dataset_id, client=client)
             api.seed_db()
             dataset_release = DatasetRelease(
                 dag_id=dag_id,
-                dataset_id=api_dataset_id,
+                entity_id="onix_workflow",
                 dag_run_id=release.run_id,
                 created=pendulum.now(),
                 modified=pendulum.now(),

--- a/dags/oaebu_workflows/onix_workflow/onix_workflow.py
+++ b/dags/oaebu_workflows/onix_workflow/onix_workflow.py
@@ -241,7 +241,7 @@ def create_dag(
     schema_folder: str = default_schema_folder(workflow_module="onix_workflow"),
     mailto: str = "agent@observatory.academy",
     crossref_start_date: pendulum.DateTime = pendulum.datetime(2018, 5, 14),
-    api_dataset_id: str = "dataset_api",
+    api_bq_dataset_id: str = "dataset_api",
     # Ariflow parameters
     sensor_dag_ids: List[str] = None,
     catchup: Optional[bool] = False,
@@ -287,7 +287,7 @@ def create_dag(
     :param schema_folder: the SQL schema path.
     :param mailto: email address used to identify the user when sending requests to an API.
     :param crossref_start_date: The starting date of crossref's API calls
-    :param api_dataset_id: The name of the Bigquery dataset to store the API release(s)
+    :param api_bq_dataset_id: The name of the Bigquery dataset to store the API release(s)
 
     :param sensor_dag_ids: Dag IDs for dependent tasks
     :param catchup: Whether to catch up missed DAG runs.
@@ -999,7 +999,7 @@ def create_dag(
 
             release = OnixWorkflowRelease.from_dict(release)
             client = Client(project=cloud_workspace.project_id)
-            api = DatasetAPI(bq_project_id=cloud_workspace.project_id, bq_dataset_id=api_dataset_id, client=client)
+            api = DatasetAPI(bq_project_id=cloud_workspace.project_id, bq_dataset_id=api_bq_dataset_id, client=client)
             api.seed_db()
             dataset_release = DatasetRelease(
                 dag_id=dag_id,

--- a/dags/oaebu_workflows/thoth_telescope/thoth_telescope.py
+++ b/dags/oaebu_workflows/thoth_telescope/thoth_telescope.py
@@ -234,11 +234,11 @@ def create_dag(
 
             release = ThothRelease.from_dict(release)
             client = Client(project=cloud_workspace.project_id)
-            api = DatasetAPI(project_id=cloud_workspace.project_id, dataset_id=api_dataset_id, client=client)
+            api = DatasetAPI(bq_project_id=cloud_workspace.project_id, bq_dataset_id=api_dataset_id, client=client)
             api.seed_db()
             dataset_release = DatasetRelease(
                 dag_id=dag_id,
-                dataset_id=api_dataset_id,
+                entity_id="thoth",
                 dag_run_id=release.run_id,
                 created=pendulum.now(),
                 modified=pendulum.now(),

--- a/dags/oaebu_workflows/thoth_telescope/thoth_telescope.py
+++ b/dags/oaebu_workflows/thoth_telescope/thoth_telescope.py
@@ -99,7 +99,7 @@ def create_dag(
     metadata_partner: Union[str, OaebuPartner] = "thoth",
     bq_dataset_description: str = "Thoth ONIX Feed",
     bq_table_description: str = "Thoth ONIX Feed",
-    api_dataset_id: str = "dataset_api",
+    api_bq_dataset_id: str = "dataset_api",
     catchup: bool = False,
     start_date: DateTime = pendulum.datetime(2022, 12, 1),
     schedule: str = "0 12 * * Sun",  # Midday every sunday
@@ -116,7 +116,7 @@ def create_dag(
     :param metadata_partner: The metadata partner name
     :param bq_dataset_description: Description for the BigQuery dataset
     :param bq_table_description: Description for the biguery table
-    :param api_dataset_id: The name of the Bigquery dataset to store the API release(s)
+    :param api_bq_dataset_id: The name of the Bigquery dataset to store the API release(s)
     :param catchup: Whether to catchup the DAG or not
     :param start_date: The start date of the DAG
     :param schedule: The schedule interval of the DAG
@@ -234,7 +234,7 @@ def create_dag(
 
             release = ThothRelease.from_dict(release)
             client = Client(project=cloud_workspace.project_id)
-            api = DatasetAPI(bq_project_id=cloud_workspace.project_id, bq_dataset_id=api_dataset_id, client=client)
+            api = DatasetAPI(bq_project_id=cloud_workspace.project_id, bq_dataset_id=api_bq_dataset_id, client=client)
             api.seed_db()
             dataset_release = DatasetRelease(
                 dag_id=dag_id,

--- a/dags/oaebu_workflows/ucl_discovery_telescope/ucl_discovery_telescope.py
+++ b/dags/oaebu_workflows/ucl_discovery_telescope/ucl_discovery_telescope.py
@@ -303,11 +303,11 @@ def create_dag(
 
             release = UclDiscoveryRelease.from_dict(release)
             client = Client(project=cloud_workspace.project_id)
-            api = DatasetAPI(project_id=cloud_workspace.project_id, dataset_id=api_dataset_id, client=client)
+            api = DatasetAPI(bq_project_id=cloud_workspace.project_id, bq_dataset_id=api_dataset_id, client=client)
             api.seed_db()
             dataset_release = DatasetRelease(
                 dag_id=dag_id,
-                dataset_id=api_dataset_id,
+                entity_id="ucl_discovery",
                 dag_run_id=release.run_id,
                 created=pendulum.now(),
                 modified=pendulum.now(),

--- a/dags/oaebu_workflows/ucl_discovery_telescope/ucl_discovery_telescope.py
+++ b/dags/oaebu_workflows/ucl_discovery_telescope/ucl_discovery_telescope.py
@@ -116,7 +116,7 @@ def create_dag(
     data_partner: Union[str, OaebuPartner] = "ucl_discovery",
     bq_dataset_description: str = "UCL Discovery dataset",
     bq_table_description: str = "UCL Discovery table",
-    api_dataset_id: str = "dataset_api",
+    api_bq_dataset_id: str = "dataset_api",
     oaebu_service_account_conn_id: str = "oaebu_service_account",
     max_threads: int = os.cpu_count() * 2,
     schedule: str = "0 0 4 * *",  # run on the 4th of every month
@@ -134,7 +134,7 @@ def create_dag(
     :param data_partner: The name of the data partner
     :param bq_dataset_description: Description for the BigQuery dataset
     :param bq_table_description: Description for the biguery table
-    :param api_dataset_id: The name of the Bigquery dataset to store the API release(s)
+    :param api_bq_dataset_id: The name of the Bigquery dataset to store the API release(s)
     :param oaebu_service_account_conn_id: Airflow connection ID for the oaebu service account
     :param max_threads: The maximum number threads to utilise for parallel processes
     :param schedule: The schedule interval of the DAG
@@ -303,7 +303,7 @@ def create_dag(
 
             release = UclDiscoveryRelease.from_dict(release)
             client = Client(project=cloud_workspace.project_id)
-            api = DatasetAPI(bq_project_id=cloud_workspace.project_id, bq_dataset_id=api_dataset_id, client=client)
+            api = DatasetAPI(bq_project_id=cloud_workspace.project_id, bq_dataset_id=api_bq_dataset_id, client=client)
             api.seed_db()
             dataset_release = DatasetRelease(
                 dag_id=dag_id,

--- a/tests/irus_oapen_telescope/test_irus_oapen_telescope.py
+++ b/tests/irus_oapen_telescope/test_irus_oapen_telescope.py
@@ -44,12 +44,13 @@ from oaebu_workflows.irus_oapen_telescope.irus_oapen_telescope import (
     upload_source_code_to_bucket,
     create_dag,
 )
-from observatory_platform.dataset_api import DatasetAPI
 from observatory_platform.airflow.workflow import CloudWorkspace, Workflow
-from observatory_platform.google.gcs import gcs_blob_name_from_path, gcs_upload_file
+from observatory_platform.dataset_api import DatasetAPI
+from observatory_platform.date_utils import datetime_normalise
 from observatory_platform.google.bigquery import bq_table_id
-from observatory_platform.sandbox.test_utils import SandboxTestCase, find_free_port, random_id
+from observatory_platform.google.gcs import gcs_blob_name_from_path, gcs_upload_file
 from observatory_platform.sandbox.sandbox_environment import SandboxEnvironment
+from observatory_platform.sandbox.test_utils import SandboxTestCase, find_free_port, random_id
 
 
 class TestIrusOapenTelescope(SandboxTestCase):
@@ -279,7 +280,7 @@ class TestIrusOapenTelescope(SandboxTestCase):
                 self.assertEqual(len(dataset_releases), 0)
 
                 # Add_dataset_release_task
-                now = pendulum.now("UTC")  # Use UTC to ensure +00UTC timezone
+                now = pendulum.now()
                 with patch("oaebu_workflows.irus_oapen_telescope.irus_oapen_telescope.pendulum.now") as mock_now:
                     mock_now.return_value = now
                     ti = env.run_task("process_release.add_new_dataset_releases", map_index=0)
@@ -290,9 +291,8 @@ class TestIrusOapenTelescope(SandboxTestCase):
                     "dag_id": dag_id,
                     "entity_id": "irus_oapen",
                     "dag_run_id": release.run_id,
-                    # Replace Z shorthand because BQ converts it to +00:00
-                    "created": now.to_iso8601_string().replace("Z", "+00:00"),
-                    "modified": now.to_iso8601_string().replace("Z", "+00:00"),
+                    "created": datetime_normalise(now),
+                    "modified": datetime_normalise(now),
                     "data_interval_start": "2021-02-01T00:00:00+00:00",
                     "data_interval_end": "2021-03-01T00:00:00+00:00",
                     "snapshot_date": None,

--- a/tests/jstor_telescope/test_jstor_telescope.py
+++ b/tests/jstor_telescope/test_jstor_telescope.py
@@ -38,13 +38,13 @@ from oaebu_workflows.jstor_telescope.jstor_telescope import (
     create_dag,
     make_jstor_api,
 )
-
 from observatory_platform.airflow.workflow import Workflow
-from observatory_platform.sandbox.test_utils import SandboxTestCase, load_and_parse_json
-from observatory_platform.sandbox.sandbox_environment import SandboxEnvironment
-from observatory_platform.google.gcs import gcs_blob_name_from_path, gcs_upload_files
-from observatory_platform.google.bigquery import bq_table_id
 from observatory_platform.dataset_api import DatasetAPI
+from observatory_platform.date_utils import datetime_normalise
+from observatory_platform.google.bigquery import bq_table_id
+from observatory_platform.google.gcs import gcs_blob_name_from_path, gcs_upload_files
+from observatory_platform.sandbox.sandbox_environment import SandboxEnvironment
+from observatory_platform.sandbox.test_utils import SandboxTestCase, load_and_parse_json
 
 
 def dummy_gmail_connection() -> Connection:
@@ -345,47 +345,48 @@ class TestJstorTelescopePublisher(SandboxTestCase):
                 self.assertEqual(len(dataset_releases), 0)
 
                 # Add_dataset_release_task
-                now = pendulum.now("UTC")  # Use UTC to ensure +00UTC timezone
+                now = pendulum.now()
                 with patch("oaebu_workflows.jstor_telescope.jstor_telescope.pendulum.now") as mock_now:
                     mock_now.return_value = now
                     ti = env.run_task("process_release.add_new_dataset_releases", map_index=0)
                 self.assertEqual(ti.state, State.SUCCESS)
                 dataset_releases = api.get_dataset_releases(dag_id=dag_id, entity_id="jstor_country")
                 self.assertEqual(len(dataset_releases), 1)
-                expected_release = { "dag_id": dag_id,
-                        "entity_id": "jstor_country",
-                        "dag_run_id": release.run_id,
-                        # Replace Z shorthand because BQ converts it to +00:00
-                        "created": now.to_iso8601_string().replace("Z", "+00:00"),
-                        "modified": now.to_iso8601_string().replace("Z", "+00:00"),
-                        "data_interval_start": "2022-07-01T00:00:00+00:00",
-                        "data_interval_end": "2022-08-01T00:00:00+00:00",
-                        "snapshot_date": None,
-                        "partition_date": "2022-07-31T00:00:00+00:00",
-                        "changefile_start_date": None,
-                        "changefile_end_date": None,
-                        "sequence_start": None,
-                        "sequence_end": None,
-                        "extra": {},
-                    },
-                self.assertEqual(dataset_releases[0].to_dict(), expected_release)
-                dataset_releases = api.get_dataset_releases(dag_id=dag_id, entity_id="jstor_country")
                 expected_release = {
-                        "dag_id": dag_id,
-                        "entity_id": "jstor_insitution",
-                        "dag_run_id": release.run_id,
-                        "created": now.to_iso8601_string().replace("Z", "+00:00"),
-                        "modified": now.to_iso8601_string().replace("Z", "+00:00"),
-                        "data_interval_start": "2022-07-01T00:00:00+00:00",
-                        "data_interval_end": "2022-08-01T00:00:00+00:00",
-                        "snapshot_date": None,
-                        "partition_date": "2022-07-31T00:00:00+00:00",
-                        "changefile_start_date": None,
-                        "changefile_end_date": None,
-                        "sequence_start": None,
-                        "sequence_end": None,
-                        "extra": {},
-                    }
+                    "dag_id": dag_id,
+                    "entity_id": "jstor_country",
+                    "dag_run_id": release.run_id,
+                    "created": datetime_normalise(now),
+                    "modified": datetime_normalise(now),
+                    "data_interval_start": "2022-07-01T00:00:00+00:00",
+                    "data_interval_end": "2022-08-01T00:00:00+00:00",
+                    "snapshot_date": None,
+                    "partition_date": "2022-07-31T00:00:00+00:00",
+                    "changefile_start_date": None,
+                    "changefile_end_date": None,
+                    "sequence_start": None,
+                    "sequence_end": None,
+                    "extra": {},
+                }
+                self.assertEqual(dataset_releases[0].to_dict(), expected_release)
+                dataset_releases = api.get_dataset_releases(dag_id=dag_id, entity_id="jstor_institution")
+                self.assertEqual(len(dataset_releases), 1)
+                expected_release = {
+                    "dag_id": dag_id,
+                    "entity_id": "jstor_institution",
+                    "dag_run_id": release.run_id,
+                    "created": datetime_normalise(now),
+                    "modified": datetime_normalise(now),
+                    "data_interval_start": "2022-07-01T00:00:00+00:00",
+                    "data_interval_end": "2022-08-01T00:00:00+00:00",
+                    "snapshot_date": None,
+                    "partition_date": "2022-07-31T00:00:00+00:00",
+                    "changefile_start_date": None,
+                    "changefile_end_date": None,
+                    "sequence_start": None,
+                    "sequence_end": None,
+                    "extra": {},
+                }
                 self.assertEqual(dataset_releases[0].to_dict(), expected_release)
 
                 # Test that all telescope data deleted
@@ -621,47 +622,48 @@ class TestJstorTelescopeCollection(SandboxTestCase):
                 self.assertEqual(len(dataset_releases), 0)
 
                 # Add_dataset_release_task
-                now = pendulum.now("UTC")  # Use UTC to ensure +00UTC timezone
+                now = pendulum.now()
                 with patch("oaebu_workflows.jstor_telescope.jstor_telescope.pendulum.now") as mock_now:
                     mock_now.return_value = now
                     ti = env.run_task("process_release.add_new_dataset_releases", map_index=0)
                 self.assertEqual(ti.state, State.SUCCESS)
                 dataset_releases = api.get_dataset_releases(dag_id=dag_id, entity_id="jstor_country")
                 self.assertEqual(len(dataset_releases), 1)
-                expected_release = { "dag_id": dag_id,
-                        "entity_id": "jstor_country",
-                        "dag_run_id": release.run_id,
-                        # Replace Z shorthand because BQ converts it to +00:00
-                        "created": now.to_iso8601_string().replace("Z", "+00:00"),
-                        "modified": now.to_iso8601_string().replace("Z", "+00:00"),
-                        "data_interval_start": "2022-07-01T00:00:00+00:00",
-                        "data_interval_end": "2022-08-01T00:00:00+00:00",
-                        "snapshot_date": None,
-                        "partition_date": "2022-07-31T00:00:00+00:00",
-                        "changefile_start_date": None,
-                        "changefile_end_date": None,
-                        "sequence_start": None,
-                        "sequence_end": None,
-                        "extra": {},
-                    },
-                self.assertEqual(dataset_releases[0].to_dict(), expected_release)
-                dataset_releases = api.get_dataset_releases(dag_id=dag_id, entity_id="jstor_country")
                 expected_release = {
-                        "dag_id": dag_id,
-                        "entity_id": "jstor_insitution",
-                        "dag_run_id": release.run_id,
-                        "created": now.to_iso8601_string().replace("Z", "+00:00"),
-                        "modified": now.to_iso8601_string().replace("Z", "+00:00"),
-                        "data_interval_start": "2022-07-01T00:00:00+00:00",
-                        "data_interval_end": "2022-08-01T00:00:00+00:00",
-                        "snapshot_date": None,
-                        "partition_date": "2022-07-31T00:00:00+00:00",
-                        "changefile_start_date": None,
-                        "changefile_end_date": None,
-                        "sequence_start": None,
-                        "sequence_end": None,
-                        "extra": {},
-                    }
+                    "dag_id": dag_id,
+                    "entity_id": "jstor_country",
+                    "dag_run_id": release.run_id,
+                    "created": datetime_normalise(now),
+                    "modified": datetime_normalise(now),
+                    "data_interval_start": "2023-09-01T00:00:00+00:00",
+                    "data_interval_end": "2023-10-01T00:00:00+00:00",
+                    "snapshot_date": None,
+                    "partition_date": "2023-09-30T00:00:00+00:00",
+                    "changefile_start_date": None,
+                    "changefile_end_date": None,
+                    "sequence_start": None,
+                    "sequence_end": None,
+                    "extra": {},
+                }
+                self.assertEqual(dataset_releases[0].to_dict(), expected_release)
+                dataset_releases = api.get_dataset_releases(dag_id=dag_id, entity_id="jstor_institution")
+                self.assertEqual(len(dataset_releases), 1)
+                expected_release = {
+                    "dag_id": dag_id,
+                    "entity_id": "jstor_institution",
+                    "dag_run_id": release.run_id,
+                    "created": datetime_normalise(now),
+                    "modified": datetime_normalise(now),
+                    "data_interval_start": "2023-09-01T00:00:00+00:00",
+                    "data_interval_end": "2023-10-01T00:00:00+00:00",
+                    "snapshot_date": None,
+                    "partition_date": "2023-09-30T00:00:00+00:00",
+                    "changefile_start_date": None,
+                    "changefile_end_date": None,
+                    "sequence_start": None,
+                    "sequence_end": None,
+                    "extra": {},
+                }
                 self.assertEqual(dataset_releases[0].to_dict(), expected_release)
 
                 # Test that all telescope data deleted

--- a/tests/oapen_metadata_telescope/test_oapen_metadata_telescope.py
+++ b/tests/oapen_metadata_telescope/test_oapen_metadata_telescope.py
@@ -35,12 +35,13 @@ from oaebu_workflows.oapen_metadata_telescope.oapen_metadata_telescope import (
     download_metadata,
     create_dag,
 )
-from observatory_platform.dataset_api import DatasetAPI
-from observatory_platform.google.gcs import gcs_blob_name_from_path
-from observatory_platform.google.bigquery import bq_sharded_table_id
 from observatory_platform.airflow.workflow import Workflow
-from observatory_platform.sandbox.test_utils import SandboxTestCase, load_and_parse_json, compare_lists_of_dicts
+from observatory_platform.dataset_api import DatasetAPI
+from observatory_platform.date_utils import datetime_normalise
+from observatory_platform.google.bigquery import bq_sharded_table_id
+from observatory_platform.google.gcs import gcs_blob_name_from_path
 from observatory_platform.sandbox.sandbox_environment import SandboxEnvironment
+from observatory_platform.sandbox.test_utils import SandboxTestCase, load_and_parse_json, compare_lists_of_dicts
 
 
 class TestOapenMetadataTelescope(SandboxTestCase):
@@ -195,7 +196,7 @@ class TestOapenMetadataTelescope(SandboxTestCase):
                 dataset_releases = api.get_dataset_releases(dag_id=dag_id, entity_id="oapen_metadata")
                 self.assertEqual(len(dataset_releases), 0)
 
-                now = pendulum.now("UTC")  # Use UTC to ensure +00UTC timezone
+                now = pendulum.now()
                 with patch(
                     "oaebu_workflows.oapen_metadata_telescope.oapen_metadata_telescope.pendulum.now"
                 ) as mock_now:
@@ -208,9 +209,8 @@ class TestOapenMetadataTelescope(SandboxTestCase):
                     "dag_id": dag_id,
                     "entity_id": "oapen_metadata",
                     "dag_run_id": release.run_id,
-                    # Replace Z shorthand because BQ converts it to +00:00
-                    "created": now.to_iso8601_string().replace("Z", "+00:00"),
-                    "modified": now.to_iso8601_string().replace("Z", "+00:00"),
+                    "created": datetime_normalise(now),
+                    "modified": datetime_normalise(now),
                     "data_interval_start": "2021-02-01T00:00:00+00:00",
                     "data_interval_end": "2021-02-07T12:00:00+00:00",
                     "snapshot_date": "2021-02-07T00:00:00+00:00",

--- a/tests/onix_workflow/test_onix_workflow.py
+++ b/tests/onix_workflow/test_onix_workflow.py
@@ -42,6 +42,7 @@ from oaebu_workflows.onix_workflow.onix_workflow import (
 from observatory_platform.airflow.workflow import Workflow
 from observatory_platform.config import module_file_path
 from observatory_platform.dataset_api import DatasetAPI
+from observatory_platform.date_utils import datetime_normalise
 from observatory_platform.files import load_jsonl, save_jsonl
 from observatory_platform.google.bigquery import bq_find_schema, bq_run_query, bq_sharded_table_id, bq_table_id
 from observatory_platform.google.gcs import gcs_blob_name_from_path
@@ -1292,7 +1293,7 @@ class TestOnixWorkflow(SandboxTestCase):
                 self.assertEqual(len(dataset_releases), 0)
 
                 # Add_dataset_release_task
-                now = pendulum.now("UTC")  # Use UTC to ensure +00UTC timezone
+                now = pendulum.now()
                 with patch("oaebu_workflows.onix_workflow.onix_workflow.pendulum.now") as mock_now:
                     mock_now.return_value = now
                     ti = env.run_task("add_new_dataset_releases")
@@ -1303,9 +1304,8 @@ class TestOnixWorkflow(SandboxTestCase):
                     "dag_id": dag_id,
                     "entity_id": "onix_workflow",
                     "dag_run_id": release.run_id,
-                    # Replace Z shorthand because BQ converts it to +00:00
-                    "created": now.to_iso8601_string().replace("Z", "+00:00"),
-                    "modified": now.to_iso8601_string().replace("Z", "+00:00"),
+                        "created": datetime_normalise(now),
+                        "modified": datetime_normalise(now),
                     "data_interval_start": "2021-05-17T00:00:00+00:00",
                     "data_interval_end": "2021-05-24T00:00:00+00:00",
                     "snapshot_date": "2021-05-24T00:00:00+00:00",

--- a/tests/onix_workflow/test_onix_workflow.py
+++ b/tests/onix_workflow/test_onix_workflow.py
@@ -983,7 +983,7 @@ class TestOnixWorkflow(SandboxTestCase):
             bq_worksid_table_name = "onix_workid_isbn"
             bq_worksid_error_table_name = "onix_workid_isbn_errors"
             bq_workfamilyid_table_name = "onix_workfamilyid_isbn"
-            api_dataset_id = env.add_dataset()
+            api_bq_dataset_id = env.add_dataset()
             dag = create_dag(
                 dag_id=dag_id,
                 cloud_workspace=env.cloud_workspace,
@@ -1008,7 +1008,7 @@ class TestOnixWorkflow(SandboxTestCase):
                 bq_workfamilyid_table_name=bq_workfamilyid_table_name,
                 bq_oaebu_export_dataset=oaebu_export_dataset_id,
                 bq_oaebu_latest_export_dataset=oaebu_latest_export_dataset_id,
-                api_dataset_id=api_dataset_id,
+                api_bq_dataset_id=api_bq_dataset_id,
                 data_partners=data_partners,
                 sensor_dag_ids=sensor_dag_ids,
                 start_date=start_date,
@@ -1286,9 +1286,9 @@ class TestOnixWorkflow(SandboxTestCase):
                 ################################
 
                 # Set up the API
-                api = DatasetAPI(project_id=self.gcp_project_id, dataset_id=api_dataset_id)
+                api = DatasetAPI(bq_project_id=self.gcp_project_id, bq_dataset_id=api_bq_dataset_id)
                 api.seed_db()
-                dataset_releases = api.get_dataset_releases(dag_id=dag_id, dataset_id=api_dataset_id)
+                dataset_releases = api.get_dataset_releases(dag_id=dag_id, entity_id="onix_workflow")
                 self.assertEqual(len(dataset_releases), 0)
 
                 # Add_dataset_release_task
@@ -1297,11 +1297,11 @@ class TestOnixWorkflow(SandboxTestCase):
                     mock_now.return_value = now
                     ti = env.run_task("add_new_dataset_releases")
                 self.assertEqual(ti.state, State.SUCCESS)
-                dataset_releases = api.get_dataset_releases(dag_id=dag_id, dataset_id=api_dataset_id)
+                dataset_releases = api.get_dataset_releases(dag_id=dag_id, entity_id="onix_workflow")
                 self.assertEqual(len(dataset_releases), 1)
                 expected_release = {
                     "dag_id": dag_id,
-                    "dataset_id": api_dataset_id,
+                    "entity_id": "onix_workflow",
                     "dag_run_id": release.run_id,
                     # Replace Z shorthand because BQ converts it to +00:00
                     "created": now.to_iso8601_string().replace("Z", "+00:00"),

--- a/tests/ucl_discovery_telescope/test_ucl_discovery_telescope.py
+++ b/tests/ucl_discovery_telescope/test_ucl_discovery_telescope.py
@@ -32,12 +32,13 @@ from oaebu_workflows.ucl_discovery_telescope.ucl_discovery_telescope import (
     download_discovery_stats,
     transform_discovery_stats,
 )
+from observatory_platform.airflow.workflow import Workflow
 from observatory_platform.dataset_api import DatasetAPI
+from observatory_platform.date_utils import datetime_normalise
 from observatory_platform.google.bigquery import bq_table_id
 from observatory_platform.google.gcs import gcs_blob_name_from_path
-from observatory_platform.airflow.workflow import Workflow
-from observatory_platform.sandbox.test_utils import SandboxTestCase, load_and_parse_json
 from observatory_platform.sandbox.sandbox_environment import SandboxEnvironment
+from observatory_platform.sandbox.test_utils import SandboxTestCase, load_and_parse_json
 
 
 class TestUclDiscoveryTelescope(SandboxTestCase):
@@ -217,7 +218,7 @@ class TestUclDiscoveryTelescope(SandboxTestCase):
             self.assertEqual(len(dataset_releases), 0)
 
             # Add_dataset_release_task
-            now = pendulum.now("UTC")  # Use UTC to ensure +00UTC timezone
+            now = pendulum.now()
             with patch("oaebu_workflows.ucl_discovery_telescope.ucl_discovery_telescope.pendulum.now") as mock_now:
                 mock_now.return_value = now
                 ti = env.run_task("add_new_dataset_releases")
@@ -228,9 +229,8 @@ class TestUclDiscoveryTelescope(SandboxTestCase):
                 "dag_id": dag_id,
                 "entity_id": "ucl_discovery",
                 "dag_run_id": release.run_id,
-                # Replace Z shorthand because BQ converts it to +00:00
-                "created": now.to_iso8601_string().replace("Z", "+00:00"),
-                "modified": now.to_iso8601_string().replace("Z", "+00:00"),
+                "created": datetime_normalise(now),
+                "modified": datetime_normalise(now),
                 "data_interval_start": "2023-06-01T00:00:00+00:00",
                 "data_interval_end": "2023-06-04T00:00:00+00:00",
                 "snapshot_date": None,


### PR DESCRIPTION
Updates to how the DatasetAPI and its releases are used. Fixes a bug that was introduced in the refactor that incorrectly labels the 'dataset_id' of the API entries. It should now be much clearer how the API and Release objects interact with bigquery.
