### PR TITLE
add email sender to dag kwargs

### DIFF
--- a/dags/oaebu_workflows/jstor_telescope/jstor_telescope.py
+++ b/dags/oaebu_workflows/jstor_telescope/jstor_telescope.py
@@ -167,6 +167,7 @@ def create_dag(
     bq_dataset_description: str = "Data from JSTOR sources",
     bq_country_table_description: Optional[str] = None,
     bq_institution_table_description: Optional[str] = None,
+    jstor_send_email: str = "no-reply@ithaka.org",
     api_bq_dataset_id: str = "dataset_api",
     gmail_api_conn_id: str = "gmail_api",
     catchup: bool = False,
@@ -199,6 +200,7 @@ def create_dag(
 
     country_partner = partner_from_str(country_partner)
     institution_partner = partner_from_str(institution_partner)
+    jstor_api = make_jstor_api(entity_type, entity_id, sender=jstor_send_email, conn_id=gmail_api_conn_id)
 
     @dag(
         dag_id=dag_id,
@@ -222,8 +224,7 @@ def create_dag(
             """
 
             # Get the reports from GMAIL API
-            api = make_jstor_api(entity_type, entity_id, gmail_api_conn_id)
-            available_reports = api.list_reports()
+            available_reports = jstor_api.list_reports()
             if not len(available_reports) > 0:
                 raise AirflowSkipException("No reports available. Skipping downstream DAG taks.")
             return available_reports
@@ -238,12 +239,11 @@ def create_dag(
 
             # Download reports and determine dates
             available_releases = {}
-            api = make_jstor_api(entity_type, entity_id, gmail_api_conn_id)
             for report in available_reports:
                 # Download report to temporary file
                 tmp_download_path = NamedTemporaryFile().name
-                api.download_report(report, download_path=tmp_download_path)
-                start_date, end_date = api.get_release_date(tmp_download_path)
+                jstor_api.download_report(report, download_path=tmp_download_path)
+                start_date, end_date = jstor_api.get_release_date(tmp_download_path)
 
                 # Create temporary release and move report to correct path
                 release = JstorRelease(
@@ -300,7 +300,6 @@ def create_dag(
                 """Task to transform the Jstor releases for a given month."""
 
                 release = JstorRelease.from_dict(release)
-                api = make_jstor_api(entity_type, entity_id, gmail_api_conn_id)
                 # Download files from GCS
                 success = gcs_download_blob(
                     bucket_name=cloud_workspace.download_bucket,
@@ -317,7 +316,7 @@ def create_dag(
                 if not success:
                     raise FileNotFoundError(f"Error downloading file: {release.download_institution_blob_name}")
 
-                api.transform_reports(
+                jstor_api.transform_reports(
                     download_country=release.download_country_path,
                     download_institution=release.download_institution_path,
                     transform_country=release.transform_country_path,
@@ -408,7 +407,7 @@ def create_dag(
                 Assign a label to the gmail messages that have been processed."""
 
                 release = JstorRelease.from_dict(release)
-                api = make_jstor_api(entity_type, entity_id, gmail_api_conn_id)
+                api = make_jstor_api(entity_type, entity_id, sender=jstor_send_email, conn_id=gmail_api_conn_id)
                 cleanup(dag_id=dag_id, workflow_folder=release.workflow_folder)
                 success = api.add_labels(release.reports)
                 set_task_state(success, context["ti"].task_id, release=release)
@@ -426,30 +425,45 @@ def create_dag(
     return jstor()
 
 
-def make_jstor_api(entity_type: Literal["publisher", "collection"], entity_id: str, conn_id: str = "gmail_api"):
+def make_jstor_api(
+    entity_type: Literal["publisher", "collection"], entity_id: str, sender: str, conn_id: str = "gmail_api"
+):
     """Create the Jstor API Instance.
 
     :param entity_type: The entity type. Should be either 'publisher' or 'collection'.
     :param entity_id: The entity id.
+    :param sender: The email sending the report
     :param conn_id: The Gmail connection ID.
     :return: The Jstor API instance
     """
 
+    # Validate sender email
+    if not re.match(r"[^@]+@[^@]+\.[^@]+", sender):
+        raise AirflowException(f"Invalid sender email address: {sender}")
+
     conn = BaseHook.get_connection(conn_id)
     service = gmail_create_service(conn.extra_dejson)
     if entity_type == "publisher":
-        jstor_api = JstorPublishersAPI(service, entity_id)
+        jstor_api = JstorPublishersAPI(service, entity_id, sender)
     elif entity_type == "collection":
-        jstor_api = JstorCollectionsAPI(service, entity_id)
+        jstor_api = JstorCollectionsAPI(service, entity_id, sender)
     else:
         raise AirflowException(f"Entity type must be 'publisher' or 'collection', got {entity_type}.")
     return jstor_api
 
 
 class JstorAPI(ABC):
-    def __init__(self, service: Any, entity_id: str):
+    def __init__(self, service: Any, entity_id: str, sender: str):
+        """
+        An interface for extracting JSTOR data from gmail.
+
+        :param service: The google service object
+        :param entity_id: The entity id
+        :param sender: The email sending the report
+        """
         self.service = service
         self.entity_id = entity_id
+        self.sender = sender
 
     @abstractmethod
     def list_reports(self) -> List[dict]:
@@ -480,8 +494,8 @@ class JstorAPI(ABC):
 
 
 class JstorPublishersAPI(JstorAPI):
-    def __init__(self, service: Any, entity_id: str):
-        super().__init__(service, entity_id)
+    def __init__(self, service: Any, entity_id: str, sender: str):
+        super().__init__(service, entity_id, sender)
 
     def list_reports(self) -> List[dict]:
         """List the available releases by going through the messages of a gmail account and looking for a specific pattern.
@@ -495,7 +509,7 @@ class JstorPublishersAPI(JstorAPI):
         # List messages with specific query
         list_params = {
             "userId": "me",
-            "q": f'-label:{JSTOR_PROCESSED_LABEL_NAME} subject:"JSTOR Publisher Report Available" from:no-reply@ithaka.org',
+            "q": f'-label:{JSTOR_PROCESSED_LABEL_NAME} subject:"JSTOR Publisher Report Available" from:{self.sender}',
             "labelIds": ["INBOX"],
             "maxResults": 500,
         }
@@ -718,8 +732,8 @@ class JstorPublishersAPI(JstorAPI):
 
 
 class JstorCollectionsAPI(JstorAPI):
-    def __init__(self, service: Any, entity_id: str):
-        super().__init__(service, entity_id)
+    def __init__(self, service: Any, entity_id: str, sender: str):
+        super().__init__(service, entity_id, sender)
 
     def list_reports(self) -> List[dict]:
         """List the available reports by going through the gmail messages from a specific sender.
@@ -730,7 +744,7 @@ class JstorCollectionsAPI(JstorAPI):
         # List messages with specific query
         list_params = {
             "userId": "me",
-            "q": f"-label:{JSTOR_PROCESSED_LABEL_NAME} from:grp_ithaka_data_intelligence@ithaka.org",
+            "q": f"-label:{JSTOR_PROCESSED_LABEL_NAME} from:{self.sender}",
             "labelIds": ["INBOX"],
             "maxResults": 500,
         }

--- a/tests/jstor_telescope/test_jstor_telescope.py
+++ b/tests/jstor_telescope/test_jstor_telescope.py
@@ -17,7 +17,8 @@
 import base64
 import json
 import os
-from unittest.mock import Mock, patch
+import unittest
+from unittest.mock import MagicMock, Mock, patch
 
 import httpretty
 import pendulum
@@ -42,6 +43,7 @@ from observatory_platform.airflow.workflow import Workflow
 from observatory_platform.dataset_api import DatasetAPI
 from observatory_platform.google.bigquery import bq_table_id
 from observatory_platform.google.gcs import gcs_blob_name_from_path, gcs_upload_files
+from observatory_platform.google.gmail import gmail_get_label_id
 from observatory_platform.sandbox.sandbox_environment import SandboxEnvironment
 from observatory_platform.sandbox.test_utils import SandboxTestCase, load_and_parse_json
 
@@ -115,9 +117,9 @@ class TestTelescopeSetup(SandboxTestCase):
         with env.create():
             env.add_connection(dummy_gmail_connection())
             for entity_type in ["collection", "publisher"]:
-                make_jstor_api(entity_type, self.entity_id)
+                make_jstor_api(entity_type, self.entity_id, sender="no-reply@ithaka.org")
             with self.assertRaisesRegex(AirflowException, "Entity type must be"):
-                make_jstor_api("invalid", self.entity_id)
+                make_jstor_api("invalid", self.entity_id, sender="no-reply@ithaka.org")
 
 
 class TestJstorTelescopePublisher(SandboxTestCase):
@@ -421,7 +423,7 @@ class TestJstorTelescopePublisher(SandboxTestCase):
                         f.write(old_report_content.format(start_date=report["start"], end_date=report["end"]))
 
             # Test new report is successful
-            api = JstorPublishersAPI(Mock(), self.entity_id)
+            api = JstorPublishersAPI(Mock(), self.entity_id, sender="no-reply@ithaka.org")
             start_date, end_date = api.get_release_date(reports[0]["file"])
             self.assertEqual(pendulum.parse(reports[0]["start"]), start_date)
             self.assertEqual(pendulum.parse(reports[0]["end"]), end_date)
@@ -438,6 +440,73 @@ class TestJstorTelescopePublisher(SandboxTestCase):
             # Test old report fails
             with self.assertRaises(AirflowException):
                 api.get_release_date(reports[3]["file"])
+
+    @patch("observatory_platform.google.gmail.build")
+    @patch("observatory_platform.google.gmail.Credentials")
+    def test_get_label_id(self, mock_account_credentials, mock_build):
+        """Test getting label id both when label already exists and does not exist yet."""
+        mock_account_credentials.from_json_keyfile_dict.return_value = ""
+
+        http = HttpMockSequence(
+            publisher_http_mock_sequence(
+                self.country_report["url"], self.institution_report["url"], self.wrong_publisher_report["url"]
+            )
+        )
+        mock_build.return_value = build("gmail", "v1", http=http)
+
+        list_labels_no_match = {
+            "labels": [
+                {
+                    "id": "CHAT",
+                    "name": "CHAT",
+                    "messageListVisibility": "hide",
+                    "labelListVisibility": "labelHide",
+                    "type": "system",
+                },
+                {"id": "SENT", "name": "SENT", "type": "system"},
+            ]
+        }
+        create_label = {
+            "id": "created_label",
+            "name": JSTOR_PROCESSED_LABEL_NAME,
+            "messageListVisibility": "show",
+            "labelListVisibility": "labelShow",
+        }
+        list_labels_match = {
+            "labels": [
+                {
+                    "id": "CHAT",
+                    "name": "CHAT",
+                    "messageListVisibility": "hide",
+                    "labelListVisibility": "labelHide",
+                    "type": "system",
+                },
+                {
+                    "id": "existing_label",
+                    "name": JSTOR_PROCESSED_LABEL_NAME,
+                    "messageListVisibility": "show",
+                    "labelListVisibility": "labelShow",
+                    "type": "user",
+                },
+            ]
+        }
+        http = HttpMockSequence(
+            [
+                ({"status": "200"}, json.dumps(list_labels_no_match)),
+                ({"status": "200"}, json.dumps(create_label)),
+                ({"status": "200"}, json.dumps(list_labels_match)),
+            ]
+        )
+        service = build("gmail", "v1", http=http)
+        _api = JstorPublishersAPI(service, self.entity_id, sender="no-reply@ithaka.org")
+
+        # call function without match for label, so label is created
+        label_id = gmail_get_label_id(service, JSTOR_PROCESSED_LABEL_NAME)
+        self.assertEqual("created_label", label_id)
+
+        # call function with match for label
+        label_id = gmail_get_label_id(service, JSTOR_PROCESSED_LABEL_NAME)
+        self.assertEqual("existing_label", label_id)
 
 
 class TestJstorTelescopeCollection(SandboxTestCase):
@@ -691,81 +760,13 @@ class TestJstorTelescopeCollection(SandboxTestCase):
                     )
 
             # Test new report is successful
-            api = JstorCollectionsAPI(Mock(), self.entity_id)
+            api = JstorCollectionsAPI(Mock(), self.entity_id, sender="no-reply@ithaka.org")
             start_date, end_date = api.get_release_date(reports[0]["file"])
             self.assertEqual(pendulum.parse("2020-01-01"), start_date)
             self.assertEqual(pendulum.parse("2020-01-31"), end_date)
             # Test new report fails
             with self.assertRaises(AirflowException):
                 api.get_release_date(reports[1]["file"])
-
-
-@patch("observatory_platform.google.gmail.build")
-@patch("observatory_platform.google.gmail.Credentials")
-def test_get_label_id(self, mock_account_credentials, mock_build):
-    """Test getting label id both when label already exists and does not exist yet."""
-    mock_account_credentials.from_json_keyfile_dict.return_value = ""
-
-    http = HttpMockSequence(
-        publisher_http_mock_sequence(
-            self.country_report["url"], self.institution_report["url"], self.wrong_publisher_report["url"]
-        )
-    )
-    mock_build.return_value = build("gmail", "v1", http=http)
-
-    list_labels_no_match = {
-        "labels": [
-            {
-                "id": "CHAT",
-                "name": "CHAT",
-                "messageListVisibility": "hide",
-                "labelListVisibility": "labelHide",
-                "type": "system",
-            },
-            {"id": "SENT", "name": "SENT", "type": "system"},
-        ]
-    }
-    create_label = {
-        "id": "created_label",
-        "name": JSTOR_PROCESSED_LABEL_NAME,
-        "messageListVisibility": "show",
-        "labelListVisibility": "labelShow",
-    }
-    list_labels_match = {
-        "labels": [
-            {
-                "id": "CHAT",
-                "name": "CHAT",
-                "messageListVisibility": "hide",
-                "labelListVisibility": "labelHide",
-                "type": "system",
-            },
-            {
-                "id": "existing_label",
-                "name": JSTOR_PROCESSED_LABEL_NAME,
-                "messageListVisibility": "show",
-                "labelListVisibility": "labelShow",
-                "type": "user",
-            },
-        ]
-    }
-    http = HttpMockSequence(
-        [
-            ({"status": "200"}, json.dumps(list_labels_no_match)),
-            ({"status": "200"}, json.dumps(create_label)),
-            ({"status": "200"}, json.dumps(list_labels_match)),
-        ]
-    )
-    service = build("gmail", "v1", http=http)
-    api = JstorPublishersAPI(service, self.entity_id)
-
-    # call function without match for label, so label is created
-    label_id = api.get_label_id(service, JSTOR_PROCESSED_LABEL_NAME)
-    self.assertEqual("created_label", label_id)
-
-    # call function with match for label
-    label_id = api.get_label_id(service, JSTOR_PROCESSED_LABEL_NAME)
-    self.assertEqual("existing_label", label_id)
 
 
 def publisher_http_mock_sequence(
@@ -1000,3 +1001,27 @@ def collection_http_mock_sequence(country_json: str, institution_json: str) -> l
         ({"status": "200"}, json.dumps(modify_message1)),
     ]
     return http_mock_sequence
+
+
+class TestSenderValidation(unittest.TestCase):
+    @patch("oaebu_workflows.jstor_telescope.jstor_telescope.BaseHook.get_connection")
+    @patch("oaebu_workflows.jstor_telescope.jstor_telescope.gmail_create_service")
+    def test_make_jstor_api_invalid_sender(self, mock_create_service, mock_get_connection):
+        mock_get_connection.return_value = MagicMock()
+
+        invalid_emails = ["invalid-email", "user@", "@domain.com", "user@domain", "user@.com"]
+        for email in invalid_emails:
+            with self.subTest(email=email):
+                with self.assertRaisesRegex(AirflowException, f"Invalid sender email address: {email}"):
+                    make_jstor_api("publisher", "entity_id", sender=email)
+
+    @patch("oaebu_workflows.jstor_telescope.jstor_telescope.BaseHook.get_connection")
+    @patch("oaebu_workflows.jstor_telescope.jstor_telescope.gmail_create_service")
+    def test_make_jstor_api_valid_sender(self, mock_create_service, mock_get_connection):
+        mock_get_connection.return_value = MagicMock()
+
+        valid_emails = ["user@domain.com", "first.last@domain.co.uk", "user123@sub.domain.org"]
+        for email in valid_emails:
+            with self.subTest(email=email):
+                # Should not raise exception
+                make_jstor_api("publisher", "entity_id", sender=email)


### PR DESCRIPTION
Add a kwarg to the jstor dag for the email sender. Allows us to change it on the fly