### PR TITLE
Add filter on SubjectCode to avoid nulls in array

### DIFF
--- a/dags/oaebu_workflows/onix_workflow/sql/book_product.sql.jinja2
+++ b/dags/oaebu_workflows/onix_workflow/sql/book_product.sql.jinja2
@@ -92,17 +92,20 @@ onix_ebook_titles_raw as (
                 SELECT
                     subject.SubjectCode
                 FROM UNNEST(onix.Subjects) as subject
-                WHERE subject.SubjectSchemeIdentifier = "BIC_subject_category") as bic_subjects,
+                WHERE subject.SubjectSchemeIdentifier = "BIC_subject_category" 
+                AND subject.SubjectCode IS NOT NULL) as bic_subjects,
             ARRAY(
                 SELECT
                     subject.SubjectCode
                 FROM UNNEST(onix.Subjects) as subject
-                WHERE subject.SubjectSchemeIdentifier = "BISAC_Subject_Heading") as bisac_subjects,
+                WHERE subject.SubjectSchemeIdentifier = "BISAC_Subject_Heading"
+                AND subject.SubjectCode IS NOT NULL) as bisac_subjects,
             ARRAY(
                 SELECT
                     subject.SubjectCode
                 FROM UNNEST(onix.Subjects) as subject
-                WHERE subject.SubjectSchemeIdentifier = "Thema_subject_category") as thema_subjects,
+                WHERE subject.SubjectSchemeIdentifier = "Thema_subject_category"
+                AND subject.SubjectCode IS NOT NULL) as thema_subjects,
             (SELECT 
                 custom_split(heading,';') 
             FROM UNNEST(onix.Subjects) as subject, UNNEST(subject.SubjectHeadingText) as heading


### PR DESCRIPTION
The book product SQL cannot handle a null value in any of the subjects field. Apparently we've never encountered this before so it hasn't been an issue until now. I added a secondary WHERE clause to the subquery that creates the array to check if the SubjectCode is NULL. This seems to fix the issue.