### PR TITLE
Impersonate chrome for discovery data retrieval

### DIFF
--- a/dags/oaebu_workflows/ucl_discovery_telescope/ucl_discovery_telescope.py
+++ b/dags/oaebu_workflows/ucl_discovery_telescope/ucl_discovery_telescope.py
@@ -17,7 +17,7 @@
 
 import logging
 import os
-from typing import List, Union
+from typing import Union
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 import pendulum
@@ -379,7 +379,7 @@ def get_isbn_eprint_mappings(sheet_id: str, service_account_conn_id: str, cutoff
         isbn = item.get("ISBN13")
         title = item.get("title_list_title")
         if not eprint_id or not isbn:
-            logging.warn(f"Item with missing information will be skipped: {item}")
+            logging.warning(f"Item with missing information will be skipped: {item}")
             continue
         if pendulum.parse(item["date"]) > cutoff_date:
             logging.info(f"Item released after cutoff date will be skipped: {item}")
@@ -409,9 +409,9 @@ def download_discovery_stats(eprint_id: str, start_date: pendulum.DateTime, end_
         f"&irs2report=eprint&set_name=eprint&set_value={eprint_id}&datatype=downloads&graph_type=column"
         "&view=Google%3A%3AGraph&date_resolution=month&title=Download+activity+-+last+12+months&export=JSON"
     )
-    response = retry_get_url(countries_url)
+    response = retry_get_url(countries_url, impersonate="chrome124")
     country = response.json()
-    response = retry_get_url(totals_url)
+    response = retry_get_url(totals_url, impersonate="chrome124")
     totals = response.json()
 
     # Perform some checks on the returned data

--- a/tests/ucl_discovery_telescope/test_ucl_discovery_telescope.py
+++ b/tests/ucl_discovery_telescope/test_ucl_discovery_telescope.py
@@ -154,9 +154,17 @@ class TestUclDiscoveryTelescope(SandboxTestCase):
             cassette = vcr.VCR(record_mode="none")
             sa_patch = patch("oaebu_workflows.ucl_discovery_telescope.ucl_discovery_telescope.service_account")
             build_patch = patch("oaebu_workflows.ucl_discovery_telescope.ucl_discovery_telescope.discovery.build")
-            with sa_patch, build_patch as mock_build, cassette.use_cassette(
+            retry_patch = patch("oaebu_workflows.ucl_discovery_telescope.ucl_discovery_telescope.retry_get_url")
+
+            def retry_get_url_side_effect(url, **kwargs):
+                import requests
+
+                return requests.get(url)
+
+            with sa_patch, build_patch as mock_build, retry_patch as mock_retry, cassette.use_cassette(
                 self.download_cassette, ignore_hosts=["oauth2.googleapis.com", "storage.googleapis.com"]
             ):
+                mock_retry.side_effect = retry_get_url_side_effect
                 mock_service = mock_build.return_value.spreadsheets.return_value.values.return_value.get.return_value
                 mock_service.execute.return_value = {"values": sheet_return}
                 ti = env.run_task("download")
@@ -367,7 +375,12 @@ class TestDownloadDiscoveryStats(TestCase):
         result = download_discovery_stats(self.eprint_id, self.start_date, self.end_date)
 
         # Check that constructed urls are correct
-        expected_calls = [call(expected_countries_url), call().json(), call(expected_totals_url), call().json()]
+        expected_calls = [
+            call(expected_countries_url, impersonate="chrome124"),
+            call().json(),
+            call(expected_totals_url, impersonate="chrome124"),
+            call().json(),
+        ]
         mock_retry_get_url.assert_has_calls(expected_calls)
 
         # Check that returned results are correct


### PR DESCRIPTION
UCL discovery has added cloudflare bot detection to their API. This gets around it by impersonating a web browser