### PR TITLE
Find format from filename, not filepath

### DIFF
--- a/dags/oaebu_workflows/onix_utils.py
+++ b/dags/oaebu_workflows/onix_utils.py
@@ -200,7 +200,8 @@ class OnixTransformer:
         self._current_md_path = file_path
 
     def _load_metadata(self, file_path: str):
-        format = re.search(r"\.(.*)$", file_path).group(1)
+        fname = file_path.split("/")[-1]
+        format = re.search(r"\.(.*)$", fname).group(1)
         if format == "xml":
             with open(file_path, "rb") as f:
                 metadata = xmltodict.parse(f)


### PR DESCRIPTION
The date generated by airflow can have a decimal place in it, which makes its way into the filepath. This breaks the regex output that determines the file format. I added a line that extracts the file name in order to determine the format instead.