### PR TITLE
Onix wf custom schedule

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -40,6 +40,7 @@ jobs:
       - name: Add dag folder to PYTHONPATH
         run: |
           echo "PYTHONPATH=$HOME/work/oaebu-workflows/oaebu-workflows/dags" >> "$GITHUB_ENV"
+          echo "PYTHONPATH=$HOME/work/oaebu-workflows/oaebu-workflows/plugins" >> "$GITHUB_ENV"
 
       # Required for testing ONIX Telescope
       - name: Set up JDK 11

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -39,8 +39,7 @@ jobs:
 
       - name: Add dag folder to PYTHONPATH
         run: |
-          echo "PYTHONPATH=$HOME/work/oaebu-workflows/oaebu-workflows/dags" >> "$GITHUB_ENV"
-          echo "PYTHONPATH=$PYTHONPATH:$HOME/work/oaebu-workflows/oaebu-workflows/plugins" >> "$GITHUB_ENV"
+          echo "PYTHONPATH=$HOME/work/oaebu-workflows/oaebu-workflows/dags:$HOME/work/oaebu-workflows/oaebu-workflows/plugins" >> "$GITHUB_ENV"
 
       # Required for testing ONIX Telescope
       - name: Set up JDK 11

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Add dag folder to PYTHONPATH
         run: |
           echo "PYTHONPATH=$HOME/work/oaebu-workflows/oaebu-workflows/dags" >> "$GITHUB_ENV"
-          echo "PYTHONPATH=$HOME/work/oaebu-workflows/oaebu-workflows/plugins" >> "$GITHUB_ENV"
+          echo "PYTHONPATH=$PYTHONPATH:$HOME/work/oaebu-workflows/oaebu-workflows/plugins" >> "$GITHUB_ENV"
 
       # Required for testing ONIX Telescope
       - name: Set up JDK 11

--- a/dags/oaebu_workflows/onix_workflow/onix_workflow.py
+++ b/dags/oaebu_workflows/onix_workflow/onix_workflow.py
@@ -27,6 +27,7 @@ from airflow.decorators import dag, task, task_group
 from airflow.exceptions import AirflowSkipException
 from airflow.models.baseoperator import chain
 from airflow.utils.trigger_rule import TriggerRule
+from airflow.timetables.base import Timetable
 from google.cloud.bigquery import Client, SourceFormat
 from jinja2 import Environment, FileSystemLoader
 from ratelimit import limits, sleep_and_retry
@@ -37,6 +38,7 @@ from oaebu_workflows.airflow_pools import CrossrefEventsPool
 from oaebu_workflows.config import oaebu_user_agent_header, schema_folder as default_schema_folder, sql_folder
 from oaebu_workflows.oaebu_partners import DataPartner, OaebuPartner, partner_from_str, create_bespoke_data_partners
 from oaebu_workflows.onix_workflow.onix_work_aggregation import BookWorkAggregator, BookWorkFamilyAggregator
+from plugins.onix_workflow_schedule import OnixWorkflowTimetable
 from observatory_platform.airflow.airflow import on_failure_callback
 from observatory_platform.airflow.release import make_snapshot_date, set_task_state, SnapshotRelease
 from observatory_platform.airflow.sensors import DagCompleteSensor
@@ -246,7 +248,7 @@ def create_dag(
     sensor_dag_ids: List[str] = None,
     catchup: Optional[bool] = False,
     start_date: Optional[pendulum.DateTime] = pendulum.datetime(2022, 8, 1),
-    schedule: Optional[str] = "0 0 * * Mon",  # Mondays at midnight
+    schedule: Union[str, Timetable] = OnixWorkflowTimetable(),  # Every Sunday and the 5th of the month
     max_active_runs: int = 1,
     retries: int = 3,
     retry_delay: Union[int, float] = 5,

--- a/dags/oaebu_workflows/onix_workflow/onix_workflow.py
+++ b/dags/oaebu_workflows/onix_workflow/onix_workflow.py
@@ -38,7 +38,7 @@ from oaebu_workflows.airflow_pools import CrossrefEventsPool
 from oaebu_workflows.config import oaebu_user_agent_header, schema_folder as default_schema_folder, sql_folder
 from oaebu_workflows.oaebu_partners import DataPartner, OaebuPartner, partner_from_str, create_bespoke_data_partners
 from oaebu_workflows.onix_workflow.onix_work_aggregation import BookWorkAggregator, BookWorkFamilyAggregator
-from plugins.onix_workflow_schedule import OnixWorkflowTimetable
+from onix_workflow_schedule import OnixWorkflowTimetable
 from observatory_platform.airflow.airflow import on_failure_callback
 from observatory_platform.airflow.release import make_snapshot_date, set_task_state, SnapshotRelease
 from observatory_platform.airflow.sensors import DagCompleteSensor

--- a/dags/oaebu_workflows/onix_workflow/onix_workflow_schedule.py
+++ b/dags/oaebu_workflows/onix_workflow/onix_workflow_schedule.py
@@ -1,0 +1,76 @@
+from pendulum import Date, DateTime, Time, datetime, timedelta, UTC
+
+from airflow.plugins_manager import AirflowPlugin
+from airflow.timetables.base import DagRunInfo, DataInterval, TimeRestriction, Timetable
+
+# DOCS: https://airflow.apache.org/docs/apache-airflow/stable/howto/timetable.html#define-scheduling-logic
+
+
+class OnixWorkflowTimetable(Timetable):
+
+    def get_end_of_interval(self, start_time: DateTime) -> DateTime:
+        """Find the end time given a start time
+
+        :param start_time: The starting datetime for which to find the ending interval for
+        :return: The end of the interval
+        """
+        provisional_end = DateTime.combine((start_time + timedelta(days=7)).date(), Time.min)
+        competing_end = datetime(year=provisional_end.year, month=provisional_end.month, day=5)
+
+        # If the start date is before the 5th of the "end" month, cut the end date off at the 5th
+        if start_time < competing_end:
+            end_time = competing_end
+        else:
+            end_time = provisional_end
+
+        return end_time
+
+    def infer_manual_data_interval(self, run_after: DateTime) -> DataInterval:
+        """Overrides the base class function.
+        When a DAG run is manually triggered, infer a data interval for it.
+
+        :param run_after: The time that the run is triggered.
+        """
+
+        # Start of interval - the end of the previous day
+        start_date = (run_after - timedelta(days=1)).date()
+        start = DateTime.combine(start_date, Time.min).replace(tzinfo=UTC)
+        end = self.get_end_of_interval(start)
+
+        return DataInterval(start=start, end=end)
+
+    def next_dagrun_info(
+        self,
+        *,
+        last_automated_data_interval: DataInterval | None,
+        restriction: TimeRestriction,
+    ) -> DagRunInfo:
+        """Overrides the base class function
+        Provide information to schedule the next DagRun.
+
+        :param last_automated_data_interval: The data interval of the associated
+            DAG's last scheduled or backfilled run (manual runs not considered).
+        :param restriction: Restriction to apply when scheduling the DAG run.
+            See documentation of :class:`TimeRestriction` for details.
+        :return: Information on when the next DagRun can be scheduled.
+        """
+
+        if restriction.catchup:
+            raise ValueError("Onix Workflow timetable received unexpected catchup=True setting")
+
+        # There was a previous run on the regular schedule.
+        if last_automated_data_interval is not None:
+            last_start = last_automated_data_interval.start
+            next_start = self.get_end_of_interval(last_start)
+
+        # Otherwise this is the first ever run on the regular schedule...
+        else:
+            next_start = max(restriction.earliest, DateTime.combine(Date.today(), Time.min))
+
+        return DagRunInfo.interval(start=next_start, end=self.get_end_of_interval(next_start))
+
+
+class OnixWorkflowTimetablePlugin(AirflowPlugin):
+    # I don't know why, but the documentation says this is required
+    name = "onix_workflow_timetable_plugin"
+    timetables = [OnixWorkflowTimetable]

--- a/plugins/onix_workflow_schedule.py
+++ b/plugins/onix_workflow_schedule.py
@@ -25,11 +25,8 @@ class OnixWorkflowTimetable(Timetable):
         :return: The previous runtime
         """
 
-        # Get the previous sunday
-        days_delta = time.weekday() + 1
-        if days_delta == 7:  # Is a sunday, don't alter the input
-            days_delta = 0
-        start_time = time - timedelta(days_delta)
+        # Get the previous monday
+        start_time = time - timedelta(time.weekday())
 
         # Don't allow the start date to cross the 5th of the month
         if time >= time.replace(day=5) and start_time <= time.replace(day=5):
@@ -43,10 +40,8 @@ class OnixWorkflowTimetable(Timetable):
         :return: The end of the interval
         """
 
-        # Get the next sunday
-        days_delta = 7 - (time.weekday() + 1)
-        if days_delta == 0:  # Is a sunday, skip ahead 7 days
-            days_delta += 7
+        # Get the next monday
+        days_delta = 7 - (time.weekday())
         end_time = time + timedelta(days_delta)
 
         # Don't allow the end date to cross the 5th of the month
@@ -63,7 +58,7 @@ class OnixWorkflowTimetable(Timetable):
 
         # Start of interval - the end of the previous sunday or the 5th
         start = self.get_start_of_interval(run_after)
-        end = self.get_end_of_interval(start)
+        end = self.get_end_of_interval(run_after)
 
         return DataInterval(start=start, end=end)
 

--- a/plugins/onix_workflow_schedule.py
+++ b/plugins/onix_workflow_schedule.py
@@ -12,10 +12,10 @@ class OnixWorkflowTimetable(Timetable):
     """A custom timetable for the Onix Workflow. The timetable runs every sunday and on the 5th of every month
 
     *Known Quirks*
-    Airflow treats custom timetables slightly differently when scheduling. When using this scheduler, any calls to
-    dag.next_dagrun_info() must supply either None or a DataInterval. Passing a DateTime object WILL RAISE AN
-    EXCEPTION. When testing with sandbox_environment.create_dag_run(), you can pass a data interval with an empty end
-    date as the execution date.
+    This timetable is a plugin and must be registered with airflow to be used. If it's not registered, it will raise
+    an exception. At the time of writing, airflow has specific requirements for timetable plugin imports. THEY MUST
+    BE IMPORTED RELATIVE TO THE PLUGIN FOLDER.
+    https://github.com/apache/airflow/discussions/23758
     """
 
     def get_start_of_interval(self, time: DateTime) -> DateTime:
@@ -101,6 +101,5 @@ class OnixWorkflowTimetable(Timetable):
 
 
 class OnixWorkflowTimetablePlugin(AirflowPlugin):
-    # I don't know why, but the documentation says this is required
     name = "onix_workflow_timetable_plugin"
     timetables = [OnixWorkflowTimetable]

--- a/plugins/onix_workflow_schedule.py
+++ b/plugins/onix_workflow_schedule.py
@@ -1,4 +1,3 @@
-import logging
 from datetime import timedelta
 
 from pendulum import Date, DateTime, Time, datetime, UTC
@@ -10,6 +9,15 @@ from airflow.timetables.base import DagRunInfo, DataInterval, TimeRestriction, T
 
 
 class OnixWorkflowTimetable(Timetable):
+    """A custom timetable for the Onix Workflow. The timetable runs every sunday and on the 5th of every month
+
+    *Known Quirks*
+    Airflow treats custom timetables slightly differently when scheduling. When using this scheduler, any calls to
+    dag.next_dagrun_info() must supply either None or a DataInterval. Passing a DateTime object WILL RAISE AN
+    EXCEPTION. When testing with sandbox_environment.create_dag_run(), you can pass a data interval with an empty end
+    date as the execution date.
+    """
+
     def get_start_of_interval(self, time: DateTime) -> DateTime:
         """Gets the start of the interval for the schedule, given a current datetime
 

--- a/tests/onix_workflow/test_onix_workflow_schedule.py
+++ b/tests/onix_workflow/test_onix_workflow_schedule.py
@@ -48,9 +48,9 @@ class TestOnixWorkflowSchedule(unittest.TestCase):
         env = SandboxEnvironment()
         with env.create():
             dag_start_date = pendulum.datetime(year=2020, month=1, day=1, tz=pendulum.UTC)
-            expected_start_date = pendulum.datetime(year=2020, month=1, day=26, tz=pendulum.UTC)  # Sunday
-            expected_end_date = pendulum.datetime(year=2020, month=2, day=2, tz=pendulum.UTC)  # Sunday
-            now = pendulum.datetime(year=2020, month=2, day=1, tz=pendulum.UTC)  # Saturday
+            expected_start_date = pendulum.datetime(year=2020, month=1, day=27, tz=pendulum.UTC)  # Monday
+            expected_end_date = pendulum.datetime(year=2020, month=2, day=3, tz=pendulum.UTC)  # Monday
+            now = pendulum.datetime(year=2020, month=2, day=2, tz=pendulum.UTC)  # Sunday
             with time_machine.travel(now):
                 dag = make_test_dag(dag_start_date)
                 dag_run_info = dag.next_dagrun_info(last_automated_dagrun=None)
@@ -70,7 +70,7 @@ class TestOnixWorkflowSchedule(unittest.TestCase):
         """Test the schedule when it's called by airflow's next_dagrun_info function with the catchup setting on"""
         env = SandboxEnvironment()
         with env.create():
-            start_date = pendulum.datetime(year=2020, month=1, day=6, tz=pendulum.UTC)  # Sunday
+            start_date = pendulum.datetime(year=2020, month=1, day=7, tz=pendulum.UTC)  # Monday
             dag = make_test_dag(start_date, catchup=True)
             # The timetable raises a value error but it's caught by airflow. So we check that info==None
             info = dag.next_dagrun_info(last_automated_dagrun=None)
@@ -82,16 +82,16 @@ class TestOnixWorkflowSchedule(unittest.TestCase):
         inputs = [
             pendulum.datetime(year=2020, month=1, day=1, tz=pendulum.UTC),  # Wednesday
             pendulum.datetime(year=2020, month=1, day=31, tz=pendulum.UTC),  # Friday
-            pendulum.datetime(year=2020, month=1, day=5, tz=pendulum.UTC),  # Sunday the 5th
-            pendulum.datetime(year=2020, month=1, day=6, tz=pendulum.UTC),  # Monday
+            pendulum.datetime(year=2020, month=10, day=5, tz=pendulum.UTC),  # Monday the 5th
+            pendulum.datetime(year=2020, month=1, day=7, tz=pendulum.UTC),  # Tueday
             pendulum.datetime(year=2020, month=2, day=5, tz=pendulum.UTC),  # Wednesday
             pendulum.datetime(year=2020, month=2, day=5, tz=pendulum.timezone("Etc/GMT+1")),  # Altered timezone
         ]
         expected_outputs = [
-            pendulum.datetime(year=2019, month=12, day=29, tz=pendulum.UTC),  # Sunday
-            pendulum.datetime(year=2020, month=1, day=26, tz=pendulum.UTC),  # Sunday
-            pendulum.datetime(year=2020, month=1, day=5, tz=pendulum.UTC),  # Sunday The 5th
-            pendulum.datetime(year=2020, month=1, day=5, tz=pendulum.UTC),  # Sunday The 5th
+            pendulum.datetime(year=2019, month=12, day=30, tz=pendulum.UTC),  # Monday
+            pendulum.datetime(year=2020, month=1, day=27, tz=pendulum.UTC),  # Monday
+            pendulum.datetime(year=2020, month=10, day=5, tz=pendulum.UTC),  # Monday The 5th
+            pendulum.datetime(year=2020, month=1, day=6, tz=pendulum.UTC),  # Monday
             pendulum.datetime(year=2020, month=2, day=5, tz=pendulum.UTC),  # The 5th
             pendulum.datetime(year=2020, month=2, day=5, tz=pendulum.UTC),  # The 5th @ UTC
         ]
@@ -106,18 +106,18 @@ class TestOnixWorkflowSchedule(unittest.TestCase):
         inputs = [
             pendulum.datetime(year=2020, month=1, day=1, tz=pendulum.UTC),  # Wednesday
             pendulum.datetime(year=2020, month=1, day=31, tz=pendulum.UTC),  # Friday
-            pendulum.datetime(year=2020, month=1, day=5, tz=pendulum.UTC),  # Sunday the 5th
-            pendulum.datetime(year=2020, month=1, day=6, tz=pendulum.UTC),  # Monday
+            pendulum.datetime(year=2020, month=10, day=5, tz=pendulum.UTC),  # Monday the 5th
+            pendulum.datetime(year=2020, month=1, day=7, tz=pendulum.UTC),  # Tuesday
             pendulum.datetime(year=2020, month=2, day=5, tz=pendulum.UTC),  # Wednesday
             pendulum.datetime(year=2020, month=2, day=5, tz=pendulum.timezone("Etc/GMT+1")),  # Altered timezone
         ]
         expected_outputs = [
-            pendulum.datetime(year=2020, month=1, day=5, tz=pendulum.UTC),  # Sunday the 5th
-            pendulum.datetime(year=2020, month=2, day=2, tz=pendulum.UTC),  # Sunday
-            pendulum.datetime(year=2020, month=1, day=12, tz=pendulum.UTC),  # Sunday (1 week after start)
-            pendulum.datetime(year=2020, month=1, day=12, tz=pendulum.UTC),  # Sunday
-            pendulum.datetime(year=2020, month=2, day=9, tz=pendulum.UTC),  # Sunday
-            pendulum.datetime(year=2020, month=2, day=9, tz=pendulum.UTC),  # Sunday @ UTC
+            pendulum.datetime(year=2020, month=1, day=5, tz=pendulum.UTC),  # The 5th
+            pendulum.datetime(year=2020, month=2, day=3, tz=pendulum.UTC),  # Monday
+            pendulum.datetime(year=2020, month=10, day=12, tz=pendulum.UTC),  # Monday (1 week after start)
+            pendulum.datetime(year=2020, month=1, day=13, tz=pendulum.UTC),  # Monday
+            pendulum.datetime(year=2020, month=2, day=10, tz=pendulum.UTC),  # Monday
+            pendulum.datetime(year=2020, month=2, day=10, tz=pendulum.UTC),  # Monday @ UTC
         ]
         for i, eo in zip(inputs, expected_outputs):
             logging.info(f"Input time: {i}")
@@ -130,35 +130,35 @@ class TestOnixWorkflowSchedule(unittest.TestCase):
         inputs = [
             pendulum.datetime(year=2020, month=1, day=1, tz=pendulum.UTC),  # Wednesday
             pendulum.datetime(year=2020, month=1, day=31, tz=pendulum.UTC),  # Friday
-            pendulum.datetime(year=2020, month=1, day=5, tz=pendulum.UTC),  # Sunday the 5th
-            pendulum.datetime(year=2020, month=1, day=6, tz=pendulum.UTC),  # Monday
+            pendulum.datetime(year=2020, month=10, day=5, tz=pendulum.UTC),  # Monday the 5th
+            pendulum.datetime(year=2020, month=1, day=7, tz=pendulum.UTC),  # Tuesday
             pendulum.datetime(year=2020, month=2, day=5, tz=pendulum.UTC),  # Wednesday
             pendulum.datetime(year=2020, month=2, day=5, tz=pendulum.timezone("Etc/GMT+1")),  # Altered timezone
         ]
         expected_outputs = [
             DataInterval(
-                pendulum.datetime(year=2019, month=12, day=29, tz=pendulum.UTC),
+                pendulum.datetime(year=2019, month=12, day=30, tz=pendulum.UTC),
                 pendulum.datetime(year=2020, month=1, day=5, tz=pendulum.UTC),
             ),
             DataInterval(
-                pendulum.datetime(year=2020, month=1, day=26, tz=pendulum.UTC),
-                pendulum.datetime(year=2020, month=2, day=2, tz=pendulum.UTC),
+                pendulum.datetime(year=2020, month=1, day=27, tz=pendulum.UTC),
+                pendulum.datetime(year=2020, month=2, day=3, tz=pendulum.UTC),
             ),
             DataInterval(
-                pendulum.datetime(year=2020, month=1, day=5, tz=pendulum.UTC),
-                pendulum.datetime(year=2020, month=1, day=12, tz=pendulum.UTC),
+                pendulum.datetime(year=2020, month=10, day=5, tz=pendulum.UTC),
+                pendulum.datetime(year=2020, month=10, day=12, tz=pendulum.UTC),
             ),
             DataInterval(
-                pendulum.datetime(year=2020, month=1, day=5, tz=pendulum.UTC),
-                pendulum.datetime(year=2020, month=1, day=12, tz=pendulum.UTC),
+                pendulum.datetime(year=2020, month=1, day=6, tz=pendulum.UTC),
+                pendulum.datetime(year=2020, month=1, day=13, tz=pendulum.UTC),
             ),
             DataInterval(
                 pendulum.datetime(year=2020, month=2, day=5, tz=pendulum.UTC),
-                pendulum.datetime(year=2020, month=2, day=9, tz=pendulum.UTC),
+                pendulum.datetime(year=2020, month=2, day=10, tz=pendulum.UTC),
             ),
             DataInterval(
                 pendulum.datetime(year=2020, month=2, day=5, tz=pendulum.UTC),
-                pendulum.datetime(year=2020, month=2, day=9, tz=pendulum.UTC),
+                pendulum.datetime(year=2020, month=2, day=10, tz=pendulum.UTC),
             ),
         ]
         for i, eo in zip(inputs, expected_outputs):

--- a/tests/onix_workflow/test_onix_workflow_schedule.py
+++ b/tests/onix_workflow/test_onix_workflow_schedule.py
@@ -14,6 +14,7 @@
 
 # Author: Keegan Smith
 
+import logging
 import unittest
 
 from airflow.decorators import dag
@@ -38,50 +39,88 @@ def make_test_dag(start_date=pendulum.datetime(year=2020, month=1, day=1), catch
 
 
 class TestOnixWorkflowSchedule(unittest.TestCase):
+    def test_get_start_of_interval(self):
+        timetable = OnixWorkflowTimetable()
+        inputs = [
+            pendulum.datetime(year=2020, month=1, day=1, tz=pendulum.UTC),  # Wednesday
+            pendulum.datetime(year=2020, month=1, day=31, tz=pendulum.UTC),  # Friday
+            pendulum.datetime(year=2020, month=1, day=5, tz=pendulum.UTC),  # Sunday the 5th
+            pendulum.datetime(year=2020, month=1, day=6, tz=pendulum.UTC),  # Monday
+            pendulum.datetime(year=2020, month=2, day=5, tz=pendulum.UTC),  # Wednesday
+            pendulum.datetime(year=2020, month=2, day=5, tz=pendulum.timezone("Etc/GMT+1")),  # Altered timezone
+        ]
+        expected_outputs = [
+            pendulum.datetime(year=2019, month=12, day=29, tz=pendulum.UTC),
+            pendulum.datetime(year=2020, month=1, day=26, tz=pendulum.UTC),
+            pendulum.datetime(year=2020, month=1, day=5, tz=pendulum.UTC),
+            pendulum.datetime(year=2020, month=1, day=5, tz=pendulum.UTC),
+            pendulum.datetime(year=2020, month=2, day=5, tz=pendulum.UTC),
+            pendulum.datetime(year=2020, month=2, day=5, tz=pendulum.UTC),
+        ]
+        for i, eo in zip(inputs, expected_outputs):
+            logging.info(f"Input time: {i}")
+            output = timetable.get_start_of_interval(i)
+            self.assertEqual(eo, output)
+
     def test_get_end_of_interval(self):
         timetable = OnixWorkflowTimetable()
         inputs = [
-            pendulum.datetime(year=2020, month=1, day=1, tz=pendulum.UTC),
-            pendulum.datetime(year=2020, month=1, day=31, tz=pendulum.UTC),
-            pendulum.datetime(year=2020, month=1, day=5, tz=pendulum.UTC),
-            pendulum.datetime(year=2020, month=1, day=6, tz=pendulum.UTC),
+            pendulum.datetime(year=2020, month=1, day=1, tz=pendulum.UTC),  # Wednesday
+            pendulum.datetime(year=2020, month=1, day=31, tz=pendulum.UTC),  # Friday
+            pendulum.datetime(year=2020, month=1, day=5, tz=pendulum.UTC),  # Sunday the 5th
+            pendulum.datetime(year=2020, month=1, day=6, tz=pendulum.UTC),  # Monday
+            pendulum.datetime(year=2020, month=2, day=5, tz=pendulum.UTC),  # Wednesday
+            pendulum.datetime(year=2020, month=2, day=5, tz=pendulum.timezone("Etc/GMT+1")),  # Altered timezone
         ]
         expected_outputs = [
             pendulum.datetime(year=2020, month=1, day=5, tz=pendulum.UTC),
-            pendulum.datetime(year=2020, month=2, day=5, tz=pendulum.UTC),
+            pendulum.datetime(year=2020, month=2, day=2, tz=pendulum.UTC),
             pendulum.datetime(year=2020, month=1, day=12, tz=pendulum.UTC),
-            pendulum.datetime(year=2020, month=1, day=13, tz=pendulum.UTC),
+            pendulum.datetime(year=2020, month=1, day=12, tz=pendulum.UTC),
+            pendulum.datetime(year=2020, month=2, day=9, tz=pendulum.UTC),
+            pendulum.datetime(year=2020, month=2, day=9, tz=pendulum.UTC),
         ]
         for i, eo in zip(inputs, expected_outputs):
+            logging.info(f"Input time: {i}")
             output = timetable.get_end_of_interval(i)
-            self.assertEqual(output, eo)
+            self.assertEqual(eo, output)
 
     def test_infer_manual_data_interval(self):
         timetable = OnixWorkflowTimetable()
         inputs = [
-            pendulum.datetime(year=2020, month=1, day=1, tz=pendulum.UTC),
-            pendulum.datetime(year=2020, month=1, day=31, tz=pendulum.UTC),
-            pendulum.datetime(year=2020, month=1, day=5, tz=pendulum.UTC),
-            pendulum.datetime(year=2020, month=1, day=6, tz=pendulum.UTC),
+            pendulum.datetime(year=2020, month=1, day=1, tz=pendulum.UTC),  # Wednesday
+            pendulum.datetime(year=2020, month=1, day=31, tz=pendulum.UTC),  # Friday
+            pendulum.datetime(year=2020, month=1, day=5, tz=pendulum.UTC),  # Sunday the 5th
+            pendulum.datetime(year=2020, month=1, day=6, tz=pendulum.UTC),  # Monday
+            pendulum.datetime(year=2020, month=2, day=5, tz=pendulum.UTC),  # Wednesday
+            pendulum.datetime(year=2020, month=2, day=5, tz=pendulum.timezone("Etc/GMT+1")),  # Altered timezone
         ]
         expected_outputs = [
             DataInterval(
-                pendulum.datetime(year=2020, month=1, day=1, tz=pendulum.UTC),
+                pendulum.datetime(year=2019, month=12, day=29, tz=pendulum.UTC),
                 pendulum.datetime(year=2020, month=1, day=5, tz=pendulum.UTC),
             ),
             DataInterval(
-                pendulum.datetime(year=2020, month=1, day=31, tz=pendulum.UTC),
-                pendulum.datetime(year=2020, month=2, day=5, tz=pendulum.UTC),
+                pendulum.datetime(year=2020, month=1, day=26, tz=pendulum.UTC),
+                pendulum.datetime(year=2020, month=2, day=2, tz=pendulum.UTC),
             ),
             DataInterval(
                 pendulum.datetime(year=2020, month=1, day=5, tz=pendulum.UTC),
                 pendulum.datetime(year=2020, month=1, day=12, tz=pendulum.UTC),
             ),
             DataInterval(
-                pendulum.datetime(year=2020, month=1, day=6, tz=pendulum.UTC),
-                pendulum.datetime(year=2020, month=1, day=13, tz=pendulum.UTC),
+                pendulum.datetime(year=2020, month=1, day=5, tz=pendulum.UTC),
+                pendulum.datetime(year=2020, month=1, day=12, tz=pendulum.UTC),
+            ),
+            DataInterval(
+                pendulum.datetime(year=2020, month=2, day=5, tz=pendulum.UTC),
+                pendulum.datetime(year=2020, month=2, day=9, tz=pendulum.UTC),
+            ),
+            DataInterval(
+                pendulum.datetime(year=2020, month=2, day=5, tz=pendulum.UTC),
+                pendulum.datetime(year=2020, month=2, day=9, tz=pendulum.UTC),
             ),
         ]
         for i, eo in zip(inputs, expected_outputs):
             output = timetable.infer_manual_data_interval(i)
-            self.assertEqual(output, eo)
+            self.assertEqual(eo, output)

--- a/tests/onix_workflow/test_onix_workflow_schedule.py
+++ b/tests/onix_workflow/test_onix_workflow_schedule.py
@@ -23,7 +23,7 @@ from airflow.timetables.base import DataInterval
 import pendulum
 import time_machine
 
-from oaebu_workflows.onix_workflow.onix_workflow_schedule import OnixWorkflowTimetable
+from onix_workflow_schedule import OnixWorkflowTimetable
 from observatory_platform.sandbox.sandbox_environment import SandboxEnvironment
 
 

--- a/tests/onix_workflow/test_onix_workflow_schedule.py
+++ b/tests/onix_workflow/test_onix_workflow_schedule.py
@@ -1,0 +1,87 @@
+# Copyright 2020-2024 Curtin University
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Author: Keegan Smith
+
+import unittest
+
+from airflow.decorators import dag
+from airflow.operators.empty import EmptyOperator
+import pendulum
+
+from oaebu_workflows.onix_workflow.onix_workflow_schedule import OnixWorkflowTimetable
+from airflow.timetables.base import DagRunInfo, DataInterval, TimeRestriction
+
+
+def make_test_dag(start_date=pendulum.datetime(year=2020, month=1, day=1), catchup=False):
+    @dag(
+        dag_id="test_dag",
+        schedule=OnixWorkflowTimetable(),
+        start_date=start_date,
+        catchup=catchup,
+    )
+    def my_dag():
+        EmptyOperator(task_id="test_task")
+
+    return my_dag()
+
+
+class TestOnixWorkflowSchedule(unittest.TestCase):
+    def test_get_end_of_interval(self):
+        timetable = OnixWorkflowTimetable()
+        inputs = [
+            pendulum.datetime(year=2020, month=1, day=1, tz=pendulum.UTC),
+            pendulum.datetime(year=2020, month=1, day=31, tz=pendulum.UTC),
+            pendulum.datetime(year=2020, month=1, day=5, tz=pendulum.UTC),
+            pendulum.datetime(year=2020, month=1, day=6, tz=pendulum.UTC),
+        ]
+        expected_outputs = [
+            pendulum.datetime(year=2020, month=1, day=5, tz=pendulum.UTC),
+            pendulum.datetime(year=2020, month=2, day=5, tz=pendulum.UTC),
+            pendulum.datetime(year=2020, month=1, day=12, tz=pendulum.UTC),
+            pendulum.datetime(year=2020, month=1, day=13, tz=pendulum.UTC),
+        ]
+        for i, eo in zip(inputs, expected_outputs):
+            output = timetable.get_end_of_interval(i)
+            self.assertEqual(output, eo)
+
+    def test_infer_manual_data_interval(self):
+        timetable = OnixWorkflowTimetable()
+        inputs = [
+            pendulum.datetime(year=2020, month=1, day=1, tz=pendulum.UTC),
+            pendulum.datetime(year=2020, month=1, day=31, tz=pendulum.UTC),
+            pendulum.datetime(year=2020, month=1, day=5, tz=pendulum.UTC),
+            pendulum.datetime(year=2020, month=1, day=6, tz=pendulum.UTC),
+        ]
+        expected_outputs = [
+            DataInterval(
+                pendulum.datetime(year=2020, month=1, day=1, tz=pendulum.UTC),
+                pendulum.datetime(year=2020, month=1, day=5, tz=pendulum.UTC),
+            ),
+            DataInterval(
+                pendulum.datetime(year=2020, month=1, day=31, tz=pendulum.UTC),
+                pendulum.datetime(year=2020, month=2, day=5, tz=pendulum.UTC),
+            ),
+            DataInterval(
+                pendulum.datetime(year=2020, month=1, day=5, tz=pendulum.UTC),
+                pendulum.datetime(year=2020, month=1, day=12, tz=pendulum.UTC),
+            ),
+            DataInterval(
+                pendulum.datetime(year=2020, month=1, day=6, tz=pendulum.UTC),
+                pendulum.datetime(year=2020, month=1, day=13, tz=pendulum.UTC),
+            ),
+        ]
+        for i, eo in zip(inputs, expected_outputs):
+            output = timetable.infer_manual_data_interval(i)
+            self.assertEqual(output, eo)


### PR DESCRIPTION
Create a custom Airflow timetable for the Onix Workflow. This makes the workflow run every week on Monday and also on the  5th of every month. 

This required the creation of the class, which inherits from Airflow's Timetable base class. We add in the logic for start and end date determination for both scheduled and manual runs. We are also required to register the timetable as a plugin. We do this with the plugin class and also adding the classes to the plugins folder. Weirdly, any DAG that uses the plugin MUST import it relative to the plugin folder. This means that the plugin folder itself must be added to the PYTHONPATH. See [this issue](https://github.com/apache/airflow/discussions/23758#discussioncomment-2769169) for a full explanation. 

Testing this with the sandbox environment required an update to the sandbox's create_dag_run function as it was unable to handle custom timetables. See [this PR](https://github.com/The-Academic-Observatory/observatory-platform/pull/660). Naturally, this means that this PR is dependent on the observatory platform's PR.