### PR TITLE
Set trigger rule to none failed

### DIFF
--- a/dags/oaebu_workflows/onix_workflow/onix_workflow.py
+++ b/dags/oaebu_workflows/onix_workflow/onix_workflow.py
@@ -549,7 +549,7 @@ def create_dag(
             )
             set_task_state(state, context["ti"].task_id, release=release)
 
-        @task(trigger_rule=TriggerRule.ALL_DONE)
+        @task(trigger_rule=TriggerRule.NONE_FAILED)
         def create_book_table(release: dict, **context) -> None:
             """Create the oaebu book table using the crossref event and metadata tables"""
 


### PR DESCRIPTION
Create book task should not trigger unless all upstream tasks did not fail. This PR changes the trigger rule from ALL_DONE to NONE_FAILED