### PR TITLE
Work with Row objects, not strings

### DIFF
--- a/dags/oaebu_workflows/google_books_telescope/google_books_telescope.py
+++ b/dags/oaebu_workflows/google_books_telescope/google_books_telescope.py
@@ -24,6 +24,7 @@ import pendulum
 from airflow.exceptions import AirflowException, AirflowSkipException
 from airflow.decorators import dag, task, task_group
 from google.cloud.bigquery import TimePartitioningType, SourceFormat, WriteDisposition, Client
+from google.cloud.bigquery.table import RowIterator
 
 from oaebu_workflows.oaebu_partners import OaebuPartner, partner_from_str
 from observatory_platform.dataset_api import DatasetAPI, DatasetRelease
@@ -465,7 +466,11 @@ def _gb_early_stop(table_id: str, cloud_workspace: CloudWorkspace, logical_date:
     client = Client(project=cloud_workspace.project_id)
     dates = get_partitions(table_id, client=client)
     this_run_date = logical_date.subtract(months=1).end_of("month")
-    most_recent_pd = sorted([pendulum.parse(t) for t in dates])[-1]  # The most recent partition date
+    try:
+        most_recent_pd = next(dates).get("release_date")  # Latest release date
+    except StopIteration:  # There are no partitions available
+        raise AirflowSkipException("No partitions available and no files required for processing. Skipping.")
+
     if most_recent_pd < this_run_date:
         if logical_date.day > 4:
             raise AirflowException("It's past the 4th and there are no files avialable for upload!")
@@ -473,12 +478,12 @@ def _gb_early_stop(table_id: str, cloud_workspace: CloudWorkspace, logical_date:
             raise AirflowSkipException("No files required for processing. Skipping.")
 
 
-def get_partitions(table_id: str, partition_key: str = "release_date", client: Client = None) -> List[str]:
+def get_partitions(table_id: str, partition_key: str = "release_date", client: Client = None) -> RowIterator:
     """Queries the table and returns a list of distinct partitions
 
     :param table_id: The fully qualified table id to query
     :param partition_key: The name of the column that the table is partitioned on
-    :return: List of partitions in descending order
+    :return: Query result as a RowIterator - rows are partition dates in descending order
     """
     query = f"SELECT DISTINCT({partition_key}) FROM {table_id} ORDER BY {partition_key} desc"
     return bq_run_query(query, client=client)

--- a/dags/oaebu_workflows/google_books_telescope/google_books_telescope.py
+++ b/dags/oaebu_workflows/google_books_telescope/google_books_telescope.py
@@ -465,9 +465,9 @@ def _gb_early_stop(table_id: str, cloud_workspace: CloudWorkspace, logical_date:
 
     client = Client(project=cloud_workspace.project_id)
     dates = get_partitions(table_id, client=client)
-    this_run_date = logical_date.subtract(months=1).end_of("month")
+    this_run_date = logical_date.subtract(months=1).end_of("month").date()
     try:
-        most_recent_pd = next(dates).get("release_date")  # Latest release date
+        most_recent_pd = dates[0].get("release_date")  # Latest release date
     except StopIteration:  # There are no partitions available
         raise AirflowSkipException("No partitions available and no files required for processing. Skipping.")
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+# Check if the project name is passed as an argument
+if [ $# -ne 1 ]; then
+    echo "Usage: $0 <deployment-id>"
+    exit 1
+fi
+
+# Assign the arguments to variables
+DEPLOYMENT_ID="$1"
+
+# Build, tag, and push the Docker image with the specified project name
+docker build --no-cache -t oaebu-workflows .
+
+# Deploy using Astro
+astro workspace switch Book\ Analytics\ Dashboard
+astro deploy -i oaebu-workflows -f ${DEPLOYMENT_ID}

--- a/tests/google_books_telescope/test_google_books_telescope.py
+++ b/tests/google_books_telescope/test_google_books_telescope.py
@@ -378,7 +378,7 @@ class TestGBEarlyStop(SandboxTestCase):
     def test_no_releases(self, mock_get_partitions):
         """Test when data is current - should not raise any exception."""
 
-        mock_get_partitions.side_effect = [iter([])]
+        mock_get_partitions.side_effect = [[]]
         with self.assertRaisesRegex(AirflowSkipException, "No partitions available"):
             _gb_early_stop(self.table_id, self.fake_cloud_workspace, self.logical_date)
 
@@ -386,9 +386,9 @@ class TestGBEarlyStop(SandboxTestCase):
     def test_matching_partitions_with_current_data(self, mock_get_partitions):
         """Test when data is current - should not raise any exception."""
 
-        row1 = Row([pendulum.datetime(2024, 2, 28)], {"release_date": 0})
-        row2 = Row([pendulum.datetime(2024, 1, 31)], {"release_date": 0})
-        mock_get_partitions.side_effect = [iter([row1, row2])]
+        row1 = Row([pendulum.date(2024, 2, 28)], {"release_date": 0})
+        row2 = Row([pendulum.date(2024, 1, 31)], {"release_date": 0})
+        mock_get_partitions.side_effect = [[row1, row2]]
         _gb_early_stop(self.table_id, self.fake_cloud_workspace, self.logical_date)
 
     @patch("oaebu_workflows.google_books_telescope.google_books_telescope.get_partitions")
@@ -396,8 +396,8 @@ class TestGBEarlyStop(SandboxTestCase):
         """Test when data is missing but it's before the 4th of the month."""
 
         logical_date = pendulum.datetime(2024, 2, 3)
-        row = Row([pendulum.datetime(2023, 12, 31)], {"release_date": 0})
-        mock_get_partitions.side_effect = [iter([row])]
+        row = Row([pendulum.date(2023, 12, 31)], {"release_date": 0})
+        mock_get_partitions.side_effect = [[row]]
         with self.assertRaisesRegex(AirflowSkipException, "No files required"):
             _gb_early_stop(self.table_id, self.fake_cloud_workspace, logical_date)
 
@@ -406,7 +406,7 @@ class TestGBEarlyStop(SandboxTestCase):
         """Test when data is missing and it's after the 4th of the month."""
 
         logical_date = pendulum.datetime(2024, 2, 5)
-        row = Row([pendulum.datetime(2023, 12, 31)], {"release_date": 0})
-        mock_get_partitions.side_effect = [iter([row])]
+        row = Row([pendulum.date(2023, 12, 31)], {"release_date": 0})
+        mock_get_partitions.side_effect = [[row]]
         with self.assertRaisesRegex(AirflowException, "It's past the 4th"):
             _gb_early_stop(self.table_id, self.fake_cloud_workspace, logical_date)


### PR DESCRIPTION
Turns out queries return row objects, not strings. I implemented this change to the early stopping for GB. Updated tests and did a dev run. Seems to work.

Also added a deploy script for development runs