### PR TITLE
Added function to make sheet contents consistent shape

### DIFF
--- a/dags/oaebu_workflows/ucl_sales_telescope/ucl_sales_telescope.py
+++ b/dags/oaebu_workflows/ucl_sales_telescope/ucl_sales_telescope.py
@@ -305,6 +305,27 @@ def drop_empty_rows(data: List[List]) -> List[List]:
     return data
 
 
+def fill_with_nulls(data: List[List]) -> List[List]:
+    """If the data does not have a consistent number of columns, adds Nones to ensure the correct shape.
+    This can occur if the final column in the Google sheet is not filled for some items, but is for others.
+
+    :param data: The data to fill
+    :return: The filled data
+    """
+    # Find the longest row
+    longest = 0
+    for d in data:
+        if len(d) > longest:
+            longest = len(d)
+
+    # Extend everything with fewer rows than the longest
+    for d in data:
+        if len(d) < longest:
+            d.extend([None] * (longest - len(d)))
+
+    return data
+
+
 def make_release(dag_id: str, context: dict) -> UclSalesRelease:
     """Creates a new ucl discovery release instance
 

--- a/tests/ucl_sales_telescope/test_ucl_sales_telescope.py
+++ b/tests/ucl_sales_telescope/test_ucl_sales_telescope.py
@@ -33,6 +33,7 @@ from oaebu_workflows.ucl_sales_telescope.ucl_sales_telescope import (
     drop_empty_rows,
     clean_row,
     convert_headings,
+    fill_with_nulls,
 )
 from observatory_platform.airflow.workflow import Workflow
 from observatory_platform.dataset_api import DatasetAPI
@@ -445,6 +446,32 @@ class TestDownloadSales(TestCase):
         # Call the function to test
         with self.assertRaisesRegex(ValueError, "No content found for sheet with ID"):
             download("sheet_id", "service_account_conn_id", "202001")
+
+
+class TestFillWithNulls(TestCase):
+    def test_all_rows_same_length(self):
+        data = [[1, 2], [3, 4]]
+        expected = [[1, 2], [3, 4]]
+        result = fill_with_nulls(data)
+        self.assertEqual(result, expected)
+
+    def test_some_rows_shorter(self):
+        data = [[1, 2], [3]]
+        expected = [[1, 2], [3, None]]
+        result = fill_with_nulls(data)
+        self.assertEqual(result, expected)
+
+    def test_empty_list(self):
+        data = []
+        expected = []
+        result = fill_with_nulls(data)
+        self.assertEqual(result, expected)
+
+    def test_rows_with_empty_lists(self):
+        data = [[], [1], [2, 3]]
+        expected = [[None, None], [1, None], [2, 3]]
+        result = fill_with_nulls(data)
+        self.assertEqual(result, expected)
 
 
 class TestTransform(TestCase):


### PR DESCRIPTION
The UCL Sales workflow is having issues due to the final column being only partially populated. This means that the csv is not a consistent shape, which is one of the assumptions that the transform task makes. 
This PR adds a function that makes the shape consistent by filling it with Nones where necessary.